### PR TITLE
Refactor unit tests

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -682,6 +682,22 @@ public class DSL {
     return compile(BuiltinFunctionName.MATCH_BOOL_PREFIX, args);
   }
 
+  public FunctionExpression unixTimeStampExpr() {
+    return compile(BuiltinFunctionName.UNIX_TIMESTAMP);
+  }
+
+  public FunctionExpression unixTimeStampOf(Expression value) {
+    return compile(BuiltinFunctionName.UNIX_TIMESTAMP, value);
+  }
+
+  public FunctionExpression fromUnixTime(Expression value) {
+    return compile(BuiltinFunctionName.FROM_UNIXTIME, value);
+  }
+
+  public FunctionExpression fromUnixTime(Expression value, Expression format) {
+    return compile(BuiltinFunctionName.FROM_UNIXTIME, value, format);
+  }
+
   private FunctionExpression compile(BuiltinFunctionName bfn, Expression... args) {
     return (FunctionExpression) repository.compile(bfn.getName(), Arrays.asList(args.clone()));
   }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeExpressionTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeExpressionTestBase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.datetime;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionTestBase;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionSignature;
+
+public class DateTimeExpressionTestBase extends ExpressionTestBase {
+  Environment<Expression, ExprValue> env;
+
+  protected Long unixTimeStamp() {
+    return dsl.unixTimeStampExpr().valueOf(null).longValue();
+  }
+
+  protected FunctionExpression unixTimeStampOf(Expression value) {
+    var repo = new ExpressionConfig().functionRepository();
+    var func = repo.resolve(new FunctionSignature(new FunctionName("unix_timestamp"),
+        List.of(value.type())));
+    return (FunctionExpression) func.apply(List.of(value));
+  }
+
+  protected Double unixTimeStampOf(LocalDateTime value) {
+    return unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value))).valueOf(null).doubleValue();
+  }
+
+  private Double unixTimeStampOf(Instant value) {
+    return unixTimeStampOf(DSL.literal(new ExprTimestampValue(value))).valueOf(null).doubleValue();
+  }
+
+  protected LocalDateTime fromUnixTime(Long value) {
+    return dsl.fromUnixTime(DSL.literal(value)).valueOf(null).datetimeValue();
+  }
+
+  protected LocalDateTime fromUnixTime(Double value) {
+    return dsl.fromUnixTime(DSL.literal(value)).valueOf(null).datetimeValue();
+  }
+
+  protected ExprValue eval(Expression expression) {
+    return expression.valueOf(env);
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTimeStampTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTimeStampTest.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,58 +27,28 @@ import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.ExpressionTestBase;
-import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.env.Environment;
-import org.opensearch.sql.expression.function.FunctionName;
-import org.opensearch.sql.expression.function.FunctionSignature;
 
-public class UnixTimeStampTest extends ExpressionTestBase {
+public class UnixTimeStampTest extends DateTimeExpressionTestBase {
 
   Environment<Expression, ExprValue> env;
 
-  private FunctionExpression unixTimeStampExpr() {
-    var repo = new ExpressionConfig().functionRepository();
-    var func = repo.resolve(new FunctionSignature(new FunctionName("unix_timestamp"), List.of()));
-    return (FunctionExpression)func.apply(List.of());
-  }
-
-  private Long unixTimeStamp() {
-    return unixTimeStampExpr().valueOf(null).longValue();
-  }
-
-  private FunctionExpression unixTimeStampOf(Expression value) {
-    var repo = new ExpressionConfig().functionRepository();
-    var func = repo.resolve(new FunctionSignature(new FunctionName("unix_timestamp"),
-        List.of(value.type())));
-    return (FunctionExpression)func.apply(List.of(value));
-  }
-
   private Double unixTimeStampOf(Double value) {
-    return unixTimeStampOf(DSL.literal(value)).valueOf(null).doubleValue();
+    return dsl.unixTimeStampOf(DSL.literal(value)).valueOf(null).doubleValue();
   }
 
   private Double unixTimeStampOf(LocalDate value) {
-    return unixTimeStampOf(DSL.literal(new ExprDateValue(value))).valueOf(null).doubleValue();
-  }
-
-  private Double unixTimeStampOf(LocalDateTime value) {
-    return unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value))).valueOf(null).doubleValue();
+    return dsl.unixTimeStampOf(DSL.literal(new ExprDateValue(value))).valueOf(null).doubleValue();
   }
 
   private Double unixTimeStampOf(Instant value) {
-    return unixTimeStampOf(DSL.literal(new ExprTimestampValue(value))).valueOf(null).doubleValue();
-  }
-
-  private ExprValue eval(Expression expression) {
-    return expression.valueOf(env);
+    return dsl.unixTimeStampOf(DSL.literal(new ExprTimestampValue(value))).valueOf(null).doubleValue();
   }
 
   @Test
   public void checkNoArgs() {
     assertEquals(System.currentTimeMillis() / 1000L, unixTimeStamp());
-    assertEquals(System.currentTimeMillis() / 1000L, eval(unixTimeStampExpr()).longValue());
+    assertEquals(System.currentTimeMillis() / 1000L, dsl.unixTimeStampExpr().valueOf(null).longValue());
   }
 
   private static Stream<Arguments> getDateSamples() {
@@ -102,7 +71,7 @@ public class UnixTimeStampTest extends ExpressionTestBase {
   public void checkOfDate(LocalDate value) {
     assertEquals(value.getLong(ChronoField.EPOCH_DAY) * 24 * 3600, unixTimeStampOf(value));
     assertEquals(value.getLong(ChronoField.EPOCH_DAY) * 24 * 3600,
-        eval(unixTimeStampOf(DSL.literal(new ExprDateValue(value)))).longValue());
+        eval(dsl.unixTimeStampOf(DSL.literal(new ExprDateValue(value)))).longValue());
   }
 
   private static Stream<Arguments> getDateTimeSamples() {
@@ -125,7 +94,7 @@ public class UnixTimeStampTest extends ExpressionTestBase {
   public void checkOfDateTime(LocalDateTime value) {
     assertEquals(value.toEpochSecond(ZoneOffset.UTC), unixTimeStampOf(value));
     assertEquals(value.toEpochSecond(ZoneOffset.UTC),
-        eval(unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value)))).longValue());
+        eval(dsl.unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value)))).longValue());
   }
 
   private static Stream<Arguments> getInstantSamples() {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTwoWayConversionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTwoWayConversionTest.java
@@ -8,92 +8,26 @@ package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
 import org.opensearch.sql.data.model.ExprDoubleValue;
 import org.opensearch.sql.data.model.ExprLongValue;
-import org.opensearch.sql.data.model.ExprTimestampValue;
-import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.DSL;
-import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.ExpressionTestBase;
-import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.config.ExpressionConfig;
-import org.opensearch.sql.expression.env.Environment;
-import org.opensearch.sql.expression.function.FunctionName;
-import org.opensearch.sql.expression.function.FunctionSignature;
 
-public class UnixTwoWayConversionTest extends ExpressionTestBase {
+public class UnixTwoWayConversionTest extends DateTimeExpressionTestBase {
 
-  Environment<Expression, ExprValue> env;
-
-  private FunctionExpression unixTimeStampExpr() {
-    var repo = new ExpressionConfig().functionRepository();
-    var func = repo.resolve(new FunctionSignature(new FunctionName("unix_timestamp"), List.of()));
-    return (FunctionExpression)func.apply(List.of());
-  }
-
-  private Long unixTimeStamp() {
-    return unixTimeStampExpr().valueOf(null).longValue();
-  }
-
-  private FunctionExpression unixTimeStampOf(Expression value) {
-    var repo = new ExpressionConfig().functionRepository();
-    var func = repo.resolve(new FunctionSignature(new FunctionName("unix_timestamp"),
-        List.of(value.type())));
-    return (FunctionExpression)func.apply(List.of(value));
-  }
-
-  private Double unixTimeStampOf(Double value) {
-    return unixTimeStampOf(DSL.literal(value)).valueOf(null).doubleValue();
-  }
-
-  private Double unixTimeStampOf(LocalDate value) {
-    return unixTimeStampOf(DSL.literal(new ExprDateValue(value))).valueOf(null).doubleValue();
-  }
-
-  private Double unixTimeStampOf(LocalDateTime value) {
-    return unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value))).valueOf(null).doubleValue();
-  }
-
-  private Double unixTimeStampOf(Instant value) {
-    return unixTimeStampOf(DSL.literal(new ExprTimestampValue(value))).valueOf(null).doubleValue();
-  }
-
-  private FunctionExpression fromUnixTime(Expression value) {
-    var repo = new ExpressionConfig().functionRepository();
-    var func = repo.resolve(new FunctionSignature(new FunctionName("from_unixtime"),
-        List.of(value.type())));
-    return (FunctionExpression)func.apply(List.of(value));
-  }
-
-  private LocalDateTime fromUnixTime(Long value) {
-    return fromUnixTime(DSL.literal(value)).valueOf(null).datetimeValue();
-  }
-
-  private LocalDateTime fromUnixTime(Double value) {
-    return fromUnixTime(DSL.literal(value)).valueOf(null).datetimeValue();
-  }
-
-  private ExprValue eval(Expression expression) {
-    return expression.valueOf(env);
-  }
 
   @Test
   public void checkConvertNow() {
     assertEquals(LocalDateTime.now(ZoneId.of("UTC")).withNano(0), fromUnixTime(unixTimeStamp()));
     assertEquals(LocalDateTime.now(ZoneId.of("UTC")).withNano(0),
-        eval(fromUnixTime(unixTimeStampExpr())).datetimeValue());
+        eval(dsl.fromUnixTime(dsl.unixTimeStampExpr())).datetimeValue());
   }
 
   private static Stream<Arguments> getDoubleSamples() {
@@ -115,11 +49,11 @@ public class UnixTwoWayConversionTest extends ExpressionTestBase {
   public void convertEpoch2DateTime2Epoch(Double value) {
     assertEquals(value, unixTimeStampOf(fromUnixTime(value)));
     assertEquals(value,
-        eval(unixTimeStampOf(fromUnixTime(DSL.literal(new ExprDoubleValue(value))))).doubleValue());
+        eval(dsl.unixTimeStampOf(dsl.fromUnixTime(DSL.literal(new ExprDoubleValue(value))))).doubleValue());
 
     assertEquals(Math.round(value) + 0d, unixTimeStampOf(fromUnixTime(Math.round(value))));
     assertEquals(Math.round(value) + 0d,
-        eval(unixTimeStampOf(fromUnixTime(DSL.literal(new ExprLongValue(Math.round(value))))))
+        eval(dsl.unixTimeStampOf(dsl.fromUnixTime(DSL.literal(new ExprLongValue(Math.round(value))))))
             .doubleValue());
   }
 
@@ -143,7 +77,7 @@ public class UnixTwoWayConversionTest extends ExpressionTestBase {
   public void convertDateTime2Epoch2DateTime(LocalDateTime value) {
     assertEquals(value, fromUnixTime(unixTimeStampOf(value)));
     assertEquals(value,
-        eval(fromUnixTime(unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value)))))
+        eval(dsl.fromUnixTime(dsl.unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value)))))
             .datetimeValue());
   }
 }


### PR DESCRIPTION
Move fromUnixTime, unixTimeStampOf, and unixTimeStampExpr to DSL class. Introduce DateTimeExpressionTestBase class for methods shared between FromUnixTimeTest, UnixTimeStampTest, and UnixTwoWayConversionTest.

Signed-off-by: MaxKsyunz <maxk@bitquilltech.com>

 
### Check List
- [x] All tests pass, including unit test, integration test and doctest
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).