### PR TITLE
RelevanceQuery refactor

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -685,8 +685,4 @@ public class DSL {
   private FunctionExpression compile(BuiltinFunctionName bfn, Expression... args) {
     return (FunctionExpression) repository.compile(bfn.getName(), Arrays.asList(args.clone()));
   }
-
-  public NamedArgumentExpression namedArgument(String name, String value) {
-    return namedArgument(name, literal(value));
-  }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -685,4 +685,8 @@ public class DSL {
   private FunctionExpression compile(BuiltinFunctionName bfn, Expression... args) {
     return (FunctionExpression) repository.compile(bfn.getName(), Arrays.asList(args.clone()));
   }
+
+  public NamedArgumentExpression namedArgument(String name, String value) {
+    return namedArgument(name, literal(value));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchBoolPrefixQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchBoolPrefixQuery.java
@@ -14,13 +14,14 @@ import org.opensearch.index.query.QueryBuilders;
  * Initializes MatchBoolPrefixQueryBuilder from a FunctionExpression.
  */
 public class MatchBoolPrefixQuery
-    extends RelevanceQuery<MatchBoolPrefixQueryBuilder> {
+    extends SingleFieldQuery<MatchBoolPrefixQueryBuilder> {
   /**
    * Constructor for MatchBoolPrefixQuery to configure RelevanceQuery
    * with support of optional parameters.
    */
   public MatchBoolPrefixQuery() {
-    super(ImmutableMap.<String, QueryBuilderStep<MatchBoolPrefixQueryBuilder>>builder()
+    super(MatchBoolPrefixQueryBuilder.NAME,
+        ImmutableMap.<String, QueryBuilderStep<MatchBoolPrefixQueryBuilder>>builder()
         .put("minimum_should_match", (b, v) -> b.minimumShouldMatch(v.stringValue()))
         .put("fuzziness", (b, v) -> b.fuzziness(v.stringValue()))
         .put("prefix_length", (b, v) -> b.prefixLength(Integer.parseInt(v.stringValue())))
@@ -41,7 +42,7 @@ public class MatchBoolPrefixQuery
    * @return  Object of executed query
    */
   @Override
-  protected MatchBoolPrefixQueryBuilder createQueryBuilder(String field, String query) {
+  protected MatchBoolPrefixQueryBuilder createBuilder(String field, String query) {
     return QueryBuilders.matchBoolPrefixQuery(field, query);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -23,13 +23,13 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
 /**
  * Lucene query that builds a match_phrase query.
  */
-public class MatchPhraseQuery extends RelevanceQuery<MatchPhraseQueryBuilder> {
+public class MatchPhraseQuery extends SingleFieldQuery<MatchPhraseQueryBuilder> {
   /**
    *  Default constructor for MatchPhraseQuery configures how RelevanceQuery.build() handles
    * named arguments.
    */
   public MatchPhraseQuery() {
-    super(ImmutableMap.<String, QueryBuilderStep<MatchPhraseQueryBuilder>>builder()
+    super(MatchPhraseQueryBuilder.NAME, ImmutableMap.<String, QueryBuilderStep<MatchPhraseQueryBuilder>>builder()
         .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("slop", (b, v) -> b.slop(Integer.parseInt(v.stringValue())))
@@ -39,7 +39,7 @@ public class MatchPhraseQuery extends RelevanceQuery<MatchPhraseQueryBuilder> {
   }
 
   @Override
-  protected MatchPhraseQueryBuilder createQueryBuilder(String field, String query) {
+  protected MatchPhraseQueryBuilder createBuilder(String field, String query) {
     return QueryBuilders.matchPhraseQuery(field, query);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilders;
@@ -14,13 +13,14 @@ import org.opensearch.index.query.QueryBuilders;
 /**
  * Initializes MatchQueryBuilder from a FunctionExpression.
  */
-public class MatchQuery extends RelevanceQuery<MatchQueryBuilder> {
+public class MatchQuery extends SingleFieldQuery<MatchQueryBuilder> {
   /**
    *  Default constructor for MatchQuery configures how RelevanceQuery.build() handles
    * named arguments.
    */
   public MatchQuery() {
-    super(ImmutableMap.<String, QueryBuilderStep<MatchQueryBuilder>>builder()
+    super(MatchQueryBuilder.NAME,
+        ImmutableMap.<String, QueryBuilderStep<MatchQueryBuilder>>builder()
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("auto_generate_synonyms_phrase_query",
             (b, v) -> b.autoGenerateSynonymsPhraseQuery(Boolean.parseBoolean(v.stringValue())))
@@ -40,7 +40,7 @@ public class MatchQuery extends RelevanceQuery<MatchQueryBuilder> {
   }
 
   @Override
-  protected MatchQueryBuilder createQueryBuilder(String field, String query) {
+  protected MatchQueryBuilder createBuilder(String field, String query) {
     return QueryBuilders.matchQuery(field, query);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQuery.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+
+/**
+ *  Base class to represent relevance queries that search multiple fields.
+ * @param <T> The builder class for the OpenSearch query.
+ */
+abstract class MultiFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T> {
+
+  public MultiFieldQuery(String queryName, Map<String, QueryBuilderStep<T>> queryBuildActions) {
+    super(queryName, queryBuildActions);
+  }
+
+  @Override
+  public T createQueryBuilder(NamedArgumentExpression fields, NamedArgumentExpression queryExpr) {
+    var fieldsAndWeights = fields
+        .getValue()
+        .valueOf(null)
+        .tupleValue()
+        .entrySet()
+        .stream()
+        .collect(ImmutableMap.toImmutableMap(e -> e.getKey(), e -> e.getValue().floatValue()));
+    var query = queryExpr.getValue().valueOf(null).stringValue();
+    return createBuilder(fieldsAndWeights, query);
+  }
+
+  abstract protected T createBuilder(ImmutableMap<String, Float> fields, String query);
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQuery.java
@@ -33,5 +33,5 @@ abstract class MultiFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T>
     return createBuilder(fieldsAndWeights, query);
   }
 
-  abstract protected T createBuilder(ImmutableMap<String, Float> fields, String query);
+  protected abstract  T createBuilder(ImmutableMap<String, Float> fields, String query);
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
@@ -6,8 +6,6 @@
 package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Iterator;
-import java.util.Objects;
 import org.opensearch.index.query.MultiMatchQueryBuilder;
 import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilders;
@@ -42,7 +40,7 @@ public class MultiMatchQuery extends MultiFieldQuery<MultiMatchQueryBuilder> {
   }
 
   @Override
-  protected MultiMatchQueryBuilder createBuilder(ImmutableMap fields, String query) {
+  protected MultiMatchQueryBuilder createBuilder(ImmutableMap<String, Float> fields, String query) {
     return QueryBuilders.multiMatchQuery(query).fields(fields);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
@@ -10,20 +10,16 @@ import java.util.Iterator;
 import java.util.Objects;
 import org.opensearch.index.query.MultiMatchQueryBuilder;
 import org.opensearch.index.query.Operator;
-import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.sql.exception.SemanticCheckException;
-import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.NamedArgumentExpression;
 
-public class MultiMatchQuery extends RelevanceQuery<MultiMatchQueryBuilder> {
+public class MultiMatchQuery extends MultiFieldQuery<MultiMatchQueryBuilder> {
   /**
    *  Default constructor for MultiMatch configures how RelevanceQuery.build() handles
    * named arguments.
    */
   public MultiMatchQuery() {
-    super(ImmutableMap.<String, QueryBuilderStep<MultiMatchQueryBuilder>>builder()
+    super(MultiMatchQueryBuilder.NAME,
+        ImmutableMap.<String, QueryBuilderStep<MultiMatchQueryBuilder>>builder()
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("auto_generate_synonyms_phrase_query", (b, v) ->
             b.autoGenerateSynonymsPhraseQuery(Boolean.parseBoolean(v.stringValue())))
@@ -46,42 +42,7 @@ public class MultiMatchQuery extends RelevanceQuery<MultiMatchQueryBuilder> {
   }
 
   @Override
-  public QueryBuilder build(FunctionExpression func) {
-    if (func.getArguments().size() < 2) {
-      throw new SemanticCheckException("'multi_match' must have at least two arguments");
-    }
-    Iterator<Expression> iterator = func.getArguments().iterator();
-    var fields = (NamedArgumentExpression) iterator.next();
-    var query = (NamedArgumentExpression) iterator.next();
-    // Fields is a map already, but we need to convert types.
-    var fieldsAndWeights = fields
-        .getValue()
-        .valueOf(null)
-        .tupleValue()
-        .entrySet()
-        .stream()
-        .collect(ImmutableMap.toImmutableMap(e -> e.getKey(), e -> e.getValue().floatValue()));
-
-    MultiMatchQueryBuilder queryBuilder = createQueryBuilder(null,
-            query.getValue().valueOf(null).stringValue())
-        .fields(fieldsAndWeights);
-    while (iterator.hasNext()) {
-      NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
-      if (!queryBuildActions.containsKey(arg.getArgName())) {
-        throw new SemanticCheckException(
-            String.format("Parameter %s is invalid for %s function.",
-                arg.getArgName(), queryBuilder.getWriteableName()));
-      }
-      (Objects.requireNonNull(
-          queryBuildActions
-              .get(arg.getArgName())))
-          .apply(queryBuilder, arg.getValue().valueOf(null));
-    }
-    return queryBuilder;
-  }
-
-  @Override
-  protected MultiMatchQueryBuilder createQueryBuilder(String field, String query) {
-    return QueryBuilders.multiMatchQuery(query);
+  protected MultiMatchQueryBuilder createBuilder(ImmutableMap fields, String query) {
+    return QueryBuilders.multiMatchQuery(query).fields(fields);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
@@ -55,14 +55,16 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
     return queryBuilder;
   }
 
-  abstract protected T createQueryBuilder(NamedArgumentExpression field, NamedArgumentExpression query);
+  protected abstract T createQueryBuilder(NamedArgumentExpression field,
+                                          NamedArgumentExpression query);
+
   /**
    * Convenience interface for a function that updates a QueryBuilder
    * based on ExprValue.
+   *
    * @param <T> Concrete query builder
    */
-  public interface QueryBuilderStep<T extends QueryBuilder> extends
+  protected interface QueryBuilderStep<T extends QueryBuilder> extends
       BiFunction<T, ExprValue, T> {
-
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryStringQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryStringQuery.java
@@ -10,22 +10,18 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Objects;
 import org.opensearch.index.query.Operator;
-import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.SimpleQueryStringBuilder;
 import org.opensearch.index.query.SimpleQueryStringFlag;
-import org.opensearch.sql.exception.SemanticCheckException;
-import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.NamedArgumentExpression;
 
-public class SimpleQueryStringQuery extends RelevanceQuery<SimpleQueryStringBuilder> {
+public class SimpleQueryStringQuery extends MultiFieldQuery<SimpleQueryStringBuilder> {
   /**
    *  Default constructor for SimpleQueryString configures how RelevanceQuery.build() handles
    * named arguments.
    */
   public SimpleQueryStringQuery() {
-    super(ImmutableMap.<String, QueryBuilderStep<SimpleQueryStringBuilder>>builder()
+    super(SimpleQueryStringBuilder.NAME,
+        ImmutableMap.<String, QueryBuilderStep<SimpleQueryStringBuilder>>builder()
         .put("analyze_wildcard", (b, v) -> b.analyzeWildcard(Boolean.parseBoolean(v.stringValue())))
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("auto_generate_synonyms_phrase_query", (b, v) ->
@@ -48,42 +44,8 @@ public class SimpleQueryStringQuery extends RelevanceQuery<SimpleQueryStringBuil
   }
 
   @Override
-  public QueryBuilder build(FunctionExpression func) {
-    if (func.getArguments().size() < 2) {
-      throw new SemanticCheckException("'simple_query_string' must have at least two arguments");
-    }
-    Iterator<Expression> iterator = func.getArguments().iterator();
-    var fields = (NamedArgumentExpression) iterator.next();
-    var query = (NamedArgumentExpression) iterator.next();
-    // Fields is a map already, but we need to convert types.
-    var fieldsAndWeights = fields
-        .getValue()
-        .valueOf(null)
-        .tupleValue()
-        .entrySet()
-        .stream()
-        .collect(ImmutableMap.toImmutableMap(e -> e.getKey(), e -> e.getValue().floatValue()));
-
-    SimpleQueryStringBuilder queryBuilder = createQueryBuilder(null,
-            query.getValue().valueOf(null).stringValue())
-        .fields(fieldsAndWeights);
-    while (iterator.hasNext()) {
-      NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
-      if (!queryBuildActions.containsKey(arg.getArgName())) {
-        throw new SemanticCheckException(
-            String.format("Parameter %s is invalid for %s function.",
-                arg.getArgName(), queryBuilder.getWriteableName()));
-      }
-      (Objects.requireNonNull(
-          queryBuildActions
-              .get(arg.getArgName())))
-          .apply(queryBuilder, arg.getValue().valueOf(null));
-    }
-    return queryBuilder;
-  }
-
-  @Override
-  protected SimpleQueryStringBuilder createQueryBuilder(String field, String query) {
-    return QueryBuilders.simpleQueryStringQuery(query);
+  protected SimpleQueryStringBuilder createBuilder(ImmutableMap<String, Float> fields,
+                                                   String query) {
+    return QueryBuilders.simpleQueryStringQuery(query).fields(fields);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
@@ -10,7 +10,9 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.sql.expression.NamedArgumentExpression;
 
 /**
- * Base class to represent relevance queries that search a single field only.
+ * Base class to represent builder class for relevance queries like match_query, match_bool_prefix,
+ * and match_phrase that search in a single field only.
+ *
  * @param <T> The builder class for the OpenSearch query class.
  */
 abstract class SingleFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T> {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import java.util.Map;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+
+/**
+ * Base class to represent relevance queries that search a single field only.
+ * @param <T> The builder class for the OpenSearch query class.
+ */
+abstract class SingleFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T> {
+  public SingleFieldQuery(String queryName, Map<String, QueryBuilderStep<T>> queryBuildActions) {
+    super(queryName, queryBuildActions);
+  }
+
+  @Override
+  protected T createQueryBuilder(NamedArgumentExpression fields, NamedArgumentExpression query) {
+    return createBuilder(
+        fields.getValue().valueOf(null).stringValue(),
+        query.getValue().valueOf(null).stringValue());
+  }
+
+  protected abstract T createBuilder(String field, String query);
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchBoolPrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchBoolPrefixQueryTest.java
@@ -61,8 +61,8 @@ public class MatchBoolPrefixQueryTest {
   @Test
   public void test_valid_when_two_arguments() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"));
+        dsl.namedArgument("field", "field_value"),
+        dsl.namedArgument("query", "query_value"));
     Assertions.assertNotNull(matchBoolPrefixQuery.build(new MatchExpression(arguments)));
   }
 
@@ -75,7 +75,7 @@ public class MatchBoolPrefixQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
-    List<Expression> arguments = List.of(namedArgument("field", "field_value"));
+    List<Expression> arguments = List.of(dsl.namedArgument("field", "field_value"));
     assertThrows(SyntaxCheckException.class,
         () -> matchBoolPrefixQuery.build(new MatchExpression(arguments)));
   }
@@ -83,15 +83,11 @@ public class MatchBoolPrefixQueryTest {
   @Test
   public void test_SemanticCheckException_when_invalid_argument() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
-        namedArgument("query", "query_value"),
-        namedArgument("unsupported", "unsupported_value"));
+        dsl.namedArgument("field", "field_value"),
+        dsl.namedArgument("query", "query_value"),
+        dsl.namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,
         () -> matchBoolPrefixQuery.build(new MatchExpression(arguments)));
-  }
-
-  private NamedArgumentExpression namedArgument(String name, String value) {
-    return dsl.namedArgument(name, DSL.literal(value));
   }
 
   private class MatchExpression extends FunctionExpression {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
@@ -20,7 +20,6 @@ import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.NamedArgumentExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
@@ -33,10 +32,6 @@ public class MatchPhraseQueryTest {
   private final MatchPhraseQuery matchPhraseQuery = new MatchPhraseQuery();
   private final FunctionName matchPhrase = FunctionName.of("match_phrase");
 
-  private NamedArgumentExpression namedArgument(String name, String value) {
-    return dsl.namedArgument(name, DSL.literal(value));
-  }
-
   @Test
   public void test_SyntaxCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
@@ -46,7 +41,7 @@ public class MatchPhraseQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
-    List<Expression> arguments = List.of(namedArgument("field", "test"));
+    List<Expression> arguments = List.of(dsl.namedArgument("field", "test"));
     assertThrows(SyntaxCheckException.class,
         () -> matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -54,9 +49,9 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_SyntaxCheckException_when_invalid_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "test"),
-        namedArgument("query", "test2"),
-        namedArgument("unsupported", "3"));
+        dsl.namedArgument("field", "test"),
+        dsl.namedArgument("query", "test2"),
+        dsl.namedArgument("unsupported", "3"));
     Assertions.assertThrows(SemanticCheckException.class,
         () -> matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -64,9 +59,9 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_analyzer_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("analyzer", "standard")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("analyzer", "standard")
     );
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -74,17 +69,17 @@ public class MatchPhraseQueryTest {
   @Test
   public void build_succeeds_with_two_arguments() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "test"),
-        namedArgument("query", "test2"));
+        dsl.namedArgument("field", "test"),
+        dsl.namedArgument("query", "test2"));
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
 
   @Test
   public void test_slop_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("slop", "2")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("slop", "2")
     );
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -92,9 +87,9 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "t1"),
-        namedArgument("query", "t2"),
-        namedArgument("zero_terms_query", "ALL")
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("zero_terms_query", "ALL")
     );
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
@@ -132,16 +133,16 @@ class MultiMatchTest {
   }
 
   @Test
-  public void test_SemanticCheckException_when_no_arguments() {
+  public void test_SyntaxCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
-    assertThrows(SemanticCheckException.class,
+    assertThrows(SyntaxCheckException.class,
         () -> multiMatchQuery.build(new MultiMatchExpression(arguments)));
   }
 
   @Test
-  public void test_SemanticCheckException_when_one_argument() {
+  public void test_SyntaxCheckException_when_one_argument() {
     List<Expression> arguments = List.of(namedArgument("fields", fields_value));
-    assertThrows(SemanticCheckException.class,
+    assertThrows(SyntaxCheckException.class,
         () -> multiMatchQuery.build(new MultiMatchExpression(arguments)));
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
@@ -151,13 +151,9 @@ class MultiMatchTest {
     List<Expression> arguments = List.of(
         namedArgument("fields", fields_value),
         namedArgument("query", query_value),
-        namedArgument("unsupported", "unsupported_value"));
+        dsl.namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,
         () -> multiMatchQuery.build(new MultiMatchExpression(arguments)));
-  }
-
-  private NamedArgumentExpression namedArgument(String name, String value) {
-    return dsl.namedArgument(name, DSL.literal(value));
   }
 
   private NamedArgumentExpression namedArgument(String name, LiteralExpression value) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/SimpleQueryStringTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/SimpleQueryStringTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
@@ -132,16 +133,16 @@ class SimpleQueryStringTest {
   }
 
   @Test
-  public void test_SemanticCheckException_when_no_arguments() {
+  public void test_SyntaxCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
-    assertThrows(SemanticCheckException.class,
+    assertThrows(SyntaxCheckException.class,
         () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments)));
   }
 
   @Test
-  public void test_SemanticCheckException_when_one_argument() {
+  public void test_SyntaxCheckException_when_one_argument() {
     List<Expression> arguments = List.of(namedArgument("fields", fields_value));
-    assertThrows(SemanticCheckException.class,
+    assertThrows(SyntaxCheckException.class,
         () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments)));
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQueryTest.java
@@ -1,0 +1,57 @@
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+
+class MultiFieldQueryTest {
+  MultiFieldQuery query;
+  private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+  private final String testQueryName = "test_query";
+  private final Map<String, RelevanceQuery.QueryBuilderStep> actionMap
+      = ImmutableMap.of("paramA", (o, v) -> o);
+
+  @BeforeEach
+  public void setUp() {
+    query = mock(MultiFieldQuery.class,
+        Mockito.withSettings().useConstructor(testQueryName, actionMap)
+            .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+  }
+
+  @Test
+  void createQueryBuilderTest() {
+    String sampleQuery = "sample query";
+    String sampleField = "fieldA";
+    float sampleValue = 34f;
+
+    var fieldSpec = ImmutableMap.<String, ExprValue>builder().put(sampleField,
+        ExprValueUtils.floatValue(sampleValue)).build();
+
+    query.createQueryBuilder(dsl.namedArgument("fields",
+        new LiteralExpression(ExprTupleValue.fromExprValueMap(fieldSpec))),
+        dsl.namedArgument("query",
+            new LiteralExpression(ExprValueUtils.stringValue(sampleQuery)) ));
+
+    verify(query).createBuilder(argThat(
+            (ArgumentMatcher<ImmutableMap<String, Float>>) map -> map.size() == 1
+                && map.containsKey(sampleField) && map.containsValue(sampleValue)),
+        eq(sampleQuery));
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQueryBuildTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQueryBuildTest.java
@@ -49,7 +49,7 @@ class RelevanceQueryBuildTest {
 
   @BeforeEach
   public void setUp() {
-    query = mock(RelevanceQuery.class, withSettings().useConstructor(
+    query = mock(RelevanceQuery.class, withSettings().useConstructor("mock_query",
             ImmutableMap.<String, RelevanceQuery.QueryBuilderStep<QueryBuilder>>builder()
                 .put("boost", (k, v) -> k.boost(Float.parseFloat(v.stringValue()))).build())
         .defaultAnswer(Mockito.CALLS_REAL_METHODS));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQueryBuildTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQueryBuildTest.java
@@ -60,12 +60,6 @@ class RelevanceQueryBuildTest {
   }
 
   @Test
-  void first_arg_field_second_arg_query_test() {
-    query.build(createCall(List.of(FIELD_ARG, QUERY_ARG)));
-    verify(query, times(1)).createQueryBuilder("field_A", "find me");
-  }
-
-  @Test
   void throws_SemanticCheckException_when_wrong_argument_name() {
     FunctionExpression expr =
         createCall(List.of(FIELD_ARG, QUERY_ARG, namedArgument("wrongArg", "value")));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQueryTest.java
@@ -1,0 +1,44 @@
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+
+class SingleFieldQueryTest {
+  SingleFieldQuery query;
+  private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+  private final String testQueryName = "test_query";
+  private final Map<String, RelevanceQuery.QueryBuilderStep> actionMap
+      = ImmutableMap.of("paramA", (o, v) -> o);
+
+  @BeforeEach
+  void setUp() {
+    query = mock(SingleFieldQuery.class,
+        Mockito.withSettings().useConstructor(testQueryName, actionMap)
+        .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+  }
+
+  @Test
+  void createQueryBuilderTest() {
+    String sampleQuery = "sample query";
+    String sampleField = "fieldA";
+
+    query.createQueryBuilder(dsl.namedArgument("field",
+            new LiteralExpression(ExprValueUtils.stringValue(sampleField))),
+        dsl.namedArgument("query",
+            new LiteralExpression(ExprValueUtils.stringValue(sampleQuery)) ));
+
+    verify(query).createBuilder(eq(sampleField),
+        eq(sampleQuery));
+  }
+}


### PR DESCRIPTION
### Description
This PR removes duplicate code in MultiMatchQuery and SimpleQueryStringQuery by adding distinct base classes for single-field and multi-field query classes..
 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).