### PR TITLE
Add `match_phrase`  to `FilterQueryBuilder` (part of #185)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -654,4 +654,9 @@ public class DSL {
     return (FunctionExpression) repository
         .compile(BuiltinFunctionName.MATCH.getName(), Arrays.asList(args.clone()));
   }
+
+  public FunctionExpression match_phrase(Expression... args) {
+    return (FunctionExpression) repository
+         .compile(BuiltinFunctionName.MATCH_PHRASE.getName(), Arrays.asList(args.clone()));
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -187,6 +187,7 @@ public enum BuiltinFunctionName {
    * Relevance Function.
    */
   MATCH(FunctionName.of("match")),
+  MATCH_PHRASE(FunctionName.of("match_phrase")),
 
   /**
    * Legacy Relevance Function.

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -25,6 +25,7 @@ import org.opensearch.sql.expression.env.Environment;
 public class OpenSearchFunctions {
   public void register(BuiltinFunctionRepository repository) {
     repository.register(match());
+    repository.register(match_phrase());
   }
 
   private static FunctionResolver match() {
@@ -71,6 +72,22 @@ public class OpenSearchFunctions {
             .put(new FunctionSignature(funcName, ImmutableList
                     .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING)),
+                args -> new OpenSearchFunction(funcName, args))
+            .build());
+  }
+
+  private static FunctionResolver match_phrase() {
+    FunctionName funcName = BuiltinFunctionName.MATCH_PHRASE.getName();
+    return new FunctionResolver(funcName,
+        ImmutableMap.<FunctionSignature, FunctionBuilder>builder()
+            .put(new FunctionSignature(funcName, ImmutableList.of(STRING, STRING)),
+                args -> new OpenSearchFunction(funcName, args))
+            .put(new FunctionSignature(funcName, ImmutableList.of(STRING, STRING, STRING)),
+                args -> new OpenSearchFunction(funcName, args))
+            .put(new FunctionSignature(funcName, ImmutableList.of(STRING, STRING, STRING, STRING)),
+                args -> new OpenSearchFunction(funcName, args))
+            .put(new FunctionSignature(funcName, ImmutableList
+                    .of(STRING, STRING, STRING, STRING, STRING)),
                 args -> new OpenSearchFunction(funcName, args))
             .build());
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -29,6 +29,7 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery.Comparison;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.TermQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.WildcardQuery;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhraseQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchQuery;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
@@ -52,7 +53,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.GTE.getName(), new RangeQuery(Comparison.GTE))
           .put(BuiltinFunctionName.LIKE.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.MATCH.getName(), new MatchQuery())
-          .put(BuiltinFunctionName.MATCH_PHRASE.getName(), new MatchQuery())
+          .put(BuiltinFunctionName.MATCH_PHRASE.getName(), new MatchPhraseQuery())
           .put(BuiltinFunctionName.QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -52,6 +52,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.GTE.getName(), new RangeQuery(Comparison.GTE))
           .put(BuiltinFunctionName.LIKE.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.MATCH.getName(), new MatchQuery())
+          .put(BuiltinFunctionName.MATCH_PHRASE.getName(), new MatchQuery())
           .put(BuiltinFunctionName.QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -44,7 +44,7 @@ public class MatchPhraseQuery extends LuceneQuery {
       NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
       if (!argAction.containsKey(arg.getArgName())) {
         throw new SemanticCheckException(String
-                .format("Parameter %s is invalid for match function.", arg.getArgName()));
+                .format("Parameter %s is invalid for match_phrase function.", arg.getArgName()));
       }
       ((BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder>) argAction
               .get(arg.getArgName()))

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Iterator;
+import java.util.function.BiFunction;
+
+import org.opensearch.index.query.*;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
+
+public class MatchPhraseQuery extends LuceneQuery {
+  private final BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder> analyzer =
+          (b, v) -> b.analyzer(v.stringValue());
+  private final BiFunction<MatchQueryBuilder, ExprValue, MatchQueryBuilder> slop =
+          (b, v) -> b.maxExpansions(Integer.parseInt(v.stringValue()));
+  private final BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder> zeroTermsQuery =
+          (b, v) -> b.zeroTermsQuery(
+                  org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue()));
+
+  ImmutableMap<Object, Object> argAction = ImmutableMap.builder()
+          .put("analyzer", analyzer)
+          .put("slop", slop)
+          .put("zero_terms_query", zeroTermsQuery)
+          .build();
+
+  @Override
+  public QueryBuilder build(FunctionExpression func) {
+    Iterator<Expression> iterator = func.getArguments().iterator();
+    NamedArgumentExpression field = (NamedArgumentExpression) iterator.next();
+    NamedArgumentExpression query = (NamedArgumentExpression) iterator.next();
+    MatchPhraseQueryBuilder queryBuilder = QueryBuilders.matchPhraseQuery(
+            field.getValue().valueOf(null).stringValue(),
+            query.getValue().valueOf(null).stringValue());
+    while (iterator.hasNext()) {
+      NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
+      if (!argAction.containsKey(arg.getArgName())) {
+        throw new SemanticCheckException(String
+                .format("Parameter %s is invalid for match function.", arg.getArgName()));
+      }
+      ((BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder>) argAction
+              .get(arg.getArgName()))
+              .apply(queryBuilder, arg.getValue().valueOf(null));
+    }
+    return queryBuilder;
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -20,8 +20,8 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
 public class MatchPhraseQuery extends LuceneQuery {
   private final BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder> analyzer =
           (b, v) -> b.analyzer(v.stringValue());
-  private final BiFunction<MatchQueryBuilder, ExprValue, MatchQueryBuilder> slop =
-          (b, v) -> b.maxExpansions(Integer.parseInt(v.stringValue()));
+  private final BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder> slop =
+          (b, v) -> b.slop(Integer.parseInt(v.stringValue()));
   private final BiFunction<MatchPhraseQueryBuilder, ExprValue, MatchPhraseQueryBuilder> zeroTermsQuery =
           (b, v) -> b.zeroTermsQuery(
                   org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue()));

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -8,8 +8,9 @@ package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
 import com.google.common.collect.ImmutableMap;
 import java.util.Iterator;
 import java.util.function.BiFunction;
-
-import org.opensearch.index.query.*;
+import org.opensearch.index.query.MatchPhraseQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.Expression;

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -6,8 +6,7 @@
 
 package org.opensearch.sql.opensearch.storage.script.filter;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
@@ -45,6 +44,7 @@ import org.opensearch.sql.data.model.ExprDatetimeValue;
 import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
@@ -361,8 +361,114 @@ class FilterQueryBuilderTest {
         dsl.namedArgument("field", literal("message")),
         dsl.namedArgument("query", literal("search query")),
         dsl.namedArgument("invalid_parameter", literal("invalid_value")));
-    assertThrows(SemanticCheckException.class, () -> buildQuery(expr),
-        "Parameter invalid_parameter is invalid for match function.");
+    var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
+    assertEquals("Parameter invalid_parameter is invalid for match function.", msg);
+  }
+
+  @Test
+  void should_build_match_phrase_query_with_default_parameters() {
+    assertJsonEquals(
+    "{\n"
+            + "  \"match_phrase\" : {\n"
+            + "    \"message\" : {\n"
+            + "      \"query\" : \"search query\",\n"
+            + "      \"slop\" : 0,\n"
+            + "      \"zero_terms_query\" : \"NONE\",\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            dsl.match_phrase(
+                dsl.namedArgument("field", literal("message")),
+                dsl.namedArgument("query", literal("search query")))));
+  }
+
+  @Test
+  void should_build_match_phrase_query_with_custom_parameters() {
+    assertJsonEquals(
+      "{\n"
+            + "  \"match_phrase\" : {\n"
+            + "    \"message\" : {\n"
+            + "      \"query\" : \"search query\",\n"
+            + "      \"analyzer\" : \"keyword\","
+            + "      \"slop\" : 2,\n"
+            + "      \"zero_terms_query\" : \"ALL\",\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            dsl.match_phrase(
+                dsl.namedArgument("field", literal("message")),
+                dsl.namedArgument("query", literal("search query")),
+                dsl.namedArgument("analyzer", literal("keyword")),
+                dsl.namedArgument("slop", literal("2")),
+                dsl.namedArgument("zero_terms_query", literal("ALL")))));
+  }
+
+  @Test
+  void match_phrase_invalid_parameter() {
+    FunctionExpression expr = dsl.match_phrase(
+        dsl.namedArgument("field", literal("message")),
+        dsl.namedArgument("query", literal("search query")),
+        dsl.namedArgument("invalid_parameter", literal("invalid_value")));
+    var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
+    assertEquals("Parameter invalid_parameter is invalid for match_phrase function.", msg);
+  }
+
+  @Test
+  void match_phrase_invalid_value_slop() {
+    FunctionExpression expr = dsl.match_phrase(
+        dsl.namedArgument("field", literal("message")),
+        dsl.namedArgument("query", literal("search query")),
+        dsl.namedArgument("slop", literal("1.5")));
+    var msg = assertThrows(NumberFormatException.class, () -> buildQuery(expr)).getMessage();
+    assertEquals("For input string: \"1.5\"", msg);
+  }
+
+  @Test
+  void match_phrase_invalid_value_ztq() {
+    FunctionExpression expr = dsl.match_phrase(
+        dsl.namedArgument("field", literal("message")),
+        dsl.namedArgument("query", literal("search query")),
+        dsl.namedArgument("zero_terms_query", literal("meow")));
+    var msg = assertThrows(IllegalArgumentException.class, () -> buildQuery(expr)).getMessage();
+    assertEquals("No enum constant org.opensearch.index.search.MatchQuery.ZeroTermsQuery.meow", msg);
+  }
+
+  @Test
+  void match_phrase_missing_field() {
+    var msg = assertThrows(ExpressionEvaluationException.class, () ->
+        dsl.match_phrase(
+            dsl.namedArgument("query", literal("search query")))).getMessage();
+    assertEquals("match_phrase function expected {[STRING,STRING],[STRING,STRING,STRING],"
+          + "[STRING,STRING,STRING,STRING],[STRING,STRING,STRING,STRING,STRING]}, but get [STRING]", msg);
+  }
+
+  @Test
+  void match_phrase_missing_query() {
+    var msg = assertThrows(ExpressionEvaluationException.class, () ->
+        dsl.match_phrase(
+            dsl.namedArgument("field", literal("message")))).getMessage();
+    assertEquals("match_phrase function expected {[STRING,STRING],[STRING,STRING,STRING],"
+          + "[STRING,STRING,STRING,STRING],[STRING,STRING,STRING,STRING,STRING]}, but get [STRING]", msg);
+  }
+
+  @Test
+  void match_phrase_too_many_args() {
+    var msg = assertThrows(ExpressionEvaluationException.class, () ->
+        dsl.match_phrase(
+            dsl.namedArgument("one", literal("1")),
+            dsl.namedArgument("two", literal("2")),
+            dsl.namedArgument("three", literal("3")),
+            dsl.namedArgument("four", literal("4")),
+            dsl.namedArgument("fix", literal("5")),
+            dsl.namedArgument("six", literal("6"))
+                )).getMessage();
+    assertEquals("match_phrase function expected {[STRING,STRING],[STRING,STRING,STRING],"
+          + "[STRING,STRING,STRING,STRING],[STRING,STRING,STRING,STRING,STRING]}, but get "
+          + "[STRING,STRING,STRING,STRING,STRING,STRING]", msg);
   }
 
   @Test


### PR DESCRIPTION
* Added `MatchPhraseQuery` which inherits `LuceneQuery` and works as `MatchQuery`
* Added `MATCH_PHRASE` function registration
* Added tests `MATCH_PHRASE`

Signed-off-by: Yury Fridlyand [yuryf@bitquilltech.com](mailto:yuryf@bitquilltech.com)