### PR TITLE
match_phrase_prefix in SQL with optional parameters

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -667,4 +667,7 @@ public class DSL {
   }
 
 
+  public NamedArgumentExpression namedArgument(String name, String value) {
+    return namedArgument(name, literal(value));
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -118,6 +118,10 @@ public class DSL {
     return new NamedArgumentExpression(argName, value);
   }
 
+  public NamedArgumentExpression namedArgument(String name, String value) {
+    return namedArgument(name, literal(value));
+  }
+
   public static ParseExpression parsed(Expression expression, Expression pattern,
                                        Expression identifier) {
     return new ParseExpression(expression, pattern, identifier);
@@ -664,10 +668,5 @@ public class DSL {
 
   private FunctionExpression compile(BuiltinFunctionName bfn, Expression... args) {
     return (FunctionExpression) repository.compile(bfn.getName(), Arrays.asList(args.clone()));
-  }
-
-
-  public NamedArgumentExpression namedArgument(String name, String value) {
-    return namedArgument(name, literal(value));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -27,7 +27,7 @@ public class OpenSearchFunctions {
   public static final int MATCH_MAX_NUM_PARAMETERS = 12;
   public static final int MATCH_PHRASE_MAX_NUM_PARAMETERS = 3;
   public static final int MIN_NUM_PARAMETERS = 2;
-  public static final int MATCH_PHRASE_PREFIX_MAX_NUM_PARAMETERS = 4;
+  public static final int MATCH_PHRASE_PREFIX_MAX_NUM_PARAMETERS = 5;
 
   /**
    * Add functions specific to OpenSearch to repository.

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -27,7 +27,7 @@ public class OpenSearchFunctions {
   public static final int MATCH_MAX_NUM_PARAMETERS = 12;
   public static final int MATCH_PHRASE_MAX_NUM_PARAMETERS = 3;
   public static final int MIN_NUM_PARAMETERS = 2;
-  public static final int MATCH_PHRASE_PREFIX_MAX_NUM_PARAMETERS = 0;
+  public static final int MATCH_PHRASE_PREFIX_MAX_NUM_PARAMETERS = 4;
 
   /**
    * Add functions specific to OpenSearch to repository.

--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -14,6 +14,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.function;
 import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
 import static org.opensearch.sql.data.model.ExprValueUtils.integerValue;
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
@@ -337,6 +338,11 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
   }
 
   @Test
+  public void match_phrase_prefix_all_parameters() {
+
+  }
+
+  @Test
   void visit_span() {
     assertAnalyzeEqual(
         DSL.span(DSL.ref("integer_value", INTEGER), DSL.literal(1), ""),
@@ -357,6 +363,30 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     assertThrows(
         SemanticCheckException.class,
         () -> analyze(AstDSL.in(field("integer_value"), Collections.emptyList())));
+  }
+
+  @Test
+  public void match_phrase_prefix_all_params() {
+    assertAnalyzeEqual(
+        dsl.match_phrase_prefix(
+            dsl.namedArgument("field", "test"),
+            dsl.namedArgument("query", "search query"),
+            dsl.namedArgument("slop", "3"),
+            dsl.namedArgument("boost", "1.5"),
+            dsl.namedArgument("analyzer", "standard"),
+            dsl.namedArgument("max_expansions", "4"),
+            dsl.namedArgument("zero_terms_query", "NONE")
+            ),
+        AstDSL.function("match_phrase_prefix",
+          unresolvedArg("field", stringLiteral("test")),
+          unresolvedArg("query", stringLiteral("search query")),
+          unresolvedArg("slop", stringLiteral("3")),
+          unresolvedArg("boost", stringLiteral("1.5")),
+          unresolvedArg("analyzer", stringLiteral("standard")),
+          unresolvedArg("max_expansions", stringLiteral("4")),
+          unresolvedArg("zero_terms_query", stringLiteral("NONE"))
+          )
+    );
   }
 
   protected Expression analyze(UnresolvedExpression unresolvedExpression) {

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
@@ -28,4 +28,12 @@ public class MatchPhrasePrefixFunctionIT extends SQLIntegTestCase {
         + " WHERE match_phrase_prefix(address, 'Quentin Str')");
     verifyDataRows(result, rows("Mcpherson"));
   }
+
+  @Test
+  public void match_phrase_prefix_all_parameters() throws IOException {
+    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_BANK
+        + " WHERE match_phrase_prefix(address, 'Quentin Str', boost = 1.0, zero_terms_query='ALL',"
+        + " max_expansions = 3, analyzer='standard')");
+    verifyDataRows(result, rows("Mcpherson"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
@@ -19,6 +19,12 @@ public class MatchPhrasePrefixQuery  extends RelevanceQuery<MatchPhrasePrefixQue
    */
   public MatchPhrasePrefixQuery() {
     super(ImmutableMap.<String, QueryBuilderStep<MatchPhrasePrefixQueryBuilder>>builder()
+        .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
+        .put("slop", (b, v) -> b.slop(Integer.parseInt(v.stringValue())))
+        .put("max_expansions", (b, v) -> b.maxExpansions(Integer.parseInt(v.stringValue())))
+        .put("zero_terms_query", (b, v) -> b.zeroTermsQuery(
+            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue())))
+        .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .build());
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -30,6 +30,7 @@ public class MatchPhraseQuery extends RelevanceQuery<MatchPhraseQueryBuilder> {
    */
   public MatchPhraseQuery() {
     super(ImmutableMap.<String, QueryBuilderStep<MatchPhraseQueryBuilder>>builder()
+        .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("slop", (b, v) -> b.slop(Integer.parseInt(v.stringValue())))
         .put("zero_terms_query", (b, v) -> b.zeroTermsQuery(

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhrasePrefixQuery;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class MatchPhrasePrefixQueryTest {
+
+  private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+  private final MatchPhrasePrefixQuery matchPhrasePrefixQuery = new MatchPhrasePrefixQuery();
+  private final FunctionName matchPhrasePrefix = FunctionName.of("match_phrase_prefix");
+
+  private NamedArgumentExpression namedArgument(String name, String value) {
+    return dsl.namedArgument(name, DSL.literal(value));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_no_arguments() {
+    List<Expression> arguments = List.of();
+    assertThrows(SyntaxCheckException.class,
+        () -> matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_one_argument() {
+    List<Expression> arguments = List.of(namedArgument("field", "test"));
+    assertThrows(SyntaxCheckException.class,
+        () -> matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_invalid_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "test"),
+        namedArgument("query", "test2"),
+        namedArgument("unsupported", "3"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  @Test
+  public void test_analyzer_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "t1"),
+        namedArgument("query", "t2"),
+        namedArgument("analyzer", "standard")
+    );
+    Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  @Test
+  public void build_succeeds_with_two_arguments() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "test"),
+        namedArgument("query", "test2"));
+    Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  @Test
+  public void test_slop_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "t1"),
+        namedArgument("query", "t2"),
+        namedArgument("slop", "2")
+    );
+    Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  @Test
+  public void test_zero_terms_query_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "t1"),
+        namedArgument("query", "t2"),
+        namedArgument("zero_terms_query", "ALL")
+    );
+    Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+
+  @Test
+  public void test_boost_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "t1"),
+        namedArgument("query", "t2"),
+        namedArgument("boost", "0.1")
+    );
+    Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
+  private class MatchPhraseExpression extends FunctionExpression {
+    public MatchPhraseExpression(List<Expression> arguments) {
+      super(MatchPhrasePrefixQueryTest.this.matchPhrasePrefix, arguments);
+    }
+
+    @Override
+    public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+      return null;
+    }
+
+    @Override
+    public ExprType type() {
+      return null;
+    }
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
@@ -20,7 +20,6 @@ import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.NamedArgumentExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
@@ -33,10 +32,6 @@ public class MatchPhrasePrefixQueryTest {
   private final MatchPhrasePrefixQuery matchPhrasePrefixQuery = new MatchPhrasePrefixQuery();
   private final FunctionName matchPhrasePrefix = FunctionName.of("match_phrase_prefix");
 
-  private NamedArgumentExpression namedArgument(String name, String value) {
-    return dsl.namedArgument(name, DSL.literal(value));
-  }
-
   @Test
   public void test_SyntaxCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
@@ -46,7 +41,7 @@ public class MatchPhrasePrefixQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
-    List<Expression> arguments = List.of(namedArgument("field", "test"));
+    List<Expression> arguments = List.of(dsl.namedArgument("field", "test"));
     assertThrows(SyntaxCheckException.class,
         () -> matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -54,9 +49,9 @@ public class MatchPhrasePrefixQueryTest {
   @Test
   public void test_SyntaxCheckException_when_invalid_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "test"),
-        namedArgument("query", "test2"),
-        namedArgument("unsupported", "3"));
+        dsl.namedArgument("field", "test"),
+        dsl.namedArgument("query", "test2"),
+        dsl.namedArgument("unsupported", "3"));
     Assertions.assertThrows(SemanticCheckException.class,
         () -> matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -64,9 +59,9 @@ public class MatchPhrasePrefixQueryTest {
   @Test
   public void test_analyzer_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("analyzer", "standard")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("analyzer", "standard")
     );
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -74,17 +69,17 @@ public class MatchPhrasePrefixQueryTest {
   @Test
   public void build_succeeds_with_two_arguments() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "test"),
-        namedArgument("query", "test2"));
+        dsl.namedArgument("field", "test"),
+        dsl.namedArgument("query", "test2"));
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
 
   @Test
   public void test_slop_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("slop", "2")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("slop", "2")
     );
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -92,9 +87,9 @@ public class MatchPhrasePrefixQueryTest {
   @Test
   public void test_zero_terms_query_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("zero_terms_query", "ALL")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("zero_terms_query", "ALL")
     );
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -103,9 +98,9 @@ public class MatchPhrasePrefixQueryTest {
   @Test
   public void test_boost_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("boost", "0.1")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("boost", "0.1")
     );
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -238,6 +239,11 @@ class SQLSyntaxParserTest {
 
   private static Stream<String> generateMatchPhrasePrefixQueries() {
     return generateQueries("match_phrase_prefix", ImmutableMap.<String, Object[]>builder()
+        .put("analyzer", new String[] {"standard", "stop", "english"})
+        .put("slop", new Integer[] {0, 1, 2})
+        .put("max_expansions", new Integer[] {0, 3, 10})
+        .put("zero_terms_query", new String[] {"NONE", "ALL", "NULL"})
+        .put("boost", new Float[] {-0.5f, 1.0f, 1.2f})
         .build());
   }
 

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -429,6 +429,23 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void matchPhrasePrefixAllParameters() {
+    assertEquals(
+      AstDSL.function("match_phrase_prefix",
+          unresolvedArg("field", stringLiteral("test")),
+          unresolvedArg("query", stringLiteral("search query")),
+          unresolvedArg("slop", stringLiteral("3")),
+          unresolvedArg("boost", stringLiteral("1.5")),
+          unresolvedArg("analyzer", stringLiteral("standard")),
+          unresolvedArg("max_expansions", stringLiteral("4")),
+          unresolvedArg("zero_terms_query", stringLiteral("NONE"))
+          ),
+        buildExprAst("match_phrase_prefix(test, 'search query', slop = 3, boost = 1.5"
+            + ", analyzer = 'standard', max_expansions = 4, zero_terms_query='NONE'"
+            + ")")
+    );
+  }
+  @Test
   public void relevanceMatch() {
     assertEquals(AstDSL.function("match",
         unresolvedArg("field", stringLiteral("message")),

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -431,7 +431,7 @@ class AstExpressionBuilderTest {
   @Test
   public void matchPhrasePrefixAllParameters() {
     assertEquals(
-      AstDSL.function("match_phrase_prefix",
+        AstDSL.function("match_phrase_prefix",
           unresolvedArg("field", stringLiteral("test")),
           unresolvedArg("query", stringLiteral("search query")),
           unresolvedArg("slop", stringLiteral("3")),
@@ -445,6 +445,7 @@ class AstExpressionBuilderTest {
             + ")")
     );
   }
+
   @Test
   public void relevanceMatch() {
     assertEquals(AstDSL.function("match",


### PR DESCRIPTION
### Description
Support boost, slop, analyzer, zero_terms_query, and max_expansions optional parameters for match_phrase_prefix in SQL. 

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).