### PR TITLE
Fix `fuzziness` parsing in `multi_match` function. Update tests.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/RelevanceFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/RelevanceFunctionIT.java
@@ -42,11 +42,11 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
     String query = "SOURCE=" + TEST_INDEX_BEER
         + " | WHERE multi_match(['Body', Tags], 'taste beer', operator='and', analyzer=english,"
         + "auto_generate_synonyms_phrase_query=true, boost = 0.77, cutoff_frequency=0.33,"
-        + "fuzziness = 14, fuzzy_transpositions = false, lenient = true, max_expansions = 25,"
+        + "fuzziness = 'AUTO:1,5', fuzzy_transpositions = false, lenient = true, max_expansions = 25,"
         + "minimum_should_match = '2<-25% 9<-3', prefix_length = 7, tie_breaker = 0.3,"
         + "type = most_fields, slop = 2, zero_terms_query = 'ALL') | fields Id";
     var result = executeQuery(query);
-    assertEquals(507, result.getInt("total"));
+    assertEquals(424, result.getInt("total"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MultiMatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MultiMatchIT.java
@@ -39,11 +39,11 @@ public class MultiMatchIT extends SQLIntegTestCase {
     String query = "SELECT Id FROM " + TEST_INDEX_BEER
         + " WHERE multi_match(['Body', Tags], 'taste beer', operator='and', analyzer=english,"
         + "auto_generate_synonyms_phrase_query=true, boost = 0.77, cutoff_frequency=0.33,"
-        + "fuzziness = 14, fuzzy_transpositions = false, lenient = true, max_expansions = 25,"
+        + "fuzziness = 'AUTO:1,5', fuzzy_transpositions = false, lenient = true, max_expansions = 25,"
         + "minimum_should_match = '2<-25% 9<-3', prefix_length = 7, tie_breaker = 0.3,"
         + "type = most_fields, slop = 2, zero_terms_query = 'ALL');";
     var result = new JSONObject(executeQuery(query, "jdbc"));
-    assertEquals(507, result.getInt("total"));
+    assertEquals(424, result.getInt("total"));
   }
 
   @Test

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
@@ -29,7 +29,7 @@ public class MultiMatchQuery extends RelevanceQuery<MultiMatchQueryBuilder> {
             b.autoGenerateSynonymsPhraseQuery(Boolean.parseBoolean(v.stringValue())))
         .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .put("cutoff_frequency", (b, v) -> b.cutoffFrequency(Float.parseFloat(v.stringValue())))
-        .put("fuzziness", (b, v) -> b.fuzziness(Integer.parseInt(v.stringValue())))
+        .put("fuzziness", (b, v) -> b.fuzziness(v.stringValue()))
         .put("fuzzy_transpositions", (b, v) ->
             b.fuzzyTranspositions(Boolean.parseBoolean(v.stringValue())))
         .put("lenient", (b, v) -> b.lenient(Boolean.parseBoolean(v.stringValue())))

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -506,7 +506,7 @@ class FilterQueryBuilderTest {
             + "    \"operator\" : \"AND\",\n"
             + "    \"analyzer\" : \"keyword\",\n"
             + "    \"slop\" : 1,\n"
-            + "    \"fuzziness\" : \"2\",\n"
+            + "    \"fuzziness\" : \"AUTO:2,4\",\n"
             + "    \"prefix_length\" : 1,\n"
             + "    \"max_expansions\" : 3,\n"
             + "    \"minimum_should_match\" : \"3\",\n"
@@ -527,7 +527,7 @@ class FilterQueryBuilderTest {
                 dsl.namedArgument("analyzer", literal("keyword")),
                 dsl.namedArgument("auto_generate_synonyms_phrase_query", literal("false")),
                 dsl.namedArgument("cutoff_frequency", literal("4.3")),
-                dsl.namedArgument("fuzziness", literal("2")),
+                dsl.namedArgument("fuzziness", literal("AUTO:2,4")),
                 dsl.namedArgument("fuzzy_transpositions", literal("false")),
                 dsl.namedArgument("lenient", literal("false")),
                 dsl.namedArgument("max_expansions", literal("3")),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
@@ -74,7 +74,7 @@ class MultiMatchTest {
         List.of(
             dsl.namedArgument("fields", fields_value),
             dsl.namedArgument("query", query_value),
-            dsl.namedArgument("fuzziness", DSL.literal("4"))
+            dsl.namedArgument("fuzziness", DSL.literal("AUTO:2,4"))
         ),
         List.of(
             dsl.namedArgument("fields", fields_value),

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -187,7 +187,7 @@ class SQLSyntaxParserTest {
     assertNotNull(parser.parse(
         "SELECT id FROM test WHERE"
             + " multi_match([\"Tags\" ^ 1.5, Title, `Body` 4.2], 'query', analyzer=keyword,"
-            + "operator='AND', tie_breaker=0.3, type = \"most_fields\", fuzziness = 4)"));
+            + "operator='AND', tie_breaker=0.3, type = \"most_fields\", fuzziness = \"AUTO\")"));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

### Description
Hotfix for PR #71.
Thanks @forestmvey for finding.

### Issues Resolved
Fix `fuzziness` parsing in `multi_match` query builder. Tests are updated to extend coverage.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).