### PR TITLE
Added a capability to support GROUP BY statement

### DIFF
--- a/sql-odbc/src/PowerBIConnector/SqlOdbcPBIConnector.pq
+++ b/sql-odbc/src/PowerBIConnector/SqlOdbcPBIConnector.pq
@@ -99,6 +99,7 @@ SqlOdbcPBIConnectorImpl = (Server as text) as table =>
             SupportsTop = false,
             LimitClauseKind = LimitClauseKind.LimitOffset,
             Sql92Conformance = ODBC[SQL_SC][SQL_SC_SQL92_FULL],
+            GroupByCapabilities = ODBC[SQL_GB][SQL_GB_GROUP_BY_CONTAINS_SELECT],
             SupportsNumericLiterals = true,
             SupportsStringLiterals = true,
             SupportsOdbcDateLiterals = true,


### PR DESCRIPTION
SQL_GB_GROUP_BY_CONTAINS_SELECT: The GROUP BY clause must contain all nonaggregated columns in the select list. It can contain columns that are not in the select list.

Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

### Description
Connector reports to PBI that the driver can do grouping in query
MSDN: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetinfo-function?view=sql-server-ver15
 
### Issues Resolved
AOS-235
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).