### PR TITLE
Fix for ADDDATE and SUBDATE with resulting 00:00:00 being unexpectedly null

### DIFF
--- a/sql-jdbc/src/main/java/org/opensearch/jdbc/types/TimestampType.java
+++ b/sql-jdbc/src/main/java/org/opensearch/jdbc/types/TimestampType.java
@@ -8,6 +8,7 @@ package org.opensearch.jdbc.types;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.Map;
@@ -78,13 +79,17 @@ public class TimestampType implements TypeHelper<Timestamp> {
                 }
             }
 
-            if (calendar == null) {
-                return Timestamp.valueOf(value);
+            final Timestamp ts;
+            if (value.length() < 11) {
+                ts = Timestamp.valueOf(LocalDate.parse(value).atStartOfDay());
             } else {
-                Timestamp ts = Timestamp.valueOf(value);
-                return localDateTimeToTimestamp(ts.toLocalDateTime(), calendar);
+                ts = Timestamp.valueOf(value);
             }
 
+            if (calendar == null) {
+                return ts;
+            }
+            return localDateTimeToTimestamp(ts.toLocalDateTime(), calendar);
         } catch (IllegalArgumentException iae) {
             throw stringConversionException(value, iae);
         }


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Added Kyle's fix for ADDDATE and SUBDATE with resulting 00:00:00 being unexpectedly null
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/291
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).