### PR TITLE
match_bool_prefix Add PPL Syntax

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/MatchBoolPrefixIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/MatchBoolPrefixIT.java
@@ -25,7 +25,7 @@ public class MatchBoolPrefixIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where match_bool_prefix(phrase, 'quick') | fields phrase",
+                "source=%s | where match_bool_prefix(phrase, 'qui') | fields phrase",
                 TEST_INDEX_PHRASE));
 
     verifyDataRows(result,
@@ -38,7 +38,7 @@ public class MatchBoolPrefixIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where match_bool_prefix(phrase, '2 test', minimum_should_match=1, fuzziness=2) | fields phrase",
+                "source=%s | where match_bool_prefix(phrase, '2 tes', minimum_should_match=1, fuzziness=2) | fields phrase",
                 TEST_INDEX_PHRASE));
 
     verifyDataRows(result,

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/MatchBoolPrefixIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/MatchBoolPrefixIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PHRASE;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class MatchBoolPrefixIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.PHRASE);
+  }
+
+  @Test
+  public void valid_query_match_test() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where match_bool_prefix(phrase, 'quick') | fields phrase",
+                TEST_INDEX_PHRASE));
+
+    verifyDataRows(result,
+        rows("quick fox"),
+        rows("quick fox here"));
+  }
+
+  @Test
+  public void optional_parameter_match_test() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where match_bool_prefix(phrase, '2 test', minimum_should_match=1, fuzziness=2) | fields phrase",
+                TEST_INDEX_PHRASE));
+
+    verifyDataRows(result,
+        rows("my test"),
+        rows("my test 2"));
+  }
+
+  @Test
+  public void no_matches_test() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where match_bool_prefix(phrase, 'rice') | fields phrase",
+                TEST_INDEX_PHRASE));
+
+    assertEquals(0, result.getInt("total"));
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -265,6 +265,7 @@ IF:                                 'IF';
 // RELEVANCE FUNCTIONS AND PARAMETERS
 MATCH:                              'MATCH';
 MATCH_PHRASE:                       'MATCH_PHRASE';
+MATCH_BOOL_PREFIX:                  'MATCH_BOOL_PREFIX';
 ANALYZER:                           'ANALYZER';
 FUZZINESS:                          'FUZZINESS';
 AUTO_GENERATE_SYNONYMS_PHRASE_QUERY:'AUTO_GENERATE_SYNONYMS_PHRASE_QUERY';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -352,6 +352,7 @@ binaryOperator
 relevanceFunctionName
     : MATCH
     | MATCH_PHRASE
+    | MATCH_BOOL_PREFIX
     ;
 
 /** literals and values*/

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserMatchBoolPrefixSamplesTests.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserMatchBoolPrefixSamplesTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.antlr;
+
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.List;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith(Parameterized.class)
+public class PPLSyntaxParserMatchBoolPrefixSamplesTests {
+
+
+  /** Returns sample queries that the PPLSyntaxParser is expected to parse successfully.
+   * @return an Iterable of sample queries.
+   */
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object> sampleQueries() {
+    return List.of(
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world')",
+        "source=t a = 1 | where match_bool_prefix(a, 'hello world',"
+            + " minimum_should_match = 3)",
+        "source=t a = 1 | where match_bool_prefix(a, 'hello world', fuzziness='AUTO')",
+        "source=t a = 1 | where match_bool_prefix(a, 'hello world', fuzziness='AUTO:4,6')",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world', prefix_length=0)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world', max_expansions=1)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_transpositions=true)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_rewrite=constant_score)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_rewrite=constant_score_boolean)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_rewrite=scoring_boolean)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_rewrite=top_terms_blended_freqs_1)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_rewrite=top_terms_boost_1)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world',"
+            + " fuzzy_rewrite=top_terms_1)",
+        "source=t a= 1 | where match_bool_prefix(a, 'hello world', boost=1)",
+        "source=t a = 1 | where match_bool_prefix(a, 'hello world', analyzer = 'standard',"
+            + "prefix_length = '0', boost = 1)");
+  }
+
+  private final String query;
+
+  public PPLSyntaxParserMatchBoolPrefixSamplesTests(String query) {
+    this.query = query;
+  }
+
+  @Test
+  public void test() {
+    ParseTree tree = new PPLSyntaxParser().parse(query);
+    assertNotEquals(null, tree);
+  }
+}


### PR DESCRIPTION
### Description
Add PPL syntax for match_bool_prefix.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).