### PR TITLE
Github Actions fix for reference to OpenSearch-Dashboard not existing outside of main OS sql project

### DIFF
--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Move Workbench to Plugins Dir
         run: |
-          mv workbench OpenSearch-Dashboards/plugins
+          mv workbench ../OpenSearch-Dashboards/plugins
 
       - name: OpenSearch Dashboards Plugin Bootstrap
         uses: nick-invision/retry@v1


### PR DESCRIPTION
### Description
Resolves issue with OpenSearch-Dashboards reference not working outside of main opensearch-project/sql repo for github actions. Resolution was to remove `sql/` before path in `sql-workbench-test-and-build-workflow.yml` and fix following references to OpenSearch-Dashboards.
 
### Check List
- [x] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).