### PR TITLE
PoC: Fix aliases in `WHERE` clause

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
@@ -7,7 +7,9 @@
 package org.opensearch.sql.analysis;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import org.opensearch.sql.expression.NamedExpression;
@@ -22,6 +24,8 @@ public class AnalysisContext {
   private TypeEnvironment environment;
   @Getter
   private final List<NamedExpression> namedParseExpressions;
+  @Getter
+  private final Map<String, String> aliases;
 
   public AnalysisContext() {
     this(new TypeEnvironment(null));
@@ -30,6 +34,7 @@ public class AnalysisContext {
   public AnalysisContext(TypeEnvironment environment) {
     this.environment = environment;
     this.namedParseExpressions = new ArrayList<>();
+    this.aliases = new HashMap<>();
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -10,6 +10,7 @@ import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_FIRST;
 import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_LAST;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder.ASC;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 import static org.opensearch.sql.utils.MLCommonsConstants.RCF_ANOMALOUS;
 import static org.opensearch.sql.utils.MLCommonsConstants.RCF_ANOMALY_GRADE;
@@ -31,6 +32,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.analysis.symbol.Namespace;
 import org.opensearch.sql.analysis.symbol.Symbol;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Let;
@@ -268,6 +270,14 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
    */
   @Override
   public LogicalPlan visitProject(Project node, AnalysisContext context) {
+    node.getProjectList().forEach(proj -> {
+        if (proj instanceof Alias) {
+            context.getAliases().put(((Alias) proj).getAlias(), ((Alias) proj).getName());
+          //context.peek().define(new Symbol(Namespace.FIELD_NAME, ((Alias)proj).getAlias()), STRING);
+                  //new ReferenceExpression()
+                  //
+        }
+    });
     LogicalPlan child = node.getChild().get(0).accept(this, context);
 
     if (node.hasArgument()) {

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -301,6 +301,8 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
       }
     }
 
+    ident = context.getAliases().getOrDefault(ident, ident);
+
     TypeEnvironment typeEnv = context.peek();
     ReferenceExpression ref = DSL.ref(ident,
         typeEnv.resolve(new Symbol(Namespace.FIELD_NAME, ident)));


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
<details>
<summary>Test data</summary>

```
opensearchsql> select int0 i0, int1 i1, int2 i2 from calcs order by i1 nulls last;
fetched rows / total rows = 17/17
+------+------+------+
| i0   | i1   | i2   |
|------+------+------|
| 8    | -9   | 6    |
| 10   | -8   | -4   |
| null | -6   | -4   |
| null | -4   | -5   |
| 1    | -3   | 5    |
| null | 2    | 0    |
| null | 3    | -6   |
| 8    | 3    | -9   |
| null | null | 5    |
| 7    | null | 3    |
| 3    | null | 2    |
| 8    | null | 9    |
| 4    | null | -3   |
| null | null | 0    |
| 4    | null | 4    |
| 11   | null | -8   |
| 4    | null | -9   |
+------+------+------+
```
</details>

#### BEFORE
```
opensearchsql> select int0 i0, int1 i1, int2 i2 from calcs where i1 > 0;
{'reason': 'Invalid SQL query', 'details': "can't resolve Symbol(namespace=FIELD_NAME, name=i1) in type env", 'type': 'SemanticCheckException'}
```
<details>
<summary>Exception</summary>

```
Client side error during query execution
org.opensearch.sql.exception.SemanticCheckException: can't resolve Symbol(namespace=FIELD_NAME, name=i1) in type env
        at org.opensearch.sql.analysis.TypeEnvironment.resolve(TypeEnvironment.java:55) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.visitIdentifier(ExpressionAnalyzer.java:308) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.visitQualifiedName(ExpressionAnalyzer.java:282) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.visitQualifiedName(ExpressionAnalyzer.java:72) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.ast.expression.QualifiedName.accept(QualifiedName.java:111) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:91) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.lambda$visitFunction$0(ExpressionAnalyzer.java:178) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
        at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.visitFunction(ExpressionAnalyzer.java:179) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.visitFunction(ExpressionAnalyzer.java:72) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.ast.expression.Function.accept(Function.java:36) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:91) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.Analyzer.visitFilter(Analyzer.java:159) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.Analyzer.visitFilter(Analyzer.java:98) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.ast.tree.Filter.accept(Filter.java:44) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.Analyzer.visitProject(Analyzer.java:277) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.Analyzer.visitProject(Analyzer.java:98) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.ast.tree.Project.accept(Project.java:71) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.analysis.Analyzer.analyze(Analyzer.java:121) ~[core-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.sql.SQLService.analyze(SQLService.java:99) ~[sql-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.legacy.plugin.RestSQLQueryAction.prepareRequest(RestSQLQueryAction.java:105) ~[legacy-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.legacy.plugin.RestSqlAction.lambda$prepareRequest$1(RestSqlAction.java:156) [legacy-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.sql.opensearch.executor.Scheduler.lambda$withCurrentContext$0(Scheduler.java:30) [opensearch-2.2.0.0-SNAPSHOT.jar:?]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:747) [opensearch-2.2.0.jar:2.2.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```
</details>

#### AFTER
```
opensearchsql> select int0 i0, int1 i1, int2 from calcs where i1 > 0;
fetched rows / total rows = 3/3
+------+------+--------+
| i0   | i1   | int2   |
|------+------+--------|
| null | 2    | 0      |
| null | 3    | -6     |
| 8    | 3    | -9     |
+------+------+--------+
```

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).