### PR TITLE
Dev match_phrase_prefix #186 required

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -658,6 +658,10 @@ public class DSL {
     return compile(BuiltinFunctionName.MATCH_PHRASE, args);
   }
 
+  public FunctionExpression match_phrase_prefix(Expression... args) {
+    return compile(BuiltinFunctionName.MATCH_PHRASE_PREFIX, args);
+  }
+
   private FunctionExpression compile(BuiltinFunctionName bfn, Expression... args) {
     return (FunctionExpression) repository.compile(bfn.getName(), Arrays.asList(args.clone()));
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -189,7 +189,7 @@ public enum BuiltinFunctionName {
   MATCH(FunctionName.of("match")),
   MATCH_PHRASE(FunctionName.of("match_phrase")),
   MATCHPHRASE(FunctionName.of("matchphrase")),
-
+  MATCH_PHRASE_PREFIX(FunctionName.of("match_phrase_prefix")),
   /**
    * Legacy Relevance Function.
    */

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -27,6 +27,7 @@ public class OpenSearchFunctions {
   public static final int MATCH_MAX_NUM_PARAMETERS = 12;
   public static final int MATCH_PHRASE_MAX_NUM_PARAMETERS = 3;
   public static final int MIN_NUM_PARAMETERS = 2;
+  private static final int MATCH_PHRASE_PREFIX_MAX_NUM_PARAMETERS = 0;
 
   /**
    * Add functions specific to OpenSearch to repository.
@@ -37,6 +38,7 @@ public class OpenSearchFunctions {
     // compatibility.
     repository.register(match_phrase(BuiltinFunctionName.MATCH_PHRASE));
     repository.register(match_phrase(BuiltinFunctionName.MATCHPHRASE));
+    repository.register(match_phrase_prefix());
   }
 
   private static FunctionResolver match() {
@@ -44,6 +46,11 @@ public class OpenSearchFunctions {
     return getRelevanceFunctionResolver(funcName, MATCH_MAX_NUM_PARAMETERS);
   }
 
+  private static FunctionResolver match_phrase_prefix() {
+    FunctionName funcName = BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName();
+    return getRelevanceFunctionResolver(funcName, MATCH_PHRASE_PREFIX_MAX_NUM_PARAMETERS);
+  }
+  
   private static FunctionResolver match_phrase(BuiltinFunctionName matchPhrase) {
     FunctionName funcName = matchPhrase.getName();
     return getRelevanceFunctionResolver(funcName, MATCH_PHRASE_MAX_NUM_PARAMETERS);

--- a/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
@@ -133,6 +133,19 @@ public class OpenSearchFunctionsTest extends ExpressionTestBase {
     );
   }
 
+  List<FunctionExpression> match_phrase_prefix_dsl_expressions() {
+    return List.of(
+        dsl.match_phrase_prefix(field, query)
+    );
+  }
+
+  @Test
+  public void match_phrase_prefix() {
+    for (FunctionExpression fe : match_phrase_prefix_dsl_expressions()) {
+      assertEquals(BOOLEAN, fe.type());
+    }
+  }
+
   @Test
   void match_in_memory() {
     FunctionExpression expr = dsl.match(field, query);

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.sql;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+public class MatchPhrasePrefixFunctionIT extends SQLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.BANK);
+  }
+
+  @Test
+  public void match_phrase_prefix_required_parameters() throws IOException {
+    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_BANK
+        + " WHERE match_phrase_prefix(address, 'Quentin Str')");
+    verifyDataRows(result, rows("Mcpherson"));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -29,6 +29,7 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery.Comparison;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.TermQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.WildcardQuery;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhrasePrefixQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhraseQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchQuery;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
@@ -58,6 +59,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())
+          .put(BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName(), new MatchPhrasePrefixQuery())
           .build();
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
@@ -1,0 +1,24 @@
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+
+/**
+    * Lucene query that builds a match_phrase_prefix query.
+    */
+public class MatchPhrasePrefixQuery  extends RelevanceQuery<MatchPhrasePrefixQueryBuilder> {
+  /**
+   *  Default constructor for MatchPhrasePrefixQuery configures how RelevanceQuery.build() handles
+   * named arguments.
+   */
+  public MatchPhrasePrefixQuery() {
+    super(ImmutableMap.<String, QueryBuilderStep<MatchPhrasePrefixQueryBuilder>>builder()
+        .build());
+  }
+
+  @Override
+  protected MatchPhrasePrefixQueryBuilder createQueryBuilder(String field, String query) {
+    return QueryBuilders.matchPhrasePrefixQuery(field, query);
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
 
 import com.google.common.collect.ImmutableMap;

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -495,6 +495,7 @@ class FilterQueryBuilderTest {
                 dsl.namedArgument("field", literal("message")),
                 dsl.namedArgument("query", literal("search query")))));
   }
+
   @Test
   void cast_to_string_in_filter() {
     String json = "{\n"

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -477,6 +477,25 @@ class FilterQueryBuilderTest {
   }
 
   @Test
+  void should_build_match_phrase_prefix_query_with_default_parameters() {
+    assertJsonEquals(
+        "{\n"
+            + "  \"match_phrase_prefix\" : {\n"
+            + "    \"message\" : {\n"
+            + "      \"query\" : \"search query\",\n"
+            + "      \"slop\" : 0,\n"
+            + "      \"zero_terms_query\" : \"NONE\",\n"
+            + "      \"max_expansions\" : 50,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            dsl.match_phrase_prefix(
+                dsl.namedArgument("field", literal("message")),
+                dsl.namedArgument("query", literal("search query")))));
+  }
+  @Test
   void cast_to_string_in_filter() {
     String json = "{\n"
         + "  \"term\" : {\n"

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -279,6 +279,7 @@ INCLUDE:                            'INCLUDE';
 IN_TERMS:                           'IN_TERMS';
 MATCHPHRASE:                        'MATCHPHRASE';
 MATCH_PHRASE:                       'MATCH_PHRASE';
+MATCH_PHRASE_PREFIX:                'MATCH_PHRASE_PREFIX';
 MATCHQUERY:                         'MATCHQUERY';
 MATCH_QUERY:                        'MATCH_QUERY';
 MINUTE_OF_DAY:                      'MINUTE_OF_DAY';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -383,7 +383,7 @@ flowControlFunctionName
     ;
 
 relevanceFunctionName
-    : MATCH | MATCH_PHRASE | MATCHPHRASE
+    : MATCH | MATCH_PHRASE | MATCHPHRASE | MATCH_PHRASE_PREFIX
     ;
 
 legacyRelevanceFunctionName

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -9,11 +9,13 @@ package org.opensearch.sql.sql.antlr;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -173,9 +175,20 @@ class SQLSyntaxParserTest {
   }
 
   @ParameterizedTest
-  @MethodSource({"matchPhraseComplexQueries",
-          "matchPhraseGeneratedQueries", "generateMatchPhraseQueries"})
+  @MethodSource({
+      "matchPhraseComplexQueries",
+      "matchPhraseGeneratedQueries",
+      "generateMatchPhraseQueries",
+  })
   public void canParseComplexMatchPhraseArgsTest(String query) {
+    assertNotNull(parser.parse(query));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "generateMatchPhrasePrefixQueries"
+  })
+  public void canParseComplexMatchPhrasePrefixQueries(String query) {
     assertNotNull(parser.parse(query));
   }
 
@@ -223,8 +236,13 @@ class SQLSyntaxParserTest {
     return generateQueries("match_phrase", matchPhraseArgs);
   }
 
+  private static Stream<String> generateMatchPhrasePrefixQueries() {
+    return generateQueries("match_phrase_prefix", ImmutableMap.<String, Object[]>builder()
+        .build());
+  }
+
   private static Stream<String> generateQueries(String function,
-                                                HashMap<String, Object[]> functionArgs) {
+                                                Map<String, Object[]> functionArgs) {
     var rand = new Random(0);
 
     class QueryGenerator implements Iterator<String> {


### PR DESCRIPTION
### Description
Add support to SQL for `match_phrase_prefix` query function with required parameters only.

Example query:
`SELECT * FROM banks WHERE match_phrase_prefix(Address, "Str")`
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).