### PR TITLE
Update Jetty Dependency

### DIFF
--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -51,11 +51,11 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testImplementation('com.github.tomakehurst:wiremock:2.27.2')
+    testImplementation('com.github.tomakehurst:wiremock-jre8-standalone:2.34.0')
     testImplementation('org.mockito:mockito-core:2.23.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.3.1')
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')
-    testImplementation('org.eclipse.jetty:jetty-server:9.2.24.v20180105')
+    testImplementation('org.eclipse.jetty:jetty-server:9.4.48.v20220622')
 
     // Enforce wiremock to use latest guava and json-smart
     testImplementation('com.google.guava:guava:31.1-jre')

--- a/sql-jdbc/src/test/java/org/opensearch/jdbc/test/TLSServer.java
+++ b/sql-jdbc/src/test/java/org/opensearch/jdbc/test/TLSServer.java
@@ -20,9 +20,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
 import java.io.IOException;
 
 public class TLSServer {
@@ -70,7 +70,7 @@ public class TLSServer {
         ServerConnector httpsConnector = null;
 
         // setup ssl
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setKeyStorePath(keyStorePath);
         sslContextFactory.setKeyStorePassword(keyStorePassword);
         sslContextFactory.setKeyStoreType(keyStoreType);
@@ -132,8 +132,6 @@ public class TLSServer {
                 connectionFactories
         );
         connector.setPort(port);
-        connector.setStopTimeout(0);
-        connector.getSelectorManager().setStopTimeout(0);
         connector.setHost(bindAddress);
 
         return connector;


### PR DESCRIPTION
Signed-off-by: forestmvey <forestv@bitquilltech.com>

### Description
Update Jetty Dependency, wiremock dependency and fixes for associated errors.
 
### Related Issue
[wiremock/1944](https://github.com/wiremock/wiremock/issues/1944)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).