### PR TITLE
Fix certificate validation for ODBC driver

### DIFF
--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -3,17 +3,20 @@ $WIN_ARCH = $args[1]
 $SRC_DIR = $args[2]
 $BUILD_DIR = $args[3]
 $INSTALL_DIR = $args[4]
+$VCPKG_DIR = $args[5]
+$LIBCURL_WIN_ARCH = $args[6]
 
 Write-Host $args
 
 # Clone the AWS SDK CPP repo
-$SDK_VER = "1.8.186"
-# -b "$SDK_VER" `
+$SDK_VER = "1.9.199"
+
 git clone `
     --branch `
     $SDK_VER `
     --single-branch `
     "https://github.com/aws/aws-sdk-cpp.git" `
+    --recurse-submodules `
     $SRC_DIR
 
 # Make and move to build directory
@@ -23,13 +26,19 @@ Set-Location $BUILD_DIR
 # Configure and build 
 cmake $SRC_DIR `
     -A $WIN_ARCH `
+    -D CMAKE_VERBOSE_MAKEFILE=ON `
     -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR `
     -D CMAKE_BUILD_TYPE=$CONFIGURATION `
     -D BUILD_ONLY="core" `
     -D ENABLE_UNITY_BUILD="ON" `
     -D CUSTOM_MEMORY_MANAGEMENT="OFF" `
     -D ENABLE_RTTI="OFF" `
-    -D ENABLE_TESTING="OFF"
+    -D ENABLE_TESTING="OFF" `
+    -D FORCE_CURL="ON" `
+    -D ENABLE_CURL_CLIENT="ON" `
+    -DCMAKE_TOOLCHAIN_FILE="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake" `
+    -D CURL_LIBRARY="${VCPKG_DIR}/packages/curl_${LIBCURL_WIN_ARCH}-windows/lib" `
+    -D CURL_INCLUDE_DIR="${VCPKG_DIR}/packages/curl_${LIBCURL_WIN_ARCH}-windows/include/"
 
 # Build AWS SDK and install to $INSTALL_DIR 
 msbuild ALL_BUILD.vcxproj /m /p:Configuration=$CONFIGURATION

--- a/sql-odbc/scripts/build_libcurl-vcpkg.ps1
+++ b/sql-odbc/scripts/build_libcurl-vcpkg.ps1
@@ -1,0 +1,11 @@
+$SRC_DIR = $args[0]
+$LIBCURL_WIN_ARCH = $args[1]
+
+if (!("${SRC_DIR}/packages/curl_${LIBCURL_WIN_ARCH}-windows" | Test-Path))
+{
+	git clone https://github.com/Microsoft/vcpkg.git $SRC_DIR
+	Set-Location $SRC_DIR
+	cmd.exe /c bootstrap-vcpkg.bat
+	.\vcpkg.exe integrate install
+	.\vcpkg.exe install curl[tool]:${LIBCURL_WIN_ARCH}-windows
+}

--- a/sql-odbc/scripts/build_windows.ps1
+++ b/sql-odbc/scripts/build_windows.ps1
@@ -9,11 +9,23 @@ if ($BITNESS -eq "64") {
 else {
     $WIN_ARCH = "Win32"
 }
+if ($BITNESS -eq "64") {
+    $LIBCURL_WIN_ARCH = "x64"
+}
+else {
+    $LIBCURL_WIN_ARCH = "x86"
+}
 
 # Create build directory; remove if exists
 $BUILD_DIR = "${WORKING_DIR}\build"
 # $BUILD_DIR = "${WORKING_DIR}\build\${CONFIGURATION}${BITNESS}"
 New-Item -Path $BUILD_DIR -ItemType Directory -Force | Out-Null
+
+$VCPKG_DIR = "${WORKING_DIR}/src/vcpkg"
+
+.\scripts\build_libcurl-vcpkg.ps1 $VCPKG_DIR $LIBCURL_WIN_ARCH
+
+Set-Location $CURRENT_DIR
 
 # Build AWS SDK CPP
 $SDK_SOURCE_DIR = "${WORKING_DIR}\src\aws-sdk-cpp"
@@ -22,7 +34,9 @@ $SDK_INSTALL_DIR = "${BUILD_DIR}\aws-sdk\install"
 
 .\scripts\build_aws-sdk-cpp.ps1 `
     $CONFIGURATION $WIN_ARCH `
-    $SDK_SOURCE_DIR $SDK_BUILD_DIR $SDK_INSTALL_DIR 
+    $SDK_SOURCE_DIR $SDK_BUILD_DIR $SDK_INSTALL_DIR $VCPKG_DIR `
+    $LIBCURL_WIN_ARCH
+
 Set-Location $CURRENT_DIR
 
 # Build driver

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -73,9 +73,9 @@ cpack_add_component(Resources
 	DISPLAY_NAME "Resources"
 	DESCRIPTION "Resources for OpenSearch SQL ODBC Driver"
 )
-
 # Install driver files
 install(TARGETS sqlodbc DESTINATION bin COMPONENT "Driver")
+
 # TODO: look into DSN Installer failure
 # if(APPLE)
 #     install(FILES "${PROJECT_ROOT}/bin64/dsn_installer" DESTINATION bin COMPONENT "Driver")
@@ -93,10 +93,18 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/Resources/opensearch_sql_odbc.tdc" DE
 # Install AWS dependencies
 if(WIN32)
     set(AWS_SDK_BIN_DIR "${PROJECT_ROOT}/build/aws-sdk/install/bin")
-    install(FILES "${AWS_SDK_BIN_DIR}/aws-c-common.dll" DESTINATION bin COMPONENT "Driver")
-    install(FILES "${AWS_SDK_BIN_DIR}/aws-c-event-stream.dll" DESTINATION bin COMPONENT "Driver")
-    install(FILES "${AWS_SDK_BIN_DIR}/aws-checksums.dll" DESTINATION bin COMPONENT "Driver")
-    install(FILES "${AWS_SDK_BIN_DIR}/aws-cpp-sdk-core.dll" DESTINATION bin COMPONENT "Driver")
+    install(DIRECTORY ${AWS_SDK_BIN_DIR} DESTINATION . COMPONENT "Driver")
+endif()
+
+if(WIN32)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # We actually never build the installer for Debug
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/libcurl-d.dll" DESTINATION bin COMPONENT "Driver")
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/zlibd1.dll" DESTINATION bin COMPONENT "Driver")
+    else() # release
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/libcurl.dll" DESTINATION bin COMPONENT "Driver")
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/zlib1.dll" DESTINATION bin COMPONENT "Driver")
+    endif()
 endif()
 
 include(CPack)

--- a/sql-odbc/src/sqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.cpp
@@ -243,6 +243,9 @@ OpenSearchCommunication::OpenSearchCommunication()
 }
 
 OpenSearchCommunication::~OpenSearchCommunication() {
+    // Release the HTTP client instance to free its resources before releasing AWS SDK.
+    // Changing order of these actions would cause crash on disconnect.
+    m_http_client.reset();
     --AWS_SDK_HELPER;
 }
 


### PR DESCRIPTION
### Description
* Having this fix driver doesn't ignore user preferences for `Hostname Verification` parameter, and once it unset driver can establish SSL connection even if self-signed certificates are used
* AWS SDK compilation workflow changed to use libcurl instead of winhttp as a transport library
  * libcurl shipped by vcpkg according to the [doc](https://curl.se/docs/install.html)
* AWS SDK updated
* Fixed crash in driver caused by improper libcurl resource release (incorrect order)

This PR has all changes from PRs #28, #29 and #30 collected all together.
Duplicate of #32, but with fix of DCO.

### Issues Resolved
https://github.com/opendistro-for-elasticsearch/sql/issues/686
https://github.com/opendistro-for-elasticsearch/sql/issues/783
https://github.com/opensearch-project/sql/issues/302
https://github.com/opensearch-project/sql/issues/280
Applicable for ODFE too
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).