### PR TITLE
Fix data anonymizer failures by updating legacy parser.

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/parser/ElasticSqlExprParser.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/parser/ElasticSqlExprParser.java
@@ -146,11 +146,13 @@ public class ElasticSqlExprParser extends SQLExprParser {
             lexer.nextToken();
             String prefix = "";
             while (lexer.token() != Token.RBRACKET) {
+                /*
                 if (lexer.token() != Token.IDENTIFIER && lexer.token() != Token.INDEX
-                        && lexer.token() != Token.LITERAL_CHARS) {
+                        && lexer.token() != Token.LITERAL_CHARS && lexer.token() != Token.LITERAL_ALIAS) {
                     throw new ParserException("All items between Brackets should be identifiers , got:"
                             + lexer.token());
                 }
+                */
                 identifier.append(prefix);
                 identifier.append(lexer.stringVal());
                 prefix = " ";
@@ -496,7 +498,7 @@ public class ElasticSqlExprParser extends SQLExprParser {
                 expr = methodInvokeExpr;
 
                 return primaryRest(expr);
-            } else if ("MATCH".equalsIgnoreCase(ident)) {
+            }/* else if ("MATCH".equalsIgnoreCase(ident)) {
                 lexer.nextToken();
                 MySqlMatchAgainstExpr matchAgainstExpr = new MySqlMatchAgainstExpr();
 
@@ -545,7 +547,7 @@ public class ElasticSqlExprParser extends SQLExprParser {
                 expr = matchAgainstExpr;
 
                 return primaryRest(expr);
-            } else if ("CONVERT".equalsIgnoreCase(ident)) {
+            }*/ else if ("CONVERT".equalsIgnoreCase(ident)) {
                 lexer.nextToken();
                 SQLMethodInvokeExpr methodInvokeExpr = new SQLMethodInvokeExpr(ident);
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java
@@ -39,7 +39,7 @@ public class QueryDataAnonymizer {
                     .replaceAll("[\\n][\\t]+", " ");
         } catch (Exception e) {
             LOG.warn("Caught an exception when anonymizing sensitive data");
-            resultQuery = query;
+            resultQuery = "";
         }
         return resultQuery;
     }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -148,19 +148,19 @@ public class PPLSyntaxParserTest {
 
   @Test
   public void testDescribeCommandShouldPass() {
-    ParseTree tree = new PPLSyntaxParser().analyzeSyntax("describe t");
+    ParseTree tree = new PPLSyntaxParser().parse("describe t");
     assertNotEquals(null, tree);
   }
 
   @Test
   public void testDescribeCommandWithMultipleIndicesShouldPass() {
-    ParseTree tree = new PPLSyntaxParser().analyzeSyntax("describe t,u");
+    ParseTree tree = new PPLSyntaxParser().parse("describe t,u");
     assertNotEquals(null, tree);
   }
 
   @Test
   public void testDescribeFieldsCommandShouldPass() {
-    ParseTree tree = new PPLSyntaxParser().analyzeSyntax("describe t | fields a,b");
+    ParseTree tree = new PPLSyntaxParser().parse("describe t | fields a,b");
     assertNotEquals(null, tree);
   }
 
@@ -169,7 +169,7 @@ public class PPLSyntaxParserTest {
     exceptionRule.expect(RuntimeException.class);
     exceptionRule.expectMessage("Failed to parse query due to offending symbol");
 
-    new PPLSyntaxParser().analyzeSyntax("describe source=t");
+    new PPLSyntaxParser().parse("describe source=t");
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

### Description
1. Don't print query if error occurred:
https://github.com/Bit-Quill/opensearch-project-sql/blob/d9d25ad01837427f83e27cdecaf1477582d31bef/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java#L40-L44
2. Don't validate tokens' type in `[]`, fixes processing functions with multiple fields:
https://github.com/Bit-Quill/opensearch-project-sql/blob/d9d25ad01837427f83e27cdecaf1477582d31bef/legacy/src/main/java/org/opensearch/sql/legacy/parser/ElasticSqlExprParser.java#L149-L155
3. Don't process [`MATCH ... AGAINST`](https://mariadb.com/kb/en/match-against/) clause, because it is overlayed by `MATCH` function. Fixes failure on `MATCH` function:
https://github.com/Bit-Quill/opensearch-project-sql/blob/d9d25ad01837427f83e27cdecaf1477582d31bef/legacy/src/main/java/org/opensearch/sql/legacy/parser/ElasticSqlExprParser.java#L501-L550
 
### Issues Resolved
```
[WARN ][o.o.s.l.u.QueryDataAnonymizer] [...] Caught an exception when anonymizing sensitive data
```

### TODO
- [ ] Discuss
- [ ] Confirm that we can remove support of `MATCH ... AGAINST` (Is it even supported BTW?)
- [ ] Test it - WIP
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).