### PR TITLE
Dev replace junit assertthat with hamcrest import

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/correctness/tests/TestConfigTest.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/tests/TestConfigTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/tests/TestDataSetTest.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/tests/TestDataSetTest.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.correctness.tests;
 
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.opensearch.sql.correctness.testset.TestDataSet;

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/tests/TestQuerySetTest.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/tests/TestQuerySetTest.java
@@ -7,7 +7,7 @@
 package org.opensearch.sql.correctness.tests;
 
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.opensearch.sql.correctness.testset.TestQuerySet;

--- a/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.base.Strings;
 import com.google.gson.JsonParser;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/antlr/semantic/SemanticAnalyzerBasicTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/antlr/semantic/SemanticAnalyzerBasicTest.java
@@ -9,7 +9,7 @@ package org.opensearch.sql.legacy.antlr.semantic;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.BOOLEAN;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.DATE;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.DOUBLE;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/antlr/semantic/scope/EnvironmentTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/antlr/semantic/scope/EnvironmentTest.java
@@ -9,7 +9,7 @@ package org.opensearch.sql.legacy.antlr.semantic.scope;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.BOOLEAN;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.DATE;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.KEYWORD;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/antlr/semantic/scope/SymbolTableTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/antlr/semantic/scope/SymbolTableTest.java
@@ -9,7 +9,7 @@ package org.opensearch.sql.legacy.antlr.semantic.scope;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.BOOLEAN;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.DATE;
 import static org.opensearch.sql.legacy.antlr.semantic.types.base.OpenSearchDataType.KEYWORD;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/esdomain/mapping/FieldMappingTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/esdomain/mapping/FieldMappingTest.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.legacy.esdomain.mapping;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetadata;
 
 import com.google.common.collect.ImmutableMap;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/cursor/DefaultCursorTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/cursor/DefaultCursorTest.java
@@ -9,12 +9,12 @@ package org.opensearch.sql.legacy.unittest.cursor;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import org.junit.Test;
-import org.opensearch.sql.legacy.cursor.CursorType;
+import org.opensearch.sql.legacy.cursor.CursorType;:qqqq
 import org.opensearch.sql.legacy.cursor.DefaultCursor;
 
 public class DefaultCursorTest {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/cursor/DefaultCursorTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/cursor/DefaultCursorTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.ArrayList;
 import java.util.Collections;
 import org.junit.Test;
-import org.opensearch.sql.legacy.cursor.CursorType;:qqqq
+import org.opensearch.sql.legacy.cursor.CursorType;
 import org.opensearch.sql.legacy.cursor.DefaultCursor;
 
 public class DefaultCursorTest {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/expression/model/ExprValueUtilsTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/expression/model/ExprValueUtilsTest.java
@@ -7,7 +7,7 @@
 package org.opensearch.sql.legacy.unittest.expression.model;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/MatcherUtils.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/MatcherUtils.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.base.Strings;
 import java.util.ArrayList;

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/UnresolvedPlanHelperTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/UnresolvedPlanHelperTest.java
@@ -6,7 +6,7 @@
 
 package org.opensearch.sql.ppl.utils;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;


### PR DESCRIPTION
### Description
Changes the deprecated method, org.junit.Assert.assertThat, to  org.hamcrest.MatcherAssert.assertThat.
 
### Issues Resolved
Replaces deprecated method org.junit.Assert.assertThat.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).