### PR TITLE
Dialect fixes for operator.date test as of AOS-203

### DIFF
--- a/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -63,16 +63,87 @@
             <argument type='datetime' />
             <argument type='datetime' />
         </function>
+
+        <function group='operator' name='==' return-type='bool'>
+            <formula>(TIMESTAMP(%1) = TIMESTAMP(%2))</formula>
+            <argument type='date' />
+            <argument type='datetime' />
+        </function>
+        <function group='operator' name='==' return-type='bool'>
+            <formula>(TIMESTAMP(%1) = TIMESTAMP(%2))</formula>
+            <argument type='datetime' />
+            <argument type='date' />
+        </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(DATE(%1), '%Y-%m-%d 00:00:00') AS TIMESTAMP) &lt;&gt; %2)</formula>
+            <formula>(TIMESTAMP(%1) &lt;&gt; TIMESTAMP(%2))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(%1 &lt;&gt; CAST(DATE_FORMAT(DATE(%2), '%Y-%m-%d 00:00:00') AS TIMESTAMP))</formula>
+            <formula>(TIMESTAMP(%1) &lt;&gt; TIMESTAMP(%2))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
+        <function group='operator' name='&gt;=' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &gt;= TIMESTAMP(%2))</formula>
+            <argument type='date' />
+            <argument type='datetime' />
+        </function>
+        <function group='operator' name='&gt;=' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &gt;= TIMESTAMP(%2))</formula>
+            <argument type='datetime' />
+            <argument type='date' />
+        </function>
+        <function group='operator' name='&lt;=' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &lt;= TIMESTAMP(%2))</formula>
+            <argument type='date' />
+            <argument type='datetime' />
+        </function>
+        <function group='operator' name='&lt;=' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &lt;= TIMESTAMP(%2))</formula>
+            <argument type='datetime' />
+            <argument type='date' />
+        </function>
+        <function group='operator' name='&gt;' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &gt; TIMESTAMP(%2))</formula>
+            <argument type='date' />
+            <argument type='datetime' />
+        </function>
+        <function group='operator' name='&gt;' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &gt; TIMESTAMP(%2))</formula>
+            <argument type='datetime' />
+            <argument type='date' />
+        </function>
+        <function group='operator' name='&lt;' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &lt; TIMESTAMP(%2))</formula>
+            <argument type='date' />
+            <argument type='datetime' />
+        </function>
+        <function group='operator' name='&lt;' return-type='bool'>
+            <formula>(TIMESTAMP(%1) &lt; TIMESTAMP(%2))</formula>
+            <argument type='datetime' />
+            <argument type='date' />
+        </function>
+
+        <function group='operator' name='-' return-type='real'>
+            <!-- 86400 as it represents seconds in a day -->
+            <formula>((TO_DAYS(TIMESTAMP(%1)) - TO_DAYS(TIMESTAMP(%2))) + ((TIME_TO_SEC(TIMESTAMP(%1)) - TIME_TO_SEC(TIMESTAMP(%2))) / 86400.0))</formula>
+            <argument type='date' />
+            <argument type='datetime' />
+        </function>
+        <function group='operator' name='-' return-type='real'>
+            <!-- 86400 as it represents seconds in a day -->
+            <formula>((TO_DAYS(TIMESTAMP(%1)) - TO_DAYS(TIMESTAMP(%2))) + ((TIME_TO_SEC(TIMESTAMP(%1)) - TIME_TO_SEC(TIMESTAMP(%2))) / 86400.0))</formula>
+            <argument type='datetime' />
+            <argument type='date' />
+        </function>
+        <function group='operator' name='-' return-type='real'>
+            <!-- 86400 as it represents seconds in a day -->
+            <formula>((TO_DAYS(TIMESTAMP(%1)) - TO_DAYS(TIMESTAMP(%2))) + ((TIME_TO_SEC(TIMESTAMP(%1)) - TIME_TO_SEC(TIMESTAMP(%2))) / 86400.0))</formula>
+            <argument type='datetime' />
+            <argument type='datetime' />
+        </function>
+
         <function group='operator' name='+' return-type='datetime'>
             <!-- 86400 as it represents seconds in a day -->
             <formula>DATE_ADD(DATE_ADD(%1, INTERVAL FLOOR(%2) DAY), INTERVAL CAST(86400 * (%2 - FLOOR(%2)) AS INT) SECOND)</formula>

--- a/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -65,81 +65,81 @@
         </function>
 
         <function group='operator' name='==' return-type='bool'>
-            <formula>(TIMESTAMP(%1) = TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) = CAST(%2 as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='==' return-type='bool'>
-            <formula>(TIMESTAMP(%1) = TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) = CAST(%2 as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &lt;&gt; TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &lt;&gt; CAST(%2 as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &lt;&gt; TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &lt;&gt; CAST(%2 as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&gt;=' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &gt;= TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &gt;= CAST(%2 as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&gt;=' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &gt;= TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &gt;= CAST(%2 as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &lt;= TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &lt;= CAST(%2 as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &lt;= TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &lt;= CAST(%2 as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&gt;' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &gt; TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &gt; CAST(%2 as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&gt;' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &gt; TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &gt; CAST(%2 as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&lt;' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &lt; TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &lt; CAST(%2 as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&lt;' return-type='bool'>
-            <formula>(TIMESTAMP(%1) &lt; TIMESTAMP(%2))</formula>
+            <formula>(CAST(%1 as TIMESTAMP) &lt; CAST(%2 as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
 
         <function group='operator' name='-' return-type='real'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>((TO_DAYS(TIMESTAMP(%1)) - TO_DAYS(TIMESTAMP(%2))) + ((TIME_TO_SEC(TIMESTAMP(%1)) - TIME_TO_SEC(TIMESTAMP(%2))) / 86400.0))</formula>
+            <formula>((TO_DAYS(CAST(%1 as TIMESTAMP)) - TO_DAYS(CAST(%2 as TIMESTAMP))) + ((TIME_TO_SEC(CAST(%1 as TIMESTAMP)) - TIME_TO_SEC(CAST(%2 as TIMESTAMP))) / 86400.0))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='-' return-type='real'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>((TO_DAYS(TIMESTAMP(%1)) - TO_DAYS(TIMESTAMP(%2))) + ((TIME_TO_SEC(TIMESTAMP(%1)) - TIME_TO_SEC(TIMESTAMP(%2))) / 86400.0))</formula>
+            <formula>((TO_DAYS(CAST(%1 as TIMESTAMP)) - TO_DAYS(CAST(%2 as TIMESTAMP))) + ((TIME_TO_SEC(CAST(%1 as TIMESTAMP)) - TIME_TO_SEC(CAST(%2 as TIMESTAMP))) / 86400.0))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='-' return-type='real'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>((TO_DAYS(TIMESTAMP(%1)) - TO_DAYS(TIMESTAMP(%2))) + ((TIME_TO_SEC(TIMESTAMP(%1)) - TIME_TO_SEC(TIMESTAMP(%2))) / 86400.0))</formula>
+            <formula>((TO_DAYS(CAST(%1 as TIMESTAMP)) - TO_DAYS(CAST(%2 as TIMESTAMP))) + ((TIME_TO_SEC(CAST(%1 as TIMESTAMP)) - TIME_TO_SEC(CAST(%2 as TIMESTAMP))) / 86400.0))</formula>
             <argument type='datetime' />
             <argument type='datetime' />
         </function>

--- a/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -65,62 +65,62 @@
         </function>
 
         <function group='operator' name='==' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) = CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) = CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='==' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) = CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) = CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &lt;&gt; CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) &lt;&gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &lt;&gt; CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) &lt;&gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&gt;=' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &gt;= CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) &gt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&gt;=' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &gt;= CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP)) &gt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &lt;= CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &lt;= CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&gt;' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &gt; CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&gt;' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &gt; CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&lt;' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &lt; CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&lt;' return-type='bool'>
-            <formula>(CAST(%1 as TIMESTAMP) &lt; CAST(%2 as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>

--- a/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/sql-jdbc/src/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -65,27 +65,27 @@
         </function>
 
         <function group='operator' name='==' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) = CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP)) = CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='==' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) = CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP)) = CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) &lt;&gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP)) &lt;&gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='!=' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) &lt;&gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP)) &lt;&gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&gt;=' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP) &gt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) AS TIMESTAMP)) &gt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
@@ -95,32 +95,32 @@
             <argument type='date' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP)) &lt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP)) &lt;= CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&gt;' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP)) &gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&gt;' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP)) &gt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='&lt;' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP)) &lt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
         <function group='operator' name='&lt;' return-type='bool'>
-            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP) &lt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
+            <formula>(CAST(DATE_FORMAT(%1, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP)) &lt; CAST(DATE_FORMAT(%2, &apos;%Y-%m-%d %H:%i:%s&apos;) as TIMESTAMP))</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>


### PR DESCRIPTION
### Description
This makes 8 of 10 tests cases pass in `operator.date` test. Due to [TDVT bug #888](https://github.com/tableau/connector-plugin-sdk/issues/888). Please note, tests passes on computer which has default time format = '`mm/dd/yyyy`' and not '`dd/mm/yyyy`' only.
Failing test cases are:
**date0 + num4**
| Expected | Actual |
|--|--|
| %null% | %null% |
| 1972-07-14 20:23:59 | 1972-07-14 20:23:59 |
| 1975-10-29 **12:43:12** | 1975-10-29 **12:43:11** |
| 2004-05-28 **22:49:00** | 2004-05-28 **22:48:00** |
| 2004-06-27 07:40:48 | 2004-06-27 07:40:48 |

**date0 - num4**
| Expected | Actual |
|--|--|
| %null% | %null% |
| 1972-06-23 03:36:01 | 1972-06-23 03:36:01 |
| 1975-11-25 **11:16:48** | 1975-11-25 **11:16:49** |
| 2004-06-10 **01:11:00** | 2004-06-10 **01:12:00** |
| 2004-06-10 16:19:12 | 2004-06-10 16:19:12 |

![image](https://user-images.githubusercontent.com/88679692/142560120-9585583d-2914-4416-8f49-14cb8c22d5da.png)
Perhaps, it is caused by different processing double numbers or different lengths of exponent and fraction parts.

### Issues Resolved
`operator.date` test
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).