### PR TITLE
Add analyzer and operator parameters to match_bool_prefix

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchBoolPrefixQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchBoolPrefixQuery.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
 
 import com.google.common.collect.ImmutableMap;
 import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
+import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilders;
 
 /**
@@ -28,6 +29,8 @@ public class MatchBoolPrefixQuery
             (b, v) -> b.fuzzyTranspositions(Boolean.parseBoolean(v.stringValue())))
         .put("fuzzy_rewrite", (b, v) -> b.fuzzyRewrite(v.stringValue()))
         .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
+        .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
+        .put("operator", (b,v) -> b.operator(Operator.fromString(v.stringValue())))
         .build());
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchBoolPrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchBoolPrefixQueryTest.java
@@ -45,7 +45,10 @@ public class MatchBoolPrefixQueryTest {
             dsl.namedArgument("fuzzy_transpositions", DSL.literal("true")),
             dsl.namedArgument("fuzzy_rewrite", DSL.literal("constant_score")),
             dsl.namedArgument("minimum_should_match", DSL.literal("3")),
-            dsl.namedArgument("boost", DSL.literal("1"))
+            dsl.namedArgument("boost", DSL.literal("1")),
+            dsl.namedArgument("analyzer", DSL.literal("simple")),
+            dsl.namedArgument("operator", DSL.literal("Or")),
+            dsl.namedArgument("operator", DSL.literal("and"))
         ).stream().map(arg -> List.of(field, query, arg));
   }
 


### PR DESCRIPTION
### Description
These were flagged as missing in the upstream PR.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).