### PR TITLE
ODBC Add check for libcurl windows architecture

### DIFF
--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -15,7 +15,7 @@ git clone `
     $SDK_VER `
     --single-branch `
     "https://github.com/aws/aws-sdk-cpp.git" `
-	--recurse-submodules `
+    --recurse-submodules `
     $SRC_DIR
 
 # Make and move to build directory
@@ -34,7 +34,7 @@ cmake $SRC_DIR `
     -D ENABLE_RTTI="OFF" `
     -D ENABLE_TESTING="OFF" `
     -D FORCE_CURL="ON" `
-    -D ENALBE_CURL_CLIENT="ON" `
+    -D ENABLE_CURL_CLIENT="ON" `
     -DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
     -D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_x86-windows/lib" `
     -D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_x86-windows/include/"

--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -4,6 +4,7 @@ $SRC_DIR = $args[2]
 $BUILD_DIR = $args[3]
 $INSTALL_DIR = $args[4]
 $VCPKG_DIR = $args[5]
+$LIBCURL_BITNESS = $args[6]
 
 Write-Host $args
 
@@ -36,8 +37,8 @@ cmake $SRC_DIR `
     -D FORCE_CURL="ON" `
     -D ENABLE_CURL_CLIENT="ON" `
     -DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
-    -D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_x86-windows/lib" `
-    -D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_x86-windows/include/"
+    -D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_${LIBCURL_WIN_ARCH}-windows/lib" `
+    -D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_${LIBCURL_WIN_ARCH}-windows/include/"
 
 # Build AWS SDK and install to $INSTALL_DIR 
 msbuild ALL_BUILD.vcxproj /m /p:Configuration=$CONFIGURATION

--- a/sql-odbc/scripts/build_libcurl-vcpkg.ps1
+++ b/sql-odbc/scripts/build_libcurl-vcpkg.ps1
@@ -1,10 +1,11 @@
 $SRC_DIR = $args[0]
+$LIBCURL_WIN_ARCH = $args[1]
 
-if (!("${SRC_DIR}/packages/curl_x86-windows" | Test-Path))
+if (!("${SRC_DIR}/packages/curl_${LIBCURL_WIN_ARCH}-windows" | Test-Path))
 {
 	git clone https://github.com/Microsoft/vcpkg.git $SRC_DIR
 	Set-Location $SRC_DIR
 	cmd.exe /c bootstrap-vcpkg.bat
 	.\vcpkg.exe integrate install
-	.\vcpkg.exe install curl[tool]
+	.\vcpkg.exe install curl[tool]:${LIBCURL_WIN_ARCH}-windows
 }

--- a/sql-odbc/scripts/build_windows.ps1
+++ b/sql-odbc/scripts/build_windows.ps1
@@ -9,6 +9,12 @@ if ($BITNESS -eq "64") {
 else {
     $WIN_ARCH = "Win32"
 }
+if ($BITNESS -eq "64") {
+    $LIBCURL_WIN_ARCH = "x64"
+}
+else {
+    $LIBCURL_WIN_ARCH = "x86"
+}
 
 # Create build directory; remove if exists
 $BUILD_DIR = "${WORKING_DIR}\build"
@@ -17,7 +23,7 @@ New-Item -Path $BUILD_DIR -ItemType Directory -Force | Out-Null
 
 $VCPKG_DIR = "${WORKING_DIR}/src/vcpkg"
 
-.\scripts\build_libcurl-vcpkg.ps1 $VCPKG_DIR
+.\scripts\build_libcurl-vcpkg.ps1 $VCPKG_DIR $LIBCURL_WIN_ARCH
 
 Set-Location $CURRENT_DIR
 
@@ -28,7 +34,8 @@ $SDK_INSTALL_DIR = "${BUILD_DIR}\aws-sdk\install"
 
 .\scripts\build_aws-sdk-cpp.ps1 `
     $CONFIGURATION $WIN_ARCH `
-    $SDK_SOURCE_DIR $SDK_BUILD_DIR $SDK_INSTALL_DIR $VCPKG_DIR
+    $SDK_SOURCE_DIR $SDK_BUILD_DIR $SDK_INSTALL_DIR $VCPKG_DIR `
+    $LIBCURL_WIN_ARCH
 
 Set-Location $CURRENT_DIR
 

--- a/sql-odbc/src/sqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.cpp
@@ -243,7 +243,7 @@ OpenSearchCommunication::OpenSearchCommunication()
 }
 
 OpenSearchCommunication::~OpenSearchCommunication() {
-    // We should release HTTP client instanse to let it release its resources before releasing AWS SDK.
+    // Release the HTTP client instance to free its resources before releasing AWS SDK.
     // Changing order of these actions would cause crash on disconnect.
     m_http_client.reset();
     --AWS_SDK_HELPER;


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Added check for bitness to determine libcurl windows architecture version

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).