### PR TITLE
Implementation of  `simple_query_string`

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -654,4 +654,9 @@ public class DSL {
     return (FunctionExpression) repository
         .compile(BuiltinFunctionName.MATCH.getName(), Arrays.asList(args.clone()));
   }
+
+  public FunctionExpression simple_query_string(Expression... args) {
+    return (FunctionExpression) repository
+        .compile(BuiltinFunctionName.SIMPLE_QUERY_STRING.getName(), Arrays.asList(args.clone()));
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -187,6 +187,7 @@ public enum BuiltinFunctionName {
    * Relevance Function.
    */
   MATCH(FunctionName.of("match")),
+  SIMPLE_QUERY_STRING(FunctionName.of("simple_query_string")),
 
   /**
    * Legacy Relevance Function.

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -7,11 +7,11 @@ package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.ToString;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
@@ -25,54 +25,40 @@ import org.opensearch.sql.expression.env.Environment;
 public class OpenSearchFunctions {
   public void register(BuiltinFunctionRepository repository) {
     repository.register(match());
+    repository.register(simple_query_string());
   }
 
   private static FunctionResolver match() {
     FunctionName funcName = BuiltinFunctionName.MATCH.getName();
+    // At most field, query, and all optional parameters
+    final int matchMaxNumParameters = 14;
+    return getRelevanceFunctionResolver(funcName, matchMaxNumParameters);
+  }
+
+  private static FunctionResolver simple_query_string() {
+    FunctionName funcName = BuiltinFunctionName.SIMPLE_QUERY_STRING.getName();
+    // At most field, query, and all optional parameters
+    // TODO 16 ? See org.opensearch.index.query.SimpleQueryStringBuilder.class
+    final int matchPhraseMaxNumParameters = 12;
+    return getRelevanceFunctionResolver(funcName, matchPhraseMaxNumParameters);
+  }
+
+  private static FunctionResolver getRelevanceFunctionResolver(
+      FunctionName funcName, int maxNumParameters) {
     return new FunctionResolver(funcName,
-        ImmutableMap.<FunctionSignature, FunctionBuilder>builder()
-            .put(new FunctionSignature(funcName, ImmutableList.of(STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList.of(STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList.of(STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .put(new FunctionSignature(funcName, ImmutableList
-                    .of(STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING, STRING, STRING, STRING)),
-                args -> new OpenSearchFunction(funcName, args))
-            .build());
+      getRelevanceFunctionSignatureMap(funcName, maxNumParameters));
+  }
+
+  private static Map<FunctionSignature, FunctionBuilder> getRelevanceFunctionSignatureMap(
+      FunctionName funcName, int maxNumParameters) {
+    final int minNumParameters = 2;
+    FunctionBuilder buildFunction = args -> new OpenSearchFunction(funcName, args);
+    var signatureMapBuilder = ImmutableMap.<FunctionSignature, FunctionBuilder>builder();
+    for (int numParameters = minNumParameters; numParameters <= maxNumParameters; numParameters++) {
+      List<ExprType> args = Collections.nCopies(numParameters, STRING);
+      signatureMapBuilder.put(new FunctionSignature(funcName, args), buildFunction);
+    }
+    return  signatureMapBuilder.build();
   }
 
   private static class OpenSearchFunction extends FunctionExpression {

--- a/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.ExpressionTestBase;
@@ -120,5 +121,10 @@ public class OpenSearchFunctionsTest extends ExpressionTestBase {
   void match_to_string() {
     FunctionExpression expr = dsl.match(field, query);
     assertEquals("match(field=\"message\", query=\"search query\")", expr.toString());
+  }
+
+  @Test
+  void simple_query_string() {
+    throw new NotImplementedException();
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -30,6 +30,7 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery.Com
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.TermQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.WildcardQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchQuery;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.SimpleQueryString;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
 @RequiredArgsConstructor
@@ -55,6 +56,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())
+          .put(BuiltinFunctionName.SIMPLE_QUERY_STRING.getName(), new SimpleQueryString())
           .build();
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryString.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryString.java
@@ -76,7 +76,6 @@ public class SimpleQueryString extends LuceneQuery {
     NamedArgumentExpression fields = (NamedArgumentExpression) iterator.next();
     NamedArgumentExpression query = (NamedArgumentExpression) iterator.next();
     SimpleQueryStringBuilder queryBuilder = QueryBuilders.simpleQueryStringQuery(
-//        field.getValue().valueOf(null).stringValue(), TODO
         query.getValue().valueOf(null).stringValue());
     queryBuilder.fields(parseFields(fields.getValue().valueOf(null).stringValue()));
     while (iterator.hasNext()) {
@@ -94,7 +93,8 @@ public class SimpleQueryString extends LuceneQuery {
 
   private Map<String, Float> parseFields(String fields) {
     try {
-      var arr = new JSONArray(fields.replace('\'', '"'));
+      // TODO support elements wrapped by single quotes
+      var arr = new JSONArray(fields);
       if (!arr.toList().stream().allMatch(s -> s instanceof String))
         throw new Exception("All listed elements should be strings.");
 
@@ -117,7 +117,7 @@ public class SimpleQueryString extends LuceneQuery {
     catch (Exception e) {
       throw new SemanticCheckException(String.format(
               "%s: Incorrect value '%s' specified for 'fields' argument of 'simple_query_string' function."
-              + "The format is: '[\"field1, field2, ...]\".", e.getMessage(), fields));
+              + "The format is: '[\"field1\", \"field2\", ...]'.", e.getMessage(), fields));
     }
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryString.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryString.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.SimpleQueryStringFlag;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public class SimpleQueryString extends LuceneQuery {
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> analyzeWildcard =
+      (b, v) -> b.analyzeWildcard(Boolean.parseBoolean(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> analyzer =
+      (b, v) -> b.analyzer(v.stringValue());
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> autoGenerateSynonymsPhraseQuery =
+      (b, v) -> b.autoGenerateSynonymsPhraseQuery(Boolean.parseBoolean(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> defaultOperator =
+      (b, v) -> b.defaultOperator(Operator.fromString(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> flags =
+      (b, v) -> b.flags(SimpleQueryStringFlag.valueOf(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> fuzzyMaxExpansions =
+      (b, v) -> b.fuzzyMaxExpansions(Integer.parseInt(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> fuzzyPrefixLength =
+      (b, v) -> b.fuzzyPrefixLength(Integer.parseInt(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> fuzzyTranspositions =
+      (b, v) -> b.fuzzyTranspositions(Boolean.parseBoolean(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> lenient =
+      (b, v) -> b.lenient(Boolean.parseBoolean(v.stringValue()));
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> minimumShouldMatch =
+      (b, v) -> b.minimumShouldMatch(v.stringValue());
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> quoteFieldSuffix =
+      (b, v) -> b.quoteFieldSuffix(v.stringValue());
+  private final BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder> boost =
+      (b, v) -> b.boost(Float.parseFloat(v.stringValue()));
+
+  ImmutableMap<Object, Object> argAction = ImmutableMap.builder()
+      .put("analyze_wildcard", analyzeWildcard)
+      .put("analyzer", analyzer)
+      .put("auto_generate_synonyms_phrase_query", autoGenerateSynonymsPhraseQuery)
+      .put("flags", flags)
+      .put("fuzzy_max_expansions", fuzzyMaxExpansions)
+      .put("fuzzy_prefix_length", fuzzyPrefixLength)
+      .put("fuzzy_transpositions", fuzzyTranspositions)
+      .put("lenient", lenient)
+      .put("default_operator", defaultOperator)
+      .put("minimum_should_match", minimumShouldMatch)
+      .put("quote_field_suffix", quoteFieldSuffix)
+      .put("boost", boost)
+      .build();
+
+  @Override
+  public QueryBuilder build(FunctionExpression func) {
+    Iterator<Expression> iterator = func.getArguments().iterator();
+    NamedArgumentExpression fields = (NamedArgumentExpression) iterator.next();
+    NamedArgumentExpression query = (NamedArgumentExpression) iterator.next();
+    SimpleQueryStringBuilder queryBuilder = QueryBuilders.simpleQueryStringQuery(
+//        field.getValue().valueOf(null).stringValue(), TODO
+        query.getValue().valueOf(null).stringValue());
+    queryBuilder.fields(parseFields(fields.getValue().valueOf(null).stringValue()));
+    while (iterator.hasNext()) {
+      NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
+      if (!argAction.containsKey(arg.getArgName())) {
+        throw new SemanticCheckException(String
+            .format("Parameter %s is invalid for simple_query_string function.", arg.getArgName()));
+      }
+      ((BiFunction<SimpleQueryStringBuilder, ExprValue, SimpleQueryStringBuilder>) argAction
+          .get(arg.getArgName()))
+          .apply(queryBuilder, arg.getValue().valueOf(null));
+    }
+    return queryBuilder;
+  }
+
+  private Map<String, Float> parseFields(String fields) {
+    //var res = new Map<String, Float>();
+    if (!fields.startsWith("[") || !fields.endsWith("]"))
+      throw new SemanticCheckException(String.format(
+              "Incorrect value specified for 'fields' argument of 'simple_query_string' function."
+              + "The format is: '[\"field1, field2, ...]\"."));
+    fields = fields.substring(1, fields.length() - 2); // Skipping []
+    return ImmutableMap.of("", 0F);
+  }
+}


### PR DESCRIPTION
### Description
Backend implementation of `simple_query_string` function, see https://github.com/opensearch-project/sql/issues/192
Require SQL/PPL parser update (#53) to support end-to-end flow

TODOs:
* tests
* new test data
* rework on argument parser

### Issues Resolved
^
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).