### PR TITLE
Add Optional Arguments for Highlight

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -348,7 +348,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
 
     HighlightFunction unresolved = (HighlightFunction) ((Alias)node.getExpression()).getDelegated();
     Expression field = expressionAnalyzer.analyze(unresolved.getHighlightField(), context);
-    return new LogicalHighlight(child, field);
+    return new LogicalHighlight(child, field, node.getArguments(), node.getName());
   }
 
 

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -193,10 +193,9 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
 
   @Override
   public Expression visitHighlightFunction(HighlightFunction node, AnalysisContext context) {
-    Expression expr = node.getHighlightField().accept(this, context);
-    String highlightStr = "highlight(" + StringUtils.unquoteText(expr.toString()) + ")";
-    return new ReferenceExpression(highlightStr, expr.toString().contains("*")
-        ? ExprCoreType.STRUCT : ExprCoreType.ARRAY);
+    return (node.getName() != null) ? new ReferenceExpression(node.getName(),
+        node.getName().contains("*") ? ExprCoreType.STRUCT : ExprCoreType.ARRAY)
+        : null;
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/analysis/HighlightAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/HighlightAnalyzer.java
@@ -30,12 +30,15 @@ public class HighlightAnalyzer extends AbstractNodeVisitor<LogicalPlan, Analysis
 
   @Override
   public LogicalPlan visitAlias(Alias node, AnalysisContext context) {
-    if (!(node.getDelegated() instanceof HighlightFunction)) {
+    UnresolvedExpression delegated = node.getDelegated();
+    if (!(delegated instanceof HighlightFunction)) {
       return null;
     }
 
-    HighlightFunction unresolved = (HighlightFunction) node.getDelegated();
+    // Must set name here else operator cannot resolve delegated reference
+    ((HighlightFunction) delegated).setName(node.getName());
+    HighlightFunction unresolved = (HighlightFunction) delegated;
     Expression field = expressionAnalyzer.analyze(unresolved.getHighlightField(), context);
-    return new LogicalHighlight(child, field);
+    return new LogicalHighlight(child, field, unresolved.getArguments(), unresolved.getName());
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -262,8 +262,9 @@ public class AstDSL {
     return new When(condition, result);
   }
 
-  public UnresolvedExpression highlight(UnresolvedExpression fieldName) {
-    return new HighlightFunction(fieldName);
+  public UnresolvedExpression highlight(UnresolvedExpression fieldName,
+      java.util.Map<String, Literal> arguments) {
+    return new HighlightFunction(fieldName, arguments);
   }
 
   public UnresolvedExpression window(UnresolvedExpression function,

--- a/core/src/main/java/org/opensearch/sql/ast/expression/HighlightFunction.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/HighlightFunction.java
@@ -6,21 +6,29 @@
 package org.opensearch.sql.ast.expression;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 /**
  * Expression node of Highlight function.
  */
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 @Getter
 @ToString
 public class HighlightFunction extends UnresolvedExpression {
   private final UnresolvedExpression highlightField;
+  private final Map<String, Literal> arguments;
+  @Setter
+  private String name;
+
+  public HighlightFunction(UnresolvedExpression highlightField, Map<String, Literal> arguments) {
+    this.highlightField = highlightField;
+    this.arguments = arguments;
+  }
 
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Highlight.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Highlight.java
@@ -7,12 +7,14 @@ package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 /**
@@ -25,6 +27,8 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 @RequiredArgsConstructor
 public class Highlight extends UnresolvedPlan {
   private final UnresolvedExpression expression;
+  private final Map<String, Literal> arguments;
+  private final String name;
   private UnresolvedPlan child;
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalHighlight.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalHighlight.java
@@ -6,9 +6,11 @@
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.expression.Expression;
 
 @EqualsAndHashCode(callSuper = true)
@@ -16,10 +18,18 @@ import org.opensearch.sql.expression.Expression;
 @ToString
 public class LogicalHighlight extends LogicalPlan {
   private final Expression highlightField;
+  private final Map<String, Literal> arguments;
+  private final String name;
 
-  public LogicalHighlight(LogicalPlan childPlan, Expression field) {
+  /**
+   * Constructor of LogicalHighlight.
+   */
+  public LogicalHighlight(LogicalPlan childPlan, Expression highlightField,
+      Map<String, Literal> arguments, String name) {
     super(Collections.singletonList(childPlan));
-    highlightField = field;
+    this.highlightField = highlightField;
+    this.arguments = arguments;
+    this.name = name;
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanDSL.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanDSL.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.expression.Expression;
@@ -61,8 +62,9 @@ public class LogicalPlanDSL {
     return new LogicalWindow(input, windowFunction, windowDefinition);
   }
 
-  public LogicalPlan highlight(LogicalPlan input, Expression field) {
-    return new LogicalHighlight(input, field);
+  public LogicalPlan highlight(LogicalPlan input, Expression field,
+      Map<String, Literal> arguments, String name) {
+    return new LogicalHighlight(input, field, arguments, name);
   }
 
   public static LogicalPlan remove(LogicalPlan input, ReferenceExpression... fields) {

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -197,32 +197,41 @@ class AnalyzerTest extends AnalyzerTestBase {
 
   @Test
   public void project_highlight() {
+    Map<String, Literal> args = new HashMap<>();
+    args.put("pre_tags", new Literal("<mark>", DataType.STRING));
+    args.put("post_tags", new Literal("</mark>", DataType.STRING));
+
     assertAnalyzeEqual(
         LogicalPlanDSL.project(
             LogicalPlanDSL.highlight(LogicalPlanDSL.relation("schema"),
-                DSL.literal("fieldA")),
-            DSL.named("highlight(fieldA)", DSL.ref("highlight(fieldA)", ARRAY))
+                DSL.literal("fieldA"), args,
+                "highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')"),
+            DSL.named("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')",
+                DSL.ref("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')", ARRAY))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("highlight(fieldA)", new HighlightFunction(AstDSL.stringLiteral("fieldA")))
+            AstDSL.alias("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')",
+                new HighlightFunction(AstDSL.stringLiteral("fieldA"), args))
         )
     );
   }
 
   @Test
   public void project_highlight_wildcard() {
+    Map<String, Literal> args = new HashMap<>();
     assertAnalyzeEqual(
         LogicalPlanDSL.project(
             LogicalPlanDSL.highlight(LogicalPlanDSL.relation("schema"),
-                DSL.literal("*")),
+                DSL.literal("*"), args, "highlight(*)"),
             DSL.named("highlight(*)", DSL.ref("highlight(*)", STRUCT))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("highlight(*)", new HighlightFunction(AstDSL.stringLiteral("*")))
+            AstDSL.alias("highlight(*)",
+                new HighlightFunction(AstDSL.stringLiteral("*"), args))
         )
     );
   }

--- a/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
@@ -8,15 +8,14 @@ package org.opensearch.sql.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.HighlightFunction;
-import org.opensearch.sql.ast.expression.QualifiedName;
-import org.opensearch.sql.expression.DSL;
-import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.springframework.context.annotation.Configuration;
@@ -40,8 +39,25 @@ class NamedExpressionAnalyzerTest extends AnalyzerTestBase {
 
   @Test
   void visit_highlight() {
+    Map<String, Literal> args = new HashMap<>();
+    HighlightFunction highlightFunction = new HighlightFunction(
+        AstDSL.stringLiteral("fieldA"), args);
+    highlightFunction.setName("highlight(fieldA)");
     Alias alias = AstDSL.alias("highlight(fieldA)",
-        new HighlightFunction(AstDSL.stringLiteral("fieldA")));
+        highlightFunction);
+    NamedExpressionAnalyzer analyzer =
+        new NamedExpressionAnalyzer(expressionAnalyzer);
+
+    NamedExpression analyze = analyzer.analyze(alias, analysisContext);
+    assertEquals("highlight(fieldA)", analyze.getNameOrAlias());
+  }
+
+  @Test
+  void visit_highlight_no_set_name() {
+    Map<String, Literal> args = new HashMap<>();
+    Alias alias = AstDSL.alias("highlight(fieldA)",
+        new HighlightFunction(
+            AstDSL.stringLiteral("fieldA"), args));
     NamedExpressionAnalyzer analyzer =
         new NamedExpressionAnalyzer(expressionAnalyzer);
 

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalHighlightTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalHighlightTest.java
@@ -10,10 +10,13 @@ import static org.opensearch.sql.ast.dsl.AstDSL.highlight;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.analysis.AnalyzerTestBase;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.Highlight;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.config.ExpressionConfig;
@@ -28,13 +31,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class LogicalHighlightTest extends AnalyzerTestBase {
   @Test
   public void analyze_highlight_with_one_field() {
+    Map<String, Literal> args = new HashMap<>();
     assertAnalyzeEqual(
         LogicalPlanDSL.highlight(
             LogicalPlanDSL.relation("schema"),
-            DSL.literal("field")),
+            DSL.literal("field"), args, "highlight(field)"),
         new Highlight(
             alias("highlight('field')",
-                highlight(stringLiteral("field"))))
+                highlight(stringLiteral("field"), args)),
+            args, "highlight(field)")
             .attach(relation("schema")));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.expression.DSL.named;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
@@ -114,8 +115,9 @@ class LogicalPlanNodeVisitorTest {
     assertNull(rareTopN.accept(new LogicalPlanNodeVisitor<Integer, Object>() {
     }, null));
 
+    Map<String, Literal> args = new HashMap<>();
     LogicalPlan highlight = new LogicalHighlight(filter,
-        new LiteralExpression(ExprValueUtils.stringValue("fieldA")));
+        new LiteralExpression(ExprValueUtils.stringValue("fieldA")), args, "highlight(fieldA)");
     assertNull(highlight.accept(new LogicalPlanNodeVisitor<Integer, Object>() {
     }, null));
 

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanNodeVisitorTest.java
@@ -17,11 +17,14 @@ import static org.opensearch.sql.expression.DSL.named;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.expression.DSL;
@@ -134,7 +137,9 @@ class PhysicalPlanNodeVisitorTest extends PhysicalPlanTestBase {
     assertNull(limit.accept(new PhysicalPlanNodeVisitor<Integer, Object>() {
     }, null));
 
-    PhysicalPlan highlight = new HighlightOperator(plan, DSL.ref("reference", STRING));
+    Map<String, Literal> args = new HashMap<>();
+    PhysicalPlan highlight = new HighlightOperator(plan, DSL.ref("reference", STRING),
+        args, "highlight(reference)");
     assertNull(highlight.accept(new PhysicalPlanNodeVisitor<Integer, Object>() {
     }, null));
   }

--- a/docs/user/ppl/functions/relevance.rst
+++ b/docs/user/ppl/functions/relevance.rst
@@ -369,10 +369,10 @@ Please refer to examples below:
 
 Example searching for field Tags::
 
-    os> source=books | where query_string(['title'], 'Pooh House') | highlight(title);
+    os> source=books | where query_string(['title'], 'Pooh House') | highlight title;
     fetched rows / total rows = 2/2
     +------+--------------------------+----------------------+----------------------------------------------+
-    | id   | title                    | author               | highlight(title)                             |
+    | id   | title                    | author               | highlight title                             |
     |------+--------------------------+----------------------+----------------------------------------------|
     | 1    | The House at Pooh Corner | Alan Alexander Milne | [The <em>House</em> at <em>Pooh</em> Corner] |
     | 2    | Winnie-the-Pooh          | Alan Alexander Milne | [Winnie-the-<em>Pooh</em>]                   |

--- a/integ-test/src/test/java/org/opensearch/sql/sql/HighlightFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/HighlightFunctionIT.java
@@ -5,13 +5,17 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestsConstants;
+import java.util.List;
 
 public class HighlightFunctionIT extends SQLIntegTestCase {
 
@@ -27,6 +31,40 @@ public class HighlightFunctionIT extends SQLIntegTestCase {
     verifySchema(response, schema("Tags", null, "text"),
         schema("highlight('Tags')", null, "nested"));
     assertEquals(1, response.getInt("total"));
+  }
+
+  @Test
+  public void highlight_optional_arguments_test() {
+    String query = "SELECT highlight('Tags', pre_tags='<mark>', post_tags='</mark>') " +
+        "FROM %s WHERE match(Tags, 'yeast') LIMIT 1";
+    JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
+    verifySchema(response, schema("highlight('Tags', pre_tags='<mark>', post_tags='</mark>')",
+            null, "nested"));
+
+    assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response,
+        rows(new JSONArray(List.of("alcohol-level <mark>yeast</mark> home-brew champagne"))));
+  }
+
+  @Test
+  public void highlight_multiple_optional_arguments_test() {
+    String query = "SELECT highlight(Title), highlight(Body, pre_tags='<mark style=\\\"background-color: " +
+        "green;\\\">', post_tags='</mark>') FROM %s WHERE multi_match([Title, Body], 'IPA') LIMIT 1";
+    JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
+
+    verifySchema(response, schema("highlight(Title)", null, "nested"),
+        schema("highlight(Body, pre_tags='<mark style=\"background-color: green;\">', " +
+                "post_tags='</mark>')", null, "nested"));
+
+    assertEquals(1, response.getInt("total"));
+
+    assertEquals("What are the differences between an <em>IPA</em> and its variants?",
+        response.getJSONArray("datarows").getJSONArray(0).getJSONArray(0).getString(0));
+
+    assertEquals("<p>I know what makes an <mark style=\"background-color: green;\">IPA</mark> an <mark style=" +
+        "\"background-color: green;\">IPA</mark>, but what are the unique characteristics of it's common variants?",
+        response.getJSONArray("datarows").getJSONArray(0).getJSONArray(1).getString(0));
   }
 
   @Test

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtector.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtector.java
@@ -156,7 +156,9 @@ public class OpenSearchExecutionProtector extends ExecutionProtector {
     HighlightOperator hlOperator = (HighlightOperator) node;
     return doProtect(
         new HighlightOperator(visitInput(hlOperator.getInput(), context),
-            ((HighlightOperator) node).getHighlight())
+            ((HighlightOperator) node).getHighlight(),
+            ((HighlightOperator) node).getArguments(),
+            ((HighlightOperator) node).getName())
     );
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -209,8 +209,9 @@ public class OpenSearchIndex implements Table {
     @Override
     public PhysicalPlan visitHighlight(LogicalHighlight node, OpenSearchIndexScan context) {
       context.getRequestBuilder().pushDownHighlight(
-          StringUtils.unquoteText(node.getHighlightField().toString()));
-      return new HighlightOperator(visitChild(node, context), node.getHighlightField());
+          StringUtils.unquoteText(node.getHighlightField().toString()), node.getArguments());
+      return new HighlightOperator(visitChild(node, context), node.getHighlightField(),
+          node.getArguments(), node.getName());
     }
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -296,10 +296,13 @@ class OpenSearchExecutionProtectorTest {
 
   @Test
   public void testVisitHighlight() {
+    Map<String, Literal> args = new HashMap<>();
     HighlightOperator hlOperator =
         new HighlightOperator(
             values(emptyList()),
-            DSL.ref("reference", STRING));
+            DSL.ref("reference", STRING),
+            args,
+            "highlight(reference)");
 
     assertEquals(executionProtector.doProtect(hlOperator),
         executionProtector.visitHighlight(hlOperator, null));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
@@ -7,8 +7,11 @@
 package org.opensearch.sql.opensearch.request;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +19,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 
 @ExtendWith(MockitoExtension.class)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchDefaultImplementorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchDefaultImplementorTest.java
@@ -13,12 +13,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.sql.planner.logical.LogicalPlanDSL.relation;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAD;
@@ -83,6 +87,6 @@ public class OpenSearchDefaultImplementorTest {
         new OpenSearchIndex.OpenSearchDefaultImplementor(indexScan, client);
 
     implementor.visitHighlight(node, indexScan);
-    verify(requestBuilder).pushDownHighlight(any());
+    verify(requestBuilder).pushDownHighlight(any(), any());
   }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -312,6 +312,8 @@ TIE_BREAKER:                        'TIE_BREAKER';
 TYPE:                               'TYPE';
 ZERO_TERMS_QUERY:                   'ZERO_TERMS_QUERY';
 HIGHLIGHT:                          'HIGHLIGHT';
+HIGHLIGHT_PRE_TAGS:                 'PRE_TAGS';
+HIGHLIGHT_POST_TAGS:                'POST_TAGS';
 
 // SPAN KEYWORDS
 SPAN:                               'SPAN';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -290,7 +290,7 @@ evalFunctionCall
     ;
 
 highlightFunction
-    : HIGHLIGHT LT_PRTHS field=relevanceField  RT_PRTHS            #highlightFunctionCall
+    : HIGHLIGHT relevanceField (COMMA highlightArg)*        #highlightFunctionCall
     ;
 
 /** cast function */
@@ -335,6 +335,10 @@ relevanceArg
     : relevanceArgName EQUAL relevanceArgValue
     ;
 
+highlightArg
+    : highlightArgName EQUAL highlightArgValue
+    ;
+
 relevanceArgName
     : ALLOW_LEADING_WILDCARD | ANALYZER | ANALYZE_WILDCARD | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
     | BOOST | CUTOFF_FREQUENCY | DEFAULT_FIELD | DEFAULT_OPERATOR | ENABLE_POSITION_INCREMENTS
@@ -343,6 +347,11 @@ relevanceArgName
     | MAX_EXPANSIONS | MINIMUM_SHOULD_MATCH | OPERATOR | PHRASE_SLOP | PREFIX_LENGTH
     | QUOTE_ANALYZER | QUOTE_FIELD_SUFFIX | REWRITE | SLOP | TIE_BREAKER | TIME_ZONE | TYPE
     | ZERO_TERMS_QUERY
+    ;
+
+
+highlightArgName
+    : HIGHLIGHT_POST_TAGS| HIGHLIGHT_PRE_TAGS
     ;
 
 relevanceFieldAndWeight
@@ -368,6 +377,10 @@ relevanceQuery
 relevanceArgValue
     : qualifiedName
     | literalValue
+    ;
+
+highlightArgValue
+    : stringLiteral
     ;
 
 mathematicalFunctionBase

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -37,7 +37,9 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
@@ -133,8 +135,11 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
    */
   @Override
   public UnresolvedPlan visitHighlightCommand(OpenSearchPPLParser.HighlightCommandContext ctx) {
-    return new Highlight(new Alias(StringUtils.unquoteText(getTextInQuery(ctx)),
-        internalVisitExpression(ctx.highlightFunction().getRuleContext())));
+    Alias highlightFunction = new Alias(StringUtils.unquoteText(getTextInQuery(ctx)),
+        internalVisitExpression(ctx.highlightFunction().getRuleContext()));
+    return new Highlight(highlightFunction,
+        ((HighlightFunction) highlightFunction.getDelegated()).getArguments(),
+        highlightFunction.getName());
   }
 
   /**

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
@@ -208,7 +209,14 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitHighlightFunctionCall(
       OpenSearchPPLParser.HighlightFunctionCallContext ctx) {
-    return new HighlightFunction(AstDSL.stringLiteral(ctx.relevanceField().getText()));
+    ImmutableMap.Builder<String, Literal> builder = ImmutableMap.builder();
+    ctx.highlightArg().forEach(v -> builder.put(
+            v.highlightArgName().getText().toLowerCase(),
+            new Literal(StringUtils.unquoteText(v.highlightArgValue().getText()),
+                DataType.STRING))
+    );
+    return new HighlightFunction(AstDSL.stringLiteral(
+        StringUtils.unquoteText(ctx.relevanceField().getText())), builder.build());
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -82,7 +82,7 @@ public class PPLSyntaxParserTest {
 
   @Test
   public void testHighlightShouldPass() {
-    ParseTree tree = new PPLSyntaxParser().parse("source=shakespeare | highlight(text_entry)");
+    ParseTree tree = new PPLSyntaxParser().parse("source=shakespeare | highlight field");
     assertNotEquals(null, tree);
   }
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -43,12 +43,13 @@ import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.sql.ast.Node;
-import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.SpanUnit;
@@ -611,21 +612,39 @@ public class AstBuilderTest {
 
   @Test
   public void testQuotedHighlightCommand() {
-    assertEqual("source=t | highlight('FieldA')",
+    Map<String, Literal> args = new HashMap<>();
+    assertEqual("source=t | highlight 'FieldA'",
         new Highlight(
-            alias("highlight('FieldA')",
-                highlight(stringLiteral("'FieldA'"))))
+            alias("highlight 'FieldA'",
+                highlight(stringLiteral("FieldA"), args)),
+            args, "highlight 'FieldA'")
             .attach(relation("t"))
     );
   }
 
   @Test
   public void testUnquotedHighlightCommand() {
-    assertEqual("source=t | highlight(FieldA)",
+    Map<String, Literal> args = new HashMap<>();
+    assertEqual("source=t | highlight fieldA",
         new Highlight(
-            alias("highlight(FieldA)",
-            highlight(stringLiteral("FieldA"))))
+            alias("highlight fieldA",
+            highlight(stringLiteral("fieldA"), args)),
+            args, "highlight fieldA")
                 .attach(relation("t"))
+    );
+  }
+
+  @Test
+  public void testHighlightCommandWithArguments() {
+    Map<String, Literal> args = new HashMap<>();
+    args.put("pre_tags", new Literal("<mark>", DataType.STRING));
+    args.put("post_tags", new Literal("</mark>", DataType.STRING));
+    assertEqual("source=t | highlight fieldA, pre_tags='<mark>', post_tags='</mark>'",
+        new Highlight(
+            alias("highlight fieldA, pre_tags='<mark>', post_tags='</mark>'",
+                highlight(stringLiteral("fieldA"), args)),
+            args, "highlight fieldA, pre_tags='<mark>', post_tags='</mark>'")
+            .attach(relation("t"))
     );
   }
 

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -348,6 +348,8 @@ TIME_ZONE:                          'TIME_ZONE';
 TYPE:                               'TYPE';
 ZERO_TERMS_QUERY:                   'ZERO_TERMS_QUERY';
 HIGHLIGHT:                          'HIGHLIGHT';
+HIGHLIGHT_PRE_TAGS:                 'PRE_TAGS';
+HIGHLIGHT_POST_TAGS:                'POST_TAGS';
 
 // RELEVANCE FUNCTIONS
 MATCH_BOOL_PREFIX:                  'MATCH_BOOL_PREFIX';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -304,7 +304,7 @@ functionCall
     ;
 
 highlightFunction
-    : HIGHLIGHT LR_BRACKET relevanceField RR_BRACKET
+    : HIGHLIGHT LR_BRACKET relevanceField (COMMA highlightArg)* RR_BRACKET
     ;
 
 scalarFunctionName
@@ -425,6 +425,10 @@ relevanceArg
     : relevanceArgName EQUAL_SYMBOL relevanceArgValue
     ;
 
+highlightArg
+    : highlightArgName EQUAL_SYMBOL highlightArgValue
+    ;
+
 relevanceArgName
     : ALLOW_LEADING_WILDCARD | ANALYZER | ANALYZE_WILDCARD | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
     | BOOST | CUTOFF_FREQUENCY | DEFAULT_FIELD | DEFAULT_OPERATOR | ENABLE_POSITION_INCREMENTS
@@ -433,6 +437,10 @@ relevanceArgName
     | MAX_EXPANSIONS | MINIMUM_SHOULD_MATCH | OPERATOR | PHRASE_SLOP | PREFIX_LENGTH
     | QUOTE_ANALYZER | QUOTE_FIELD_SUFFIX | REWRITE | SLOP | TIE_BREAKER | TIME_ZONE | TYPE
     | ZERO_TERMS_QUERY
+    ;
+
+highlightArgName
+    : HIGHLIGHT_POST_TAGS | HIGHLIGHT_PRE_TAGS
     ;
 
 relevanceFieldAndWeight
@@ -458,5 +466,9 @@ relevanceQuery
 relevanceArgValue
     : qualifiedName
     | constant
+    ;
+
+highlightArgValue
+    : stringLiteral
     ;
 

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -48,6 +48,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.WindowFunc
 import static org.opensearch.sql.sql.parser.ParserUtils.createSortOption;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -134,7 +135,15 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitHighlightFunctionCall(
       OpenSearchSQLParser.HighlightFunctionCallContext ctx) {
-    return new HighlightFunction(visit(ctx.highlightFunction().relevanceField()));
+    ImmutableMap.Builder<String, Literal> builder = ImmutableMap.builder();
+    ctx.highlightFunction().highlightArg().forEach(v -> builder.put(
+        v.highlightArgName().getText().toLowerCase(),
+        new Literal(StringUtils.unquoteText(v.highlightArgValue().getText()),
+            DataType.STRING))
+    );
+
+    return new HighlightFunction(visit(ctx.highlightFunction().relevanceField()),
+        builder.build());
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -32,10 +32,14 @@ import static org.opensearch.sql.utils.SystemIndexUtils.TABLE_INFO;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.Map;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.AllFields;
+import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
@@ -671,18 +675,36 @@ class AstBuilderTest {
 
   @Test
   public void can_build_qualified_name_highlight() {
+    Map<String, Literal> args = new HashMap<>();
     assertEquals(
         project(relation("test"),
-            alias("highlight(fieldA)", highlight(AstDSL.qualifiedName("fieldA")))),
+            alias("highlight(fieldA)",
+                highlight(AstDSL.qualifiedName("fieldA"), args))),
         buildAST("SELECT highlight(fieldA) FROM test")
     );
   }
 
   @Test
-  public void can_build_string_literal_highlight() {
+  public void can_build_qualified_highlight_with_arguments() {
+    Map<String, Literal> args = new HashMap<>();
+    args.put("pre_tags", new Literal("<mark>", DataType.STRING));
+    args.put("post_tags", new Literal("</mark>", DataType.STRING));
     assertEquals(
         project(relation("test"),
-            alias("highlight(\"fieldA\")", highlight(AstDSL.stringLiteral("fieldA")))),
+            alias("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')",
+                highlight(AstDSL.qualifiedName("fieldA"), args))),
+        buildAST("SELECT highlight(fieldA, pre_tags='<mark>', post_tags='</mark>') "
+            + "FROM test")
+    );
+  }
+
+  @Test
+  public void can_build_string_literal_highlight() {
+    Map<String, Literal> args = new HashMap<>();
+    assertEquals(
+        project(relation("test"),
+            alias("highlight(\"fieldA\")",
+                highlight(AstDSL.stringLiteral("fieldA"), args))),
         buildAST("SELECT highlight(\"fieldA\") FROM test")
     );
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -13,7 +13,6 @@ import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.caseWhen;
 import static org.opensearch.sql.ast.dsl.AstDSL.dateLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.doubleLiteral;
-import static org.opensearch.sql.ast.dsl.AstDSL.floatLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.function;
 import static org.opensearch.sql.ast.dsl.AstDSL.highlight;
 import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
@@ -35,12 +34,15 @@ import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
@@ -311,16 +313,18 @@ class AstExpressionBuilderTest {
 
   @Test
   public void canBuildStringLiteralHighlightFunction() {
+    Map<String, Literal> args = new HashMap<>();
     assertEquals(
-        highlight(AstDSL.stringLiteral("fieldA")),
+        highlight(AstDSL.stringLiteral("fieldA"), args),
         buildExprAst("highlight(\"fieldA\")")
     );
   }
 
   @Test
   public void canBuildQualifiedNameHighlightFunction() {
+    Map<String, Literal> args = new HashMap<>();
     assertEquals(
-        highlight(AstDSL.qualifiedName("fieldA")),
+        highlight(AstDSL.qualifiedName("fieldA"), args),
         buildExprAst("highlight(fieldA)")
     );
   }


### PR DESCRIPTION
Signed-off-by: forestmvey <forestv@bitquilltech.com>

### Description
Add support for optional arguments `pre_tags` and `post_tags` for highlight.
 
### Issues Resolved
issue: [636](https://github.com/opensearch-project/sql/issues/636)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).