### PR TITLE
Add new test workflow.

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -75,3 +75,4 @@ jobs:
           integ-test/build/reports/**
           protocol/build/reports/**
           legacy/build/reports/**
+          plugin/build/reports/**

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -1,0 +1,103 @@
+name: SQL Plugin Tests
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - '**/*.java'
+      - '**/*.g4'
+      - '!sql-jdbc/**'
+      - '**gradle*'
+      - '**lombok*'
+      - '**checkstyle*'
+      - 'integ-test/**'
+      - 'docs/**'
+      - 'doctest/**'
+      - '**/*.jar'
+      - '**/*.pom'
+      - '.github/workflows/sql-test-workflow.yml'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java:
+          - 11
+          - 17
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+    
+    - name: Run tests
+      id: tests
+      run: |
+        # checkstyle
+        ./gradlew :opensearch:checkstyleMain              || echo "* Checkstyle failed for opensearch/src" > report.log
+        ./gradlew :opensearch:checkstyleTest              || echo "* Checkstyle failed for opensearch/test" >> report.log
+        ./gradlew :sql:checkstyleMain                     || echo "* Checkstyle failed for sql/src" >> report.log
+        ./gradlew :sql:checkstyleTest                     || echo "* Checkstyle failed for sql/test" >> report.log
+        ./gradlew :ppl:checkstyleMain                     || echo "* Checkstyle failed for ppl/src" >> report.log
+        ./gradlew :ppl:checkstyleTest                     || echo "* Checkstyle failed for ppl/test" >> report.log
+        ./gradlew :core:checkstyleMain                    || echo "* Checkstyle failed for core/src" >> report.log
+        ./gradlew :core:checkstyleTest                    || echo "* Checkstyle failed for core/test" >> report.log
+        ./gradlew :common:checkstyleMain                  || echo "* Checkstyle failed for common/src" >> report.log
+        ./gradlew :common:checkstyleTest                  || echo "* Checkstyle failed for common/test" >> report.log
+        ./gradlew :legacy:checkstyleMain                  || echo "* Checkstyle failed for legacy/src" >> report.log
+        ./gradlew :legacy:checkstyleTest                  || echo "* Checkstyle failed for legacy/test" >> report.log
+        ./gradlew :protocol:checkstyleMain                || echo "* Checkstyle failed for protocol/src" >> report.log
+        ./gradlew :protocol:checkstyleTest                || echo "* Checkstyle failed for protocol/test" >> report.log
+        ./gradlew :opensearch-sql-plugin:checkstyleMain   || echo "* Checkstyle failed for plugin/src" >> report.log
+        ./gradlew :opensearch-sql-plugin:checkstyleTest   || echo "* Checkstyle failed for plugin/test" >> report.log
+        # Add checkstyle for `integ-test` when fixed
+        # Unit tests
+        ./gradlew :opensearch:test                        || echo "* Unit tests failed for opensearch" >> report.log
+        ./gradlew :ppl:test                               || echo "* Unit tests failed for sql" >> report.log
+        ./gradlew :sql:test                               || echo "* Unit tests failed for ppl" >> report.log
+        ./gradlew :core:test                              || echo "* Unit tests failed for core" >> report.log
+        ./gradlew :protocol:test                          || echo "* Unit tests failed for protocol" >> report.log
+        ./gradlew :opensearch-sql-plugin:test             || echo "* Unit tests failed for plugin" >> report.log
+        ./gradlew :legacy:test                            || echo "* Unit tests failed for legacy" >> report.log
+        # jacoco
+        ./gradlew :opensearch:jacocoTestCoverageVerification             || echo "* Jacoco failed for opensearch" >> report.log
+        ./gradlew :ppl:jacocoTestCoverageVerification                    || echo "* Jacoco failed for sql" >> report.log
+        ./gradlew :sql:jacocoTestCoverageVerification                    || echo "* Jacoco failed for ppl" >> report.log
+        ./gradlew :core:jacocoTestCoverageVerification                   || echo "* Jacoco failed for core" >> report.log
+        ./gradlew :protocol:jacocoTestCoverageVerification               || echo "* Jacoco failed for protocol" >> report.log
+        ./gradlew :opensearch-sql-plugin:jacocoTestCoverageVerification  || echo "* Jacoco failed for plugin" >> report.log
+        # Misc tests
+        ./gradlew :integ-test:integTest                   || echo "* Integration test failed" >> report.log
+        ./gradlew :doctest:doctest                        || echo "* Doctest failed" >> report.log
+        ./scripts/bwctest.sh                              || echo "* Backward compatibility test failed" >> report.log
+        
+    - name: Verify test results
+      run: |
+        if [[ -e failures.log ]]
+        then
+          echo "## FAILED TESTS :facepalm::warning::bangbang:" >> $GITHUB_STEP_SUMMARY
+          cat failures.log >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi
+
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-reports
+        path: |
+          sql/build/reports/**
+          ppl/build/reports/**
+          core/build/reports/**
+          common/build/reports/**
+          opensearch/build/reports/**
+          integ-test/build/reports/**
+          protocol/build/reports/**
+          legacy/build/reports/**
+          plugin/build/reports/**

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -1,9 +1,10 @@
 name: SQL Plugin Tests
 
 on:
+  workflow_dispatch:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - 'dev-*'
     paths:
       - '**/*.java'
       - '**/*.g4'


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
I decided to extend #118 and add an SQL plugin test workflow. It runs all test jobs regardless of other failures (assuming you don't have compilation errors) and reports all failures after that.
See run example: https://github.com/Bit-Quill/opensearch-project-sql/actions/runs/3077854910 (I intentionally damaged few tests).
Unfortunately, it runs much longer than regular workflow (~22 min), because it repeats some steps, (compilation) multiple times.

_I paused upstream PR while this one is on review_
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).