### PR TITLE
Support legacy syntax for match_phrase in the new SQL engine.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -188,6 +188,7 @@ public enum BuiltinFunctionName {
    */
   MATCH(FunctionName.of("match")),
   MATCH_PHRASE(FunctionName.of("match_phrase")),
+  MATCHPHRASE(FunctionName.of("matchphrase")),
 
   /**
    * Legacy Relevance Function.

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -28,9 +28,15 @@ public class OpenSearchFunctions {
   public static final int MATCH_PHRASE_MAX_NUM_PARAMETERS = 3;
   public static final int MIN_NUM_PARAMETERS = 2;
 
+  /**
+   * Add functions specific to OpenSearch to repository.
+   */
   public void register(BuiltinFunctionRepository repository) {
     repository.register(match());
-    repository.register(match_phrase());
+    // Register MATCHPHRASE as MATCH_PHRASE as well for backwards
+    // compatibility.
+    repository.register(match_phrase(BuiltinFunctionName.MATCH_PHRASE));
+    repository.register(match_phrase(BuiltinFunctionName.MATCHPHRASE));
   }
 
   private static FunctionResolver match() {
@@ -38,8 +44,8 @@ public class OpenSearchFunctions {
     return getRelevanceFunctionResolver(funcName, MATCH_MAX_NUM_PARAMETERS);
   }
 
-  private static FunctionResolver match_phrase() {
-    FunctionName funcName = BuiltinFunctionName.MATCH_PHRASE.getName();
+  private static FunctionResolver match_phrase(BuiltinFunctionName matchPhrase) {
+    FunctionName funcName = matchPhrase.getName();
     return getRelevanceFunctionResolver(funcName, MATCH_PHRASE_MAX_NUM_PARAMETERS);
   }
 
@@ -53,7 +59,9 @@ public class OpenSearchFunctions {
       FunctionName funcName, int numOptionalParameters) {
     FunctionBuilder buildFunction = args -> new OpenSearchFunction(funcName, args);
     var signatureMapBuilder = ImmutableMap.<FunctionSignature, FunctionBuilder>builder();
-    for (int numParameters = MIN_NUM_PARAMETERS; numParameters <= MIN_NUM_PARAMETERS + numOptionalParameters; numParameters++) {
+    for (int numParameters = MIN_NUM_PARAMETERS;
+         numParameters <= MIN_NUM_PARAMETERS + numOptionalParameters;
+         numParameters++) {
       List<ExprType> args = Collections.nCopies(numParameters, STRING);
       signatureMapBuilder.put(new FunctionSignature(funcName, args), buildFunction);
     }

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2209,6 +2209,8 @@ The match_phrase function maps to the match_phrase query used in search engine, 
 - slop
 - zero_terms_query
 
+For backward compatibility, matchphrase is also supported and mapped to match_phrase query as well.
+
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 
     os> SELECT author, title FROM books WHERE match_phrase(author, 'Alexander Milne');

--- a/docs/user/ppl/functions/relevance.rst
+++ b/docs/user/ppl/functions/relevance.rst
@@ -70,6 +70,8 @@ The match_phrase function maps to the match_phrase query used in search engine, 
 - slop
 - zero_terms_query
 
+For backward compatibility, matchphrase is also supported and mapped to match_phrase query as well.
+
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 
     os> source=books | where match_phrase(author, 'Alexander Milne') | fields author, title

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -54,6 +54,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.LIKE.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.MATCH.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_PHRASE.getName(), new MatchPhraseQuery())
+          .put(BuiltinFunctionName.MATCHPHRASE.getName(), new MatchPhraseQuery())
           .put(BuiltinFunctionName.QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -171,7 +171,7 @@ statsFunctionName
     ;
 
 percentileAggFunction
-    : PERCENTILE '<' value=integerLiteral '>' LT_PRTHS aggField=fieldExpression RT_PRTHS
+    : PERCENTILE LESS value=integerLiteral GREATER LT_PRTHS aggField=fieldExpression RT_PRTHS
     ;
 
 /** expressions */

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -383,7 +383,7 @@ flowControlFunctionName
     ;
 
 relevanceFunctionName
-    : MATCH | MATCH_PHRASE
+    : MATCH | MATCH_PHRASE | MATCHPHRASE
     ;
 
 legacyRelevanceFunctionName


### PR DESCRIPTION
These changes have already been reviewed as part of  #48.

Creating another PR to bring them into the integration branch.

### Description
 Add support for matchphrase as an alternative spelling of match_phrase.

Mention in both SQL and PPL documentation that matchphrase is accepted
as well as match_phrase.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).