### PR TITLE
ODBC driver: update and fix AWS SDK with CURL

### DIFF
--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -3,12 +3,13 @@ $WIN_ARCH = $args[1]
 $SRC_DIR = $args[2]
 $BUILD_DIR = $args[3]
 $INSTALL_DIR = $args[4]
+$VCPKG_DIR = $args[5]
 
 Write-Host $args
 
 # Clone the AWS SDK CPP repo
 $SDK_VER = "1.8.186"
-# -b "$SDK_VER" `
+
 git clone `
     --branch `
     $SDK_VER `
@@ -23,13 +24,19 @@ Set-Location $BUILD_DIR
 # Configure and build 
 cmake $SRC_DIR `
     -A $WIN_ARCH `
+	-D CMAKE_VERBOSE_MAKEFILE=ON `
     -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR `
     -D CMAKE_BUILD_TYPE=$CONFIGURATION `
     -D BUILD_ONLY="core" `
     -D ENABLE_UNITY_BUILD="ON" `
     -D CUSTOM_MEMORY_MANAGEMENT="OFF" `
     -D ENABLE_RTTI="OFF" `
-    -D ENABLE_TESTING="OFF"
+	-D ENABLE_TESTING="OFF" `
+	-D FORCE_CURL="ON" `
+	-D ENALBE_CURL_CLIENT="ON" `
+	-DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
+	-D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_x86-windows/lib" `
+	-D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_x86-windows/include/"
 
 # Build AWS SDK and install to $INSTALL_DIR 
 msbuild ALL_BUILD.vcxproj /m /p:Configuration=$CONFIGURATION

--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -15,7 +15,7 @@ git clone `
     $SDK_VER `
     --single-branch `
     "https://github.com/aws/aws-sdk-cpp.git" `
-	--recurse-submodules `
+    --recurse-submodules `
     $SRC_DIR
 
 # Make and move to build directory
@@ -34,7 +34,7 @@ cmake $SRC_DIR `
     -D ENABLE_RTTI="OFF" `
     -D ENABLE_TESTING="OFF" `
     -D FORCE_CURL="ON" `
-    -D ENALBE_CURL_CLIENT="ON" `
+    -D ENABLE_CURL_CLIENT="ON" `
     -DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
     -D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_x86-windows/lib" `
     -D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_x86-windows/include/"

--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -8,13 +8,14 @@ $VCPKG_DIR = $args[5]
 Write-Host $args
 
 # Clone the AWS SDK CPP repo
-$SDK_VER = "1.8.186"
+$SDK_VER = "1.9.199"
 
 git clone `
     --branch `
     $SDK_VER `
     --single-branch `
     "https://github.com/aws/aws-sdk-cpp.git" `
+	--recurse-submodules `
     $SRC_DIR
 
 # Make and move to build directory

--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -25,19 +25,19 @@ Set-Location $BUILD_DIR
 # Configure and build 
 cmake $SRC_DIR `
     -A $WIN_ARCH `
-	-D CMAKE_VERBOSE_MAKEFILE=ON `
+    -D CMAKE_VERBOSE_MAKEFILE=ON `
     -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR `
     -D CMAKE_BUILD_TYPE=$CONFIGURATION `
     -D BUILD_ONLY="core" `
     -D ENABLE_UNITY_BUILD="ON" `
     -D CUSTOM_MEMORY_MANAGEMENT="OFF" `
     -D ENABLE_RTTI="OFF" `
-	-D ENABLE_TESTING="OFF" `
-	-D FORCE_CURL="ON" `
-	-D ENALBE_CURL_CLIENT="ON" `
-	-DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
-	-D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_x86-windows/lib" `
-	-D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_x86-windows/include/"
+    -D ENABLE_TESTING="OFF" `
+    -D FORCE_CURL="ON" `
+    -D ENALBE_CURL_CLIENT="ON" `
+    -DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
+    -D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_x86-windows/lib" `
+    -D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_x86-windows/include/"
 
 # Build AWS SDK and install to $INSTALL_DIR 
 msbuild ALL_BUILD.vcxproj /m /p:Configuration=$CONFIGURATION

--- a/sql-odbc/scripts/build_libcurl-vcpkg.ps1
+++ b/sql-odbc/scripts/build_libcurl-vcpkg.ps1
@@ -1,0 +1,10 @@
+$SRC_DIR = $args[0]
+
+if (!("${SRC_DIR}/packages/curl_x86-windows" | Test-Path))
+{
+	git clone https://github.com/Microsoft/vcpkg.git $SRC_DIR
+	Set-Location $SRC_DIR
+	cmd.exe /c bootstrap-vcpkg.bat
+	.\vcpkg.exe integrate install
+	.\vcpkg.exe install curl[tool]
+}

--- a/sql-odbc/scripts/build_windows.ps1
+++ b/sql-odbc/scripts/build_windows.ps1
@@ -15,6 +15,12 @@ $BUILD_DIR = "${WORKING_DIR}\build"
 # $BUILD_DIR = "${WORKING_DIR}\build\${CONFIGURATION}${BITNESS}"
 New-Item -Path $BUILD_DIR -ItemType Directory -Force | Out-Null
 
+$VCPKG_DIR = "${WORKING_DIR}/src/vcpkg"
+
+.\scripts\build_libcurl-vcpkg.ps1 $VCPKG_DIR
+
+Set-Location $CURRENT_DIR
+
 # Build AWS SDK CPP
 $SDK_SOURCE_DIR = "${WORKING_DIR}\src\aws-sdk-cpp"
 $SDK_BUILD_DIR = "${BUILD_DIR}\aws-sdk\build"
@@ -22,7 +28,8 @@ $SDK_INSTALL_DIR = "${BUILD_DIR}\aws-sdk\install"
 
 .\scripts\build_aws-sdk-cpp.ps1 `
     $CONFIGURATION $WIN_ARCH `
-    $SDK_SOURCE_DIR $SDK_BUILD_DIR $SDK_INSTALL_DIR 
+    $SDK_SOURCE_DIR $SDK_BUILD_DIR $SDK_INSTALL_DIR $VCPKG_DIR
+
 Set-Location $CURRENT_DIR
 
 # Build driver

--- a/sql-odbc/src/sqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.cpp
@@ -243,7 +243,7 @@ OpenSearchCommunication::OpenSearchCommunication()
 }
 
 OpenSearchCommunication::~OpenSearchCommunication() {
-    // We should release HTTP client instanse to let it release its resources before releasing AWS SDK.
+    // Release the HTTP client instance to free its resources before releasing AWS SDK.
     // Changing order of these actions would cause crash on disconnect.
     m_http_client.reset();
     --AWS_SDK_HELPER;

--- a/sql-odbc/src/sqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.cpp
@@ -243,6 +243,8 @@ OpenSearchCommunication::OpenSearchCommunication()
 }
 
 OpenSearchCommunication::~OpenSearchCommunication() {
+    // We should release HTTP client instanse to let it release its resources before releasing AWS SDK.
+    // Changing order of these actions would cause crash on disconnect.
     m_http_client.reset();
     --AWS_SDK_HELPER;
 }

--- a/sql-odbc/src/sqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.cpp
@@ -243,6 +243,7 @@ OpenSearchCommunication::OpenSearchCommunication()
 }
 
 OpenSearchCommunication::~OpenSearchCommunication() {
+    m_http_client.~shared_ptr();
     --AWS_SDK_HELPER;
 }
 

--- a/sql-odbc/src/sqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.cpp
@@ -243,7 +243,7 @@ OpenSearchCommunication::OpenSearchCommunication()
 }
 
 OpenSearchCommunication::~OpenSearchCommunication() {
-    m_http_client.~shared_ptr();
+    m_http_client.reset();
     --AWS_SDK_HELPER;
 }
 


### PR DESCRIPTION
### Description
- `AWS SDK` compilation workflow changed to use `libcurl` instead of `winhttp` as a transport library
  - `libcurl` shipped by `vcpkg` according to the [doc](https://curl.se/docs/install.html)
- AWS SDK updated
- Fixed crash in driver caused by improper libcurl resource release (incorrect order) (see pic below)

### TODO
- Optimize `AWS SDK` checkout (~90k files)
  - Don't checkout all submodules
  - Don't checkout entire library
- Optimize `vcpkg` deploy to make it faster
  - Checkout `libcurl` only if possible
- Fix compilation of 64 bit driver (`libcurl` in `vcpkg` is 32 only in current config) - see PR #29 
- Don't compile tests (unit tests _aka_ `ut` and google tests)
- Compile static library of driver too
- Fix Power BI connector to set `Certificate validation` flag to false
- Fix installer to include all required files (`libcurl`, `zlib`, etc)
 
### Issues Resolved
https://github.com/opendistro-for-elasticsearch/sql/issues/686
https://github.com/opendistro-for-elasticsearch/sql/issues/783
https://github.com/opensearch-project/sql/issues/302
https://github.com/opensearch-project/sql/issues/280
Applicable for `ODFE` too
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
![image](https://user-images.githubusercontent.com/88679692/155267150-2f2208d4-5944-43ef-92e6-f99468e44d6c.png)
