### PR TITLE
Fix String Functions in the Tableau Connector

### DIFF
--- a/bi-connectors/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/bi-connectors/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -32,6 +32,10 @@
             <formula>TO_DAYS(%1) - 693961.0</formula>
             <argument type='datetime' />
         </function>
+        <function group='cast' name='FLOAT' return-type='real'>
+            <formula>CAST(%1 AS DOUBLE)</formula>
+            <argument type='str' />
+        </function>
         <function group='cast' name='STR' return-type='str'>
             <formula>CAST(%1 as string)</formula>
             <argument type='real' />
@@ -252,6 +256,16 @@
             <argument type='date' />
         </function>
 
+        <function group='string' name='LEFT' return-type='str'>
+            <formula>(CASE WHEN %2 >= 0 THEN LEFT(%1, CAST(%2 AS INT)) ELSE NULL END)</formula>
+            <argument type='str' />
+            <argument type='real' />
+        </function>
+        <function group='string' name='RIGHT' return-type='str'>
+            <formula>(CASE WHEN %2 >= 0 THEN RIGHT(%1, CAST(%2 AS INT)) ELSE NULL END)</formula>
+            <argument type='str' />
+            <argument type='real' />
+        </function>
         <function group='string' name='MID' return-type='str'>
             <formula>SUBSTR(%1,%2)</formula>
             <argument type='str' />
@@ -281,7 +295,7 @@
             <argument type='real' />
         </function>
         <function group='string' name='MID' return-type='str'>
-            <formula>SUBSTR(%1,CAST(%2 as int),CAST(%3 as int))</formula>
+            <formula>CASE WHEN %3 &lt; 1 THEN &apos;&apos; WHEN %2 &lt; 1 THEN SUBSTR(%1,1,CAST(%3 AS INT)) ELSE SUBSTR(%1,CAST(%2 AS INT),CAST(%3 AS INT)) END</formula>
             <argument type='str' />
             <argument type='real' />
             <argument type='real' />
@@ -392,6 +406,14 @@
 
         <remove-function name='SPACE'>
             <argument type='int' />
+        </remove-function>
+        <remove-function name='SPACE'>
+            <argument type='real' />
+        </remove-function>
+        <remove-function name='SPLIT'>
+            <argument type='str' />
+            <argument type='localstr' />
+            <argument type='localint' />
         </remove-function>
    </function-map>
 </dialect>


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Tests fixed:
- exprtests/standard\setup.string.left.real.txt
- exprtests/standard\setup.string.right.real.txt
- exprtests/standard\setup.string.rtrim.txt
- exprtests/standard\setup.cast.float.string.txt
- exprtests/standard\setup.string.mid.calc.txt
- staples\setup.Filter.Add_to_context.simple_lower.xml

Functions removed as they are unsupported:
- SPACE
- CHAR
- SPLIT

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).