### PR TITLE
Adding Match Query Unit Tests

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
@@ -63,7 +63,7 @@ public class MatchQuery extends LuceneQuery {
 
   @Override
   public QueryBuilder build(FunctionExpression func) {
-    if(func.getArguments().size() < 2) {
+    if (func.getArguments().size() < 2) {
       throw new SemanticCheckException("match must have at least two arguments");
     }
     Iterator<Expression> iterator = func.getArguments().iterator();

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
@@ -63,6 +63,9 @@ public class MatchQuery extends LuceneQuery {
 
   @Override
   public QueryBuilder build(FunctionExpression func) {
+    if(func.getArguments().size() < 2) {
+      throw new SemanticCheckException("match must have at least two arguments");
+    }
     Iterator<Expression> iterator = func.getArguments().iterator();
     NamedArgumentExpression field = (NamedArgumentExpression) iterator.next();
     NamedArgumentExpression query = (NamedArgumentExpression) iterator.next();

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -1,5 +1,9 @@
-package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -7,12 +7,14 @@ package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -30,6 +32,82 @@ public class MatchQueryTest {
   private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
   private final MatchQuery matchQuery = new MatchQuery();
   private final FunctionName match = FunctionName.of("match");
+
+  static Stream<List<Expression>> generateValidData() {
+    final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+    return Stream.of(
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("analyzer", DSL.literal("standard"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("auto_generate_synonyms_phrase_query", DSL.literal("true"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("fuzziness", DSL.literal("AUTO"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("max_expansions", DSL.literal("50"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("prefix_length", DSL.literal("0"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("fuzzy_transpositions", DSL.literal("true"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("fuzzy_rewrite", DSL.literal("constant_score"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("lenient", DSL.literal("false"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("operator", DSL.literal("OR"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("minimum_should_match", DSL.literal("3"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("zero_terms_query", DSL.literal("NONE"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("boost", DSL.literal("1"))
+        )
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateValidData")
+  public void test_valid_parameters(List<Expression> validArgs) {
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(validArgs)));
+  }
 
   @Test
   public void test_SemanticCheckException_when_no_arguments() {
@@ -53,42 +131,6 @@ public class MatchQueryTest {
         namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,
         () -> matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void build_succeeds_with_two_arguments() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"));
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_valid_parameters() {
-    final int validArgIndex = 2;
-    final List<Expression> validArgs = List.of(
-        namedArgument("analyzer", "standard"),
-        namedArgument("auto_generate_synonyms_phrase_query", "true"),
-        namedArgument("fuzziness", "AUTO"),
-        namedArgument("max_expansions", "50"),
-        namedArgument("prefix_length", "0"),
-        namedArgument("fuzzy_transpositions", "true"),
-        namedArgument("fuzzy_rewrite", "constant_score"),
-        namedArgument("lenient", "false"),
-        namedArgument("operator", "OR"),
-        namedArgument("minimum_should_match", "3"),
-        namedArgument("zero_terms_query", "NONE"),
-        namedArgument("boost", "1"));
-
-    List<Expression> arguments = new ArrayList<Expression>();
-    arguments.add(namedArgument("field", "field_value"));
-    arguments.add(namedArgument("query", "query_value"));
-    arguments.add(namedArgument("", ""));
-
-    for (Expression arg : validArgs) {
-      arguments.set(validArgIndex, arg);
-      Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
   }
 
   private NamedArgumentExpression namedArgument(String name, String value) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -26,180 +26,179 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.Matc
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class MatchQueryTest {
+  private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+  private final MatchQuery matchQuery = new MatchQuery();
+  private final FunctionName match = FunctionName.of("match");
 
-    private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
-    private final MatchQuery matchQuery = new MatchQuery();
-    private final FunctionName match = FunctionName.of("match");
+  private NamedArgumentExpression namedArgument(String name, String value) {
+    return dsl.namedArgument(name, DSL.literal(value));
+  }
 
-    private NamedArgumentExpression namedArgument(String name, String value) {
-        return dsl.namedArgument(name, DSL.literal(value));
+  @Test
+  public void test_SemanticCheckException_when_no_arguments() {
+    List<Expression> arguments = List.of();
+    assertThrows(SemanticCheckException.class,
+        () -> matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_SemanticCheckException_when_one_argument() {
+    List<Expression> arguments = List.of(namedArgument("field", "field_value"));
+    assertThrows(SemanticCheckException.class,
+        () -> matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_SemanticCheckException_when_invalid_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("unsupported", "unsupported_value"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_analyzer_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("analyzer", "standard")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void build_succeeds_with_two_arguments() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"));
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_auto_generate_synonyms_phrase_query_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("auto_generate_synonyms_phrase_query", "true")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_fuzziness_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("fuzziness", "AUTO")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_max_expansions_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("max_expansions", "50")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_prefix_length_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("prefix_length", "0")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_fuzzy_transpositions_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("fuzzy_transpositions", "true")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_fuzzy_rewrite_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("fuzzy_rewrite", "constant_score")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_lenient_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("lenient", "false")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_operator_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("operator", "OR")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_minimum_should_match_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("minimum_should_match", "3")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_zero_terms_query_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("zero_terms_query", "NONE")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  @Test
+  public void test_boost_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("boost", "1")
+    );
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+  }
+
+  private class MatchExpression extends FunctionExpression {
+    public MatchExpression(List<Expression> arguments) {
+      super(MatchQueryTest.this.match, arguments);
     }
 
-    @Test
-    public void test_SemanticCheckException_when_no_arguments() {
-        List<Expression> arguments = List.of();
-        assertThrows(SemanticCheckException.class,
-                () -> matchQuery.build(new MatchExpression(arguments)));
+    @Override
+    public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+      return null;
     }
 
-    @Test
-    public void test_SemanticCheckException_when_one_argument() {
-        List<Expression> arguments = List.of(namedArgument("field", "field_value"));
-        assertThrows(SemanticCheckException.class,
-                () -> matchQuery.build(new MatchExpression(arguments)));
+    @Override
+    public ExprType type() {
+      return null;
     }
-
-    @Test
-    public void test_SemanticCheckException_when_invalid_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("unsupported", "unsupported_value"));
-        Assertions.assertThrows(SemanticCheckException.class,
-                () -> matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_analyzer_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("analyzer", "standard")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void build_succeeds_with_two_arguments() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"));
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_auto_generate_synonyms_phrase_query_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("auto_generate_synonyms_phrase_query", "true")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_fuzziness_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("fuzziness", "AUTO")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_max_expansions_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("max_expansions", "50")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_prefix_length_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("prefix_length", "0")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_fuzzy_transpositions_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("fuzzy_transpositions", "true")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_fuzzy_rewrite_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("fuzzy_rewrite", "constant_score")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_lenient_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("lenient", "false")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_operator_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("operator", "OR")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_minimum_should_match_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("minimum_should_match", "3")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_zero_terms_query_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("zero_terms_query", "NONE")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    @Test
-    public void test_boost_parameter() {
-        List<Expression> arguments = List.of(
-                namedArgument("field", "field_value"),
-                namedArgument("query", "query_value"),
-                namedArgument("boost", "1")
-        );
-        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-    }
-
-    private class MatchExpression extends FunctionExpression {
-        public MatchExpression(List<Expression> arguments) {
-            super(MatchQueryTest.this.match, arguments);
-        }
-
-        @Override
-        public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
-            return null;
-        }
-
-        @Override
-        public ExprType type() {
-            return null;
-        }
-    }
+  }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -1,0 +1,201 @@
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchQuery;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class MatchQueryTest {
+
+    private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+    private final MatchQuery matchQuery = new MatchQuery();
+    private final FunctionName match = FunctionName.of("match");
+
+    private NamedArgumentExpression namedArgument(String name, String value) {
+        return dsl.namedArgument(name, DSL.literal(value));
+    }
+
+    @Test
+    public void test_SemanticCheckException_when_no_arguments() {
+        List<Expression> arguments = List.of();
+        assertThrows(SemanticCheckException.class,
+                () -> matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_SemanticCheckException_when_one_argument() {
+        List<Expression> arguments = List.of(namedArgument("field", "field_value"));
+        assertThrows(SemanticCheckException.class,
+                () -> matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_SemanticCheckException_when_invalid_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("unsupported", "unsupported_value"));
+        Assertions.assertThrows(SemanticCheckException.class,
+                () -> matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_analyzer_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("analyzer", "standard")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void build_succeeds_with_two_arguments() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"));
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_auto_generate_synonyms_phrase_query_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("auto_generate_synonyms_phrase_query", "true")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_fuzziness_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("fuzziness", "AUTO")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_max_expansions_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("max_expansions", "50")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_prefix_length_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("prefix_length", "0")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_fuzzy_transpositions_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("fuzzy_transpositions", "true")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_fuzzy_rewrite_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("fuzzy_rewrite", "constant_score")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_lenient_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("lenient", "false")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_operator_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("operator", "OR")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_minimum_should_match_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("minimum_should_match", "3")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_zero_terms_query_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("zero_terms_query", "NONE")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    @Test
+    public void test_boost_parameter() {
+        List<Expression> arguments = List.of(
+                namedArgument("field", "field_value"),
+                namedArgument("query", "query_value"),
+                namedArgument("boost", "1")
+        );
+        Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
+
+    private class MatchExpression extends FunctionExpression {
+        public MatchExpression(List<Expression> arguments) {
+            super(MatchQueryTest.this.match, arguments);
+        }
+
+        @Override
+        public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+            return null;
+        }
+
+        @Override
+        public ExprType type() {
+            return null;
+        }
+    }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -55,16 +56,6 @@ public class MatchQueryTest {
   }
 
   @Test
-  public void test_analyzer_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("analyzer", "standard")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
   public void build_succeeds_with_two_arguments() {
     List<Expression> arguments = List.of(
         namedArgument("field", "field_value"),
@@ -73,113 +64,31 @@ public class MatchQueryTest {
   }
 
   @Test
-  public void test_auto_generate_synonyms_phrase_query_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("auto_generate_synonyms_phrase_query", "true")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
+  public void test_valid_parameters() {
+    final int validArgIndex = 2;
+    final List<Expression> validArgs = List.of(
+        namedArgument("analyzer", "standard"),
+        namedArgument("auto_generate_synonyms_phrase_query", "true"),
+        namedArgument("fuzziness", "AUTO"),
+        namedArgument("max_expansions", "50"),
+        namedArgument("prefix_length", "0"),
+        namedArgument("fuzzy_transpositions", "true"),
+        namedArgument("fuzzy_rewrite", "constant_score"),
+        namedArgument("lenient", "false"),
+        namedArgument("operator", "OR"),
+        namedArgument("minimum_should_match", "3"),
+        namedArgument("zero_terms_query", "NONE"),
+        namedArgument("boost", "1"));
 
-  @Test
-  public void test_fuzziness_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("fuzziness", "AUTO")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
+    List<Expression> arguments = new ArrayList<Expression>();
+    arguments.add(namedArgument("field", "field_value"));
+    arguments.add(namedArgument("query", "query_value"));
+    arguments.add(namedArgument("", ""));
 
-  @Test
-  public void test_max_expansions_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("max_expansions", "50")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_prefix_length_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("prefix_length", "0")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_fuzzy_transpositions_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("fuzzy_transpositions", "true")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_fuzzy_rewrite_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("fuzzy_rewrite", "constant_score")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_lenient_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("lenient", "false")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_operator_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("operator", "OR")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_minimum_should_match_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("minimum_should_match", "3")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_zero_terms_query_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("zero_terms_query", "NONE")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
-  }
-
-  @Test
-  public void test_boost_parameter() {
-    List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("boost", "1")
-    );
-    Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    for (Expression arg : validArgs) {
+      arguments.set(validArgIndex, arg);
+      Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
+    }
   }
 
   private NamedArgumentExpression namedArgument(String name, String value) {
@@ -193,12 +102,14 @@ public class MatchQueryTest {
 
     @Override
     public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
-      throw new UnsupportedOperationException("Invalid function call, valueOf function need implementation only to support Expression interface");
+      throw new UnsupportedOperationException("Invalid function call, "
+          + "valueOf function need implementation only to support Expression interface");
     }
 
     @Override
     public ExprType type() {
-      throw new UnsupportedOperationException("Invalid function call, type function need implementation only to support Expression interface");
+      throw new UnsupportedOperationException("Invalid function call, "
+          + "type function need implementation only to support Expression interface");
     }
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -30,10 +30,6 @@ public class MatchQueryTest {
   private final MatchQuery matchQuery = new MatchQuery();
   private final FunctionName match = FunctionName.of("match");
 
-  private NamedArgumentExpression namedArgument(String name, String value) {
-    return dsl.namedArgument(name, DSL.literal(value));
-  }
-
   @Test
   public void test_SemanticCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
@@ -186,6 +182,10 @@ public class MatchQueryTest {
     Assertions.assertNotNull(matchQuery.build(new MatchExpression(arguments)));
   }
 
+  private NamedArgumentExpression namedArgument(String name, String value) {
+    return dsl.namedArgument(name, DSL.literal(value));
+  }
+
   private class MatchExpression extends FunctionExpression {
     public MatchExpression(List<Expression> arguments) {
       super(MatchQueryTest.this.match, arguments);
@@ -193,12 +193,12 @@ public class MatchQueryTest {
 
     @Override
     public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
-      return null;
+      throw new UnsupportedOperationException("Invalid function call, valueOf function need implementation only to support Expression interface");
     }
 
     @Override
     public ExprType type() {
-      return null;
+      throw new UnsupportedOperationException("Invalid function call, type function need implementation only to support Expression interface");
     }
   }
 }


### PR DESCRIPTION
### Description
Add unit tests for match function implementation with 100% code coverage.
 
### Check List
- [x] New functionality includes testing.
- [x] All tests pass, including unit test, integration test and doctest
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).