### PR TITLE
Improve Error Reporting for New SQL Engine

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -64,6 +64,13 @@ public class RestSQLQueryAction extends BaseRestHandler {
    * Settings required by been initialization.
    */
   private final Settings pluginSettings;
+
+  /**
+   * Captured error message to aggregate diagnostics
+   * for both legacy and new SQL engines.
+   * This member variable and it's usage can be deleted once the
+   * legacy SQL engine is deprecated.
+   */
   private String ErrorStr;
 
   /**
@@ -90,10 +97,18 @@ public class RestSQLQueryAction extends BaseRestHandler {
     throw new UnsupportedOperationException("New SQL handler is not ready yet");
   }
 
+  /**
+   * Setter for ErrorStr member variable.
+   * @param error : String error value to set member variable.
+   */
   public void setErrorStr(String error) {
     ErrorStr = error;
   }
 
+  /**
+   * Getter for ErrorStr member variable.
+   * @return : ErrorStr member variable.
+   */
   public String getErrorStr() {
     return ErrorStr;
   }
@@ -122,6 +137,11 @@ public class RestSQLQueryAction extends BaseRestHandler {
       if (request.isExplainRequest()) {
         LOG.info("Request is falling back to old SQL engine due to: " + e.getMessage());
       }
+
+      /**
+       * Setting ErrorStr member variable is used to aggregate error messages when both legacy and new SQL engines fail.
+       * This implementation can be removed when the legacy SQL engine is deprecated.
+       */
       setErrorStr(ErrorMessageFactory.createErrorMessage(e, isClientError(e) ? BAD_REQUEST.getStatus() : SERVICE_UNAVAILABLE.getStatus()).toString());
       return NOT_SUPPORTED_YET;
     }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -253,10 +253,17 @@ public class RestSqlAction extends BaseRestHandler {
         channel.sendResponse(new BytesRestResponse(status, message));
     }
 
-    private void reportError(final RestChannel channel, final Exception e, final RestStatus status, String otherError) {
-        sendResponse(channel, ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString() + (otherError.isEmpty()
+    /**
+     * Report Error message to user.
+     * @param channel : Rest channel to sent response through.
+     * @param e : Exception caught when attempting query.
+     * @param status : Status for rest request made.
+     * @param newSqlEngineError : Error message for new SQL engine. Can be removed when old SQL engine is deprecated.
+     */
+    private void reportError(final RestChannel channel, final Exception e, final RestStatus status, String newSqlEngineError) {
+        sendResponse(channel, ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString() + (newSqlEngineError.isEmpty()
             ? "" : "\nQuery failed both legacy and new SQL engines, see error message below for new SQL engine error.\n"
-            + otherError), status);
+            + newSqlEngineError), status);
     }
 
     private boolean isSQLFeatureEnabled() {


### PR DESCRIPTION
### Description
When a query fails both legacy and new SQL engines, only the legacy engine error is reported to the user. On failure in both the legacy and new SQL engines, error messages from both should be reported to the end user.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).