### PR TITLE
Add integration tests for match_phrase_prefix in SQL

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
@@ -34,21 +34,11 @@ public class MatchPhrasePrefixFunctionIT extends SQLIntegTestCase {
   @Test
   public void all_optional_parameters() throws IOException {
     // The values for optional parameters are valid but arbitrary.
-    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'champagne be', " +
-        "boost = 1.0, zero_terms_query='ALL', max_expansions = 3, analyzer=standard, slop=0)";
+    String query = "SELECT Title FROM %s " +
+        "WHERE match_phrase_prefix(Title, 'flat champ', boost = 1.0, zero_terms_query='ALL', " +
+        "max_expansions = 2, analyzer=standard, slop=0)";
     JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
     verifyDataRows(result, rows("Can old flat champagne be used for vinegar?"));
-  }
-
-  @Test
-  public void max_expansions_is_2() throws IOException {
-    // max_expansions applies to the last term in the query -- 'bottl'
-    // It tells OpenSearch to consider only the first 2 terms that start with 'bottl'
-    // In this dataset these are 'bottle-conditioning', and 'bottling'.
-    String query = "SELECT Tags FROM %s " +
-        "WHERE match_phrase_prefix(Tags, 'draught bottl', max_expansions=2)";
-    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
-    verifyDataRows(result, rows("brewing draught bottling"));
   }
 
   @Test
@@ -100,25 +90,21 @@ public class MatchPhrasePrefixFunctionIT extends SQLIntegTestCase {
 
 
   @Test
-  public void slop_is_0() throws IOException {
+  public void slop_is_2() throws IOException {
     // When slop is 0, the terms are matched exactly in the order specified.
     // 'open' is used to match prefix of the next term.
-    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'bottle open', slop=0)";
+    String query = "SELECT Tags from %s where match_phrase_prefix(Tags, 'gas ta', slop=2)";
     JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
-    verifyDataRows(result, rows("How to open a beer without a bottle opener?"));
+    verifyDataRows(result, rows("taste gas"));
   }
 
   @Test
-  public void slop_is_2() throws IOException {
+  public void slop_is_3() throws IOException {
     // When slop is 2, results will include phrases where the query terms are transposed.
-    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'bottle open', slop=1)";
+    String query = "SELECT Tags from %s where match_phrase_prefix(Tags, 'gas ta', slop=3)";
     JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
     verifyDataRows(result,
-        rows("How long does an opened bottle of wine last in the fridge?"),
-        rows("How long will an opened bottle of whisky last while stored " +
-            "under ideal conditions?"),
-        rows("How long does an open bottle of Sake last?"),
-        rows("Does whisky change its taste in an open bottle?"),
-        rows("How to open a beer without a bottle opener?"));
+        rows("taste draught gas"),
+        rows("taste gas"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhrasePrefixFunctionIT.java
@@ -6,7 +6,7 @@
 
 package org.opensearch.sql.sql;
 
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
@@ -19,21 +19,106 @@ public class MatchPhrasePrefixFunctionIT extends SQLIntegTestCase {
 
   @Override
   protected void init() throws Exception {
-    loadIndex(Index.BANK);
+    loadIndex(Index.BEER);
   }
 
   @Test
-  public void match_phrase_prefix_required_parameters() throws IOException {
-    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_BANK
-        + " WHERE match_phrase_prefix(address, 'Quentin Str')");
-    verifyDataRows(result, rows("Mcpherson"));
+  public void required_parameters() throws IOException {
+    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'champagne be')";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result,
+        rows("Can old flat champagne be used for vinegar?"),
+        rows("Elder flower champagne best to use natural yeast or add a wine yeast?"));
   }
 
   @Test
-  public void match_phrase_prefix_all_parameters() throws IOException {
-    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_BANK
-        + " WHERE match_phrase_prefix(address, 'Quentin Str', boost = 1.0, zero_terms_query='ALL',"
-        + " max_expansions = 3, analyzer='standard')");
-    verifyDataRows(result, rows("Mcpherson"));
+  public void all_optional_parameters() throws IOException {
+    // The values for optional parameters are valid but arbitrary.
+    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'champagne be', " +
+        "boost = 1.0, zero_terms_query='ALL', max_expansions = 3, analyzer=standard, slop=0)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result, rows("Can old flat champagne be used for vinegar?"));
+  }
+
+  @Test
+  public void max_expansions_is_2() throws IOException {
+    // max_expansions applies to the last term in the query -- 'bottl'
+    // It tells OpenSearch to consider only the first 2 terms that start with 'bottl'
+    // In this dataset these are 'bottle-conditioning', and 'bottling'.
+    String query = "SELECT Tags FROM %s " +
+        "WHERE match_phrase_prefix(Tags, 'draught bottl', max_expansions=2)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result, rows("brewing draught bottling"));
+  }
+
+  @Test
+  public void max_expansions_is_3() throws IOException {
+    // max_expansions applies to the last term in the query -- 'bottl'
+    // It tells OpenSearch to consider only the first 3 terms that start with 'bottl'
+    // In this dataset these are 'bottle-conditioning', 'bottling', 'bottles'.
+
+    String query = "SELECT Tags FROM %s " +
+        "WHERE match_phrase_prefix(Tags, 'draught bottl', max_expansions=3)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result, rows("brewing draught bottling"),
+        rows("draught bottles"));
+  }
+
+  @Test
+  public void analyzer_english() throws IOException {
+    // English analyzer removes 'in' and 'to' as they are common words.
+    // This results in an empty query.
+    String query = "SELECT Title FROM %s " +
+        "WHERE match_phrase_prefix(Title, 'in to', analyzer=english)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    assertTrue("Expect English analyzer to filter out common words 'in' and 'to'",
+        result.getInt("total") == 0);
+  }
+
+  @Test
+  public void analyzer_standard() throws IOException {
+    // Standard analyzer does not treat 'in' and 'to' as special terms.
+    // This results in 'to' being used as a phrase prefix given us 'Tokyo'.
+    String query = "SELECT Title FROM %s " +
+        "WHERE match_phrase_prefix(Title, 'in to', analyzer=standard)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result, rows("Local microbreweries and craft beer in Tokyo"));
+  }
+
+  @Test
+  public void zero_term_query_all() throws IOException {
+    // English analyzer removes 'in' and 'to' as they are common words.
+    // zero_terms_query of 'ALL' causes all rows to be returned.
+    // ORDER BY ... LIMIT helps make the test understandable.
+    String query = "SELECT Title FROM %s" +
+        " WHERE match_phrase_prefix(Title, 'in to', analyzer=english, zero_terms_query='ALL')" +
+        " ORDER BY Title DESC" +
+        " LIMIT 1";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result, rows("was working great, now all foam"));
+  }
+
+
+  @Test
+  public void slop_is_0() throws IOException {
+    // When slop is 0, the terms are matched exactly in the order specified.
+    // 'open' is used to match prefix of the next term.
+    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'bottle open', slop=0)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result, rows("How to open a beer without a bottle opener?"));
+  }
+
+  @Test
+  public void slop_is_2() throws IOException {
+    // When slop is 2, results will include phrases where the query terms are transposed.
+    String query = "SELECT Title FROM %s WHERE match_phrase_prefix(Title, 'bottle open', slop=1)";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_BEER));
+    verifyDataRows(result,
+        rows("How long does an opened bottle of wine last in the fridge?"),
+        rows("How long will an opened bottle of whisky last while stored " +
+            "under ideal conditions?"),
+        rows("How long does an open bottle of Sake last?"),
+        rows("Does whisky change its taste in an open bottle?"),
+        rows("How to open a beer without a bottle opener?"));
   }
 }


### PR DESCRIPTION
### Description
Add integration tests for match_phrase_prefix in SQL

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).