### PR TITLE
Expose query metadata to SQL functions

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -50,6 +50,7 @@ import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.Values;
 
 /**
@@ -90,6 +91,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitRelationSubquery(RelationSubquery node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitTableFunction(TableFunction node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -57,6 +57,7 @@ import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
+import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 
@@ -85,6 +86,10 @@ public class AstDSL {
 
   public UnresolvedPlan relation(String tableName, String alias) {
     return new Relation(qualifiedName(tableName), alias);
+  }
+
+  public UnresolvedPlan tableFunction(List<String> functionName, UnresolvedExpression... args) {
+    return new TableFunction(new QualifiedName(functionName), Arrays.asList(args));
   }
 
   public static UnresolvedPlan project(UnresolvedPlan input, UnresolvedExpression... projectList) {

--- a/core/src/main/java/org/opensearch/sql/ast/tree/TableFunction.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/TableFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.Let;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+/**
+ * ASTNode for Table Function.
+ */
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class TableFunction extends UnresolvedPlan {
+
+  private final UnresolvedExpression functionName;
+
+  @Getter
+  private final List<UnresolvedExpression> arguments;
+
+  public QualifiedName getFunctionName() {
+    return (QualifiedName) functionName;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitTableFunction(this, context);
+  }
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    return null;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -118,7 +118,7 @@ public class DSL {
     return new NamedAggregator(name, aggregator);
   }
 
-  public NamedArgumentExpression namedArgument(String argName, Expression value) {
+  public static NamedArgumentExpression namedArgument(String argName, Expression value) {
     return new NamedArgumentExpression(argName, value);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java
@@ -65,7 +65,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> new AvgAggregator(arguments, DOUBLE))
+                (queryContext, arguments) -> new AvgAggregator(arguments, DOUBLE))
             .build()
     );
   }
@@ -75,7 +75,7 @@ public class AggregatorFunction {
     DefaultFunctionResolver functionResolver = new DefaultFunctionResolver(functionName,
         ExprCoreType.coreTypes().stream().collect(Collectors.toMap(
           type -> new FunctionSignature(functionName, Collections.singletonList(type)),
-          type -> (qc, arguments) -> new CountAggregator(arguments, INTEGER))));
+          type -> (queryContext, arguments) -> new CountAggregator(arguments, INTEGER))));
     return functionResolver;
   }
 
@@ -85,13 +85,13 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(INTEGER)),
-                (qc, arguments) -> new SumAggregator(arguments, INTEGER))
+                (queryContext, arguments) -> new SumAggregator(arguments, INTEGER))
             .put(new FunctionSignature(functionName, Collections.singletonList(LONG)),
-                (qc, arguments) -> new SumAggregator(arguments, LONG))
+                (queryContext, arguments) -> new SumAggregator(arguments, LONG))
             .put(new FunctionSignature(functionName, Collections.singletonList(FLOAT)),
-                (qc, arguments) -> new SumAggregator(arguments, FLOAT))
+                (queryContext, arguments) -> new SumAggregator(arguments, FLOAT))
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> new SumAggregator(arguments, DOUBLE))
+                (queryContext, arguments) -> new SumAggregator(arguments, DOUBLE))
             .build()
     );
   }
@@ -102,23 +102,23 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(INTEGER)),
-                (qc, arguments) -> new MinAggregator(arguments, INTEGER))
+                (queryContext, arguments) -> new MinAggregator(arguments, INTEGER))
             .put(new FunctionSignature(functionName, Collections.singletonList(LONG)),
-                (qc, arguments) -> new MinAggregator(arguments, LONG))
+                (queryContext, arguments) -> new MinAggregator(arguments, LONG))
             .put(new FunctionSignature(functionName, Collections.singletonList(FLOAT)),
-                (qc, arguments) -> new MinAggregator(arguments, FLOAT))
+                (queryContext, arguments) -> new MinAggregator(arguments, FLOAT))
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> new MinAggregator(arguments, DOUBLE))
+                (queryContext, arguments) -> new MinAggregator(arguments, DOUBLE))
             .put(new FunctionSignature(functionName, Collections.singletonList(STRING)),
-                (qc, arguments) -> new MinAggregator(arguments, STRING))
+                (queryContext, arguments) -> new MinAggregator(arguments, STRING))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATE)),
-                (qc, arguments) -> new MinAggregator(arguments, DATE))
+                (queryContext, arguments) -> new MinAggregator(arguments, DATE))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATETIME)),
-                (qc, arguments) -> new MinAggregator(arguments, DATETIME))
+                (queryContext, arguments) -> new MinAggregator(arguments, DATETIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIME)),
-                (qc, arguments) -> new MinAggregator(arguments, TIME))
+                (queryContext, arguments) -> new MinAggregator(arguments, TIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIMESTAMP)),
-                (qc, arguments) -> new MinAggregator(arguments, TIMESTAMP))
+                (queryContext, arguments) -> new MinAggregator(arguments, TIMESTAMP))
             .build());
   }
 
@@ -128,23 +128,23 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(INTEGER)),
-                (qc, arguments) -> new MaxAggregator(arguments, INTEGER))
+                (queryContext, arguments) -> new MaxAggregator(arguments, INTEGER))
             .put(new FunctionSignature(functionName, Collections.singletonList(LONG)),
-                (qc, arguments) -> new MaxAggregator(arguments, LONG))
+                (queryContext, arguments) -> new MaxAggregator(arguments, LONG))
             .put(new FunctionSignature(functionName, Collections.singletonList(FLOAT)),
-                (qc, arguments) -> new MaxAggregator(arguments, FLOAT))
+                (queryContext, arguments) -> new MaxAggregator(arguments, FLOAT))
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> new MaxAggregator(arguments, DOUBLE))
+                (queryContext, arguments) -> new MaxAggregator(arguments, DOUBLE))
             .put(new FunctionSignature(functionName, Collections.singletonList(STRING)),
-                (qc, arguments) -> new MaxAggregator(arguments, STRING))
+                (queryContext, arguments) -> new MaxAggregator(arguments, STRING))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATE)),
-                (qc, arguments) -> new MaxAggregator(arguments, DATE))
+                (queryContext, arguments) -> new MaxAggregator(arguments, DATE))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATETIME)),
-                (qc, arguments) -> new MaxAggregator(arguments, DATETIME))
+                (queryContext, arguments) -> new MaxAggregator(arguments, DATETIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIME)),
-                (qc, arguments) -> new MaxAggregator(arguments, TIME))
+                (queryContext, arguments) -> new MaxAggregator(arguments, TIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIMESTAMP)),
-                (qc, arguments) -> new MaxAggregator(arguments, TIMESTAMP))
+                (queryContext, arguments) -> new MaxAggregator(arguments, TIMESTAMP))
             .build()
     );
   }
@@ -155,7 +155,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> varianceSample(arguments, DOUBLE))
+                (queryContext, arguments) -> varianceSample(arguments, DOUBLE))
             .build()
     );
   }
@@ -166,7 +166,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> variancePopulation(arguments, DOUBLE))
+                (queryContext, arguments) -> variancePopulation(arguments, DOUBLE))
             .build()
     );
   }
@@ -177,7 +177,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> stddevSample(arguments, DOUBLE))
+                (queryContext, arguments) -> stddevSample(arguments, DOUBLE))
             .build()
     );
   }
@@ -188,7 +188,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                (qc, arguments) -> stddevPopulation(arguments, DOUBLE))
+                (queryContext, arguments) -> stddevPopulation(arguments, DOUBLE))
             .build()
     );
   }

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java
@@ -65,7 +65,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> new AvgAggregator(arguments, DOUBLE))
+                (qc, arguments) -> new AvgAggregator(arguments, DOUBLE))
             .build()
     );
   }
@@ -75,7 +75,7 @@ public class AggregatorFunction {
     DefaultFunctionResolver functionResolver = new DefaultFunctionResolver(functionName,
         ExprCoreType.coreTypes().stream().collect(Collectors.toMap(
           type -> new FunctionSignature(functionName, Collections.singletonList(type)),
-          type -> arguments -> new CountAggregator(arguments, INTEGER))));
+          type -> (qc, arguments) -> new CountAggregator(arguments, INTEGER))));
     return functionResolver;
   }
 
@@ -85,13 +85,13 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(INTEGER)),
-                arguments -> new SumAggregator(arguments, INTEGER))
+                (qc, arguments) -> new SumAggregator(arguments, INTEGER))
             .put(new FunctionSignature(functionName, Collections.singletonList(LONG)),
-                arguments -> new SumAggregator(arguments, LONG))
+                (qc, arguments) -> new SumAggregator(arguments, LONG))
             .put(new FunctionSignature(functionName, Collections.singletonList(FLOAT)),
-                arguments -> new SumAggregator(arguments, FLOAT))
+                (qc, arguments) -> new SumAggregator(arguments, FLOAT))
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> new SumAggregator(arguments, DOUBLE))
+                (qc, arguments) -> new SumAggregator(arguments, DOUBLE))
             .build()
     );
   }
@@ -102,23 +102,23 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(INTEGER)),
-                arguments -> new MinAggregator(arguments, INTEGER))
+                (qc, arguments) -> new MinAggregator(arguments, INTEGER))
             .put(new FunctionSignature(functionName, Collections.singletonList(LONG)),
-                arguments -> new MinAggregator(arguments, LONG))
+                (qc, arguments) -> new MinAggregator(arguments, LONG))
             .put(new FunctionSignature(functionName, Collections.singletonList(FLOAT)),
-                arguments -> new MinAggregator(arguments, FLOAT))
+                (qc, arguments) -> new MinAggregator(arguments, FLOAT))
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> new MinAggregator(arguments, DOUBLE))
+                (qc, arguments) -> new MinAggregator(arguments, DOUBLE))
             .put(new FunctionSignature(functionName, Collections.singletonList(STRING)),
-                arguments -> new MinAggregator(arguments, STRING))
+                (qc, arguments) -> new MinAggregator(arguments, STRING))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATE)),
-                arguments -> new MinAggregator(arguments, DATE))
+                (qc, arguments) -> new MinAggregator(arguments, DATE))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATETIME)),
-                arguments -> new MinAggregator(arguments, DATETIME))
+                (qc, arguments) -> new MinAggregator(arguments, DATETIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIME)),
-                arguments -> new MinAggregator(arguments, TIME))
+                (qc, arguments) -> new MinAggregator(arguments, TIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIMESTAMP)),
-                arguments -> new MinAggregator(arguments, TIMESTAMP))
+                (qc, arguments) -> new MinAggregator(arguments, TIMESTAMP))
             .build());
   }
 
@@ -128,23 +128,23 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(INTEGER)),
-                arguments -> new MaxAggregator(arguments, INTEGER))
+                (qc, arguments) -> new MaxAggregator(arguments, INTEGER))
             .put(new FunctionSignature(functionName, Collections.singletonList(LONG)),
-                arguments -> new MaxAggregator(arguments, LONG))
+                (qc, arguments) -> new MaxAggregator(arguments, LONG))
             .put(new FunctionSignature(functionName, Collections.singletonList(FLOAT)),
-                arguments -> new MaxAggregator(arguments, FLOAT))
+                (qc, arguments) -> new MaxAggregator(arguments, FLOAT))
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> new MaxAggregator(arguments, DOUBLE))
+                (qc, arguments) -> new MaxAggregator(arguments, DOUBLE))
             .put(new FunctionSignature(functionName, Collections.singletonList(STRING)),
-                arguments -> new MaxAggregator(arguments, STRING))
+                (qc, arguments) -> new MaxAggregator(arguments, STRING))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATE)),
-                arguments -> new MaxAggregator(arguments, DATE))
+                (qc, arguments) -> new MaxAggregator(arguments, DATE))
             .put(new FunctionSignature(functionName, Collections.singletonList(DATETIME)),
-                arguments -> new MaxAggregator(arguments, DATETIME))
+                (qc, arguments) -> new MaxAggregator(arguments, DATETIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIME)),
-                arguments -> new MaxAggregator(arguments, TIME))
+                (qc, arguments) -> new MaxAggregator(arguments, TIME))
             .put(new FunctionSignature(functionName, Collections.singletonList(TIMESTAMP)),
-                arguments -> new MaxAggregator(arguments, TIMESTAMP))
+                (qc, arguments) -> new MaxAggregator(arguments, TIMESTAMP))
             .build()
     );
   }
@@ -155,7 +155,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> varianceSample(arguments, DOUBLE))
+                (qc, arguments) -> varianceSample(arguments, DOUBLE))
             .build()
     );
   }
@@ -166,7 +166,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> variancePopulation(arguments, DOUBLE))
+                (qc, arguments) -> variancePopulation(arguments, DOUBLE))
             .build()
     );
   }
@@ -177,7 +177,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> stddevSample(arguments, DOUBLE))
+                (qc, arguments) -> stddevSample(arguments, DOUBLE))
             .build()
     );
   }
@@ -188,7 +188,7 @@ public class AggregatorFunction {
         functionName,
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
-                arguments -> stddevPopulation(arguments, DOUBLE))
+                (qc, arguments) -> stddevPopulation(arguments, DOUBLE))
             .build()
     );
   }

--- a/core/src/main/java/org/opensearch/sql/expression/config/ExpressionConfig.java
+++ b/core/src/main/java/org/opensearch/sql/expression/config/ExpressionConfig.java
@@ -6,6 +6,9 @@
 
 package org.opensearch.sql.expression.config;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.HashMap;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.aggregation.AggregatorFunction;
@@ -13,6 +16,7 @@ import org.opensearch.sql.expression.datetime.DateTimeFunction;
 import org.opensearch.sql.expression.datetime.IntervalClause;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.OpenSearchFunctions;
+import org.opensearch.sql.expression.function.QueryContext;
 import org.opensearch.sql.expression.operator.arthmetic.ArithmeticFunction;
 import org.opensearch.sql.expression.operator.arthmetic.MathematicalFunction;
 import org.opensearch.sql.expression.operator.convert.TypeCastOperator;
@@ -33,8 +37,17 @@ public class ExpressionConfig {
    */
   @Bean
   public BuiltinFunctionRepository functionRepository() {
+
+    QueryContext queryContext = new QueryContext() {
+      private final Clock currentTime = Clock.fixed(Instant.now(),
+          ZoneId.systemDefault());
+      @Override
+      public Clock getQueryStartTime() {
+        return currentTime;
+      }
+    };
     BuiltinFunctionRepository builtinFunctionRepository =
-        new BuiltinFunctionRepository(new HashMap<>());
+        new BuiltinFunctionRepository(new HashMap<>(), queryContext);
     ArithmeticFunction.register(builtinFunctionRepository);
     BinaryPredicateOperator.register(builtinFunctionRepository);
     MathematicalFunction.register(builtinFunctionRepository);
@@ -53,4 +66,5 @@ public class ExpressionConfig {
   public DSL dsl(BuiltinFunctionRepository repository) {
     return new DSL(repository);
   }
+
 }

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -134,8 +134,8 @@ public class DateTimeFunction {
   private FunctionResolver now(FunctionName functionName) {
     return define(functionName,
         queryContextFunction(
-            queryScope -> new ExprDatetimeValue(
-                formatNow(queryScope.getQueryStartTime())), DATETIME)
+            queryContext -> new ExprDatetimeValue(
+                formatNow(queryContext.getQueryStartTime())), DATETIME)
     );
   }
 
@@ -160,8 +160,10 @@ public class DateTimeFunction {
    */
   private FunctionResolver sysdate() {
     return define(BuiltinFunctionName.SYSDATE.getName(),
-        queryContextFunction(qc -> new ExprDatetimeValue(formatNow(Clock.systemDefaultZone())), DATETIME),
-        queryContextFunction((qc, v) -> new ExprDatetimeValue(formatNow(Clock.systemDefaultZone(), v.integerValue())), DATETIME, INTEGER)
+        queryContextFunction(
+            queryContext -> new ExprDatetimeValue(formatNow(Clock.systemDefaultZone())), DATETIME),
+        queryContextFunction((queryContext, v) -> new ExprDatetimeValue(formatNow(Clock.systemDefaultZone(),
+            v.integerValue())), DATETIME, INTEGER)
     );
   }
 
@@ -170,7 +172,8 @@ public class DateTimeFunction {
    */
   private FunctionResolver curtime(FunctionName functionName) {
     return define(functionName,
-        queryContextFunction(qc -> new ExprTimeValue(formatNow(qc.getQueryStartTime()).toLocalTime()), TIME));
+        queryContextFunction(
+            queryContext -> new ExprTimeValue(formatNow(queryContext.getQueryStartTime()).toLocalTime()), TIME));
   }
 
   private FunctionResolver curtime() {
@@ -183,7 +186,8 @@ public class DateTimeFunction {
 
   private FunctionResolver curdate(FunctionName functionName) {
     return define(functionName,
-        queryContextFunction(qc -> new ExprDateValue(formatNow(qc.getQueryStartTime()).toLocalDate()), DATE));
+        queryContextFunction(
+            queryContext -> new ExprDateValue(formatNow(queryContext.getQueryStartTime()).toLocalDate()), DATE));
   }
 
   private FunctionResolver curdate() {
@@ -1093,6 +1097,7 @@ public class DateTimeFunction {
   private LocalDateTime formatNow(Clock clock) {
     return formatNow(clock, 0);
   }
+
   /**
    * Prepare LocalDateTime value. Truncate fractional second part according to the argument.
    * @param fsp argument is given to specify a fractional seconds precision from 0 to 6,

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -27,6 +27,7 @@ import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
 
 /**
  * Builtin Function Repository.
@@ -69,6 +70,11 @@ public class BuiltinFunctionRepository {
     namespaceFunctionResolverMap.get(namespace).put(resolver.getFunctionName(), resolver);
   }
 
+
+  public FunctionImplementation compile(BuiltinFunctionName functionName,
+                                        List<Expression> expressions) {
+    return compile(functionName.getName(), expressions);
+  }
 
   /**
    * Compile FunctionExpression under default namespace.
@@ -149,7 +155,7 @@ public class BuiltinFunctionRepository {
   private FunctionBuilder castArguments(List<ExprType> sourceTypes,
                                         List<ExprType> targetTypes,
                                         FunctionBuilder funcBuilder) {
-    return (queryScope, arguments) -> {
+    return (queryContext, arguments) -> {
       List<Expression> argsCasted = new ArrayList<>();
       for (int i = 0; i < arguments.size(); i++) {
         Expression arg = arguments.get(i);
@@ -162,7 +168,7 @@ public class BuiltinFunctionRepository {
           argsCasted.add(arg);
         }
       }
-      return funcBuilder.apply(queryScope, argsCasted);
+      return funcBuilder.apply(queryContext, argsCasted);
     };
   }
 
@@ -183,5 +189,4 @@ public class BuiltinFunctionRepository {
     }
     return (Expression) compile(castFunctionName, ImmutableList.of(arg));
   }
-
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -37,10 +37,11 @@ import org.opensearch.sql.expression.Expression;
  */
 @RequiredArgsConstructor
 public class BuiltinFunctionRepository {
-
   public static final String DEFAULT_NAMESPACE = "default";
 
   private final Map<String, Map<FunctionName, FunctionResolver>> namespaceFunctionResolverMap;
+
+  private final QueryContext queryContext;
 
 
   /**
@@ -91,7 +92,7 @@ public class BuiltinFunctionRepository {
     FunctionBuilder resolvedFunctionBuilder = resolve(namespaceList,
         new FunctionSignature(functionName, expressions
             .stream().map(expression -> expression.type()).collect(Collectors.toList())));
-    return resolvedFunctionBuilder.apply(expressions);
+    return resolvedFunctionBuilder.apply(queryContext, expressions);
   }
 
   /**
@@ -148,7 +149,7 @@ public class BuiltinFunctionRepository {
   private FunctionBuilder castArguments(List<ExprType> sourceTypes,
                                         List<ExprType> targetTypes,
                                         FunctionBuilder funcBuilder) {
-    return arguments -> {
+    return (queryScope, arguments) -> {
       List<Expression> argsCasted = new ArrayList<>();
       for (int i = 0; i < arguments.size(); i++) {
         Expression arg = arguments.get(i);
@@ -161,7 +162,7 @@ public class BuiltinFunctionRepository {
           argsCasted.add(arg);
         }
       }
-      return funcBuilder.apply(argsCasted);
+      return funcBuilder.apply(queryScope, argsCasted);
     };
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionBuilder.java
@@ -21,5 +21,5 @@ public interface FunctionBuilder {
    * @param arguments {@link Expression} list
    * @return {@link FunctionImplementation}
    */
-  FunctionImplementation apply(List<Expression> arguments);
+  FunctionImplementation apply(QueryContext qc, List<Expression> arguments);
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionBuilder.java
@@ -21,5 +21,5 @@ public interface FunctionBuilder {
    * @param arguments {@link Expression} list
    * @return {@link FunctionImplementation}
    */
-  FunctionImplementation apply(QueryContext qc, List<Expression> arguments);
+  FunctionImplementation apply(QueryContext queryContext, List<Expression> arguments);
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -58,7 +58,17 @@ public class FunctionDSL {
     return builder.build();
   }
 
-  public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>> queryContextFunction(
+  /**
+   * Implementation of a function that takes one argument, returns a value, and
+   * requires QueryContext to complete.
+   *
+   * @param function   {@link ExprValue} based unary function.
+   * @param returnType return type.
+   * @param argsType argument type.
+   * @return Unary Function Implementation.
+   */
+  public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      queryContextFunction(
       SerializableBiFunction<QueryContext, ExprValue, ExprValue> function,
       ExprType returnType,
       ExprType argsType) {
@@ -67,11 +77,11 @@ public class FunctionDSL {
       FunctionSignature functionSignature =
           new FunctionSignature(functionName, Collections.singletonList(argsType));
       FunctionBuilder functionBuilder =
-          (qc, arguments) -> new FunctionExpression(functionName, arguments) {
+          (queryContext, arguments) -> new FunctionExpression(functionName, arguments) {
             @Override
             public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
               ExprValue value = arguments.get(0).valueOf(valueEnv);
-              return function.apply(qc, value);
+              return function.apply(queryContext, value);
             }
 
             @Override
@@ -91,16 +101,23 @@ public class FunctionDSL {
     };
   }
 
+  /**
+   * Implementation of no args function that uses QueryContext.
+   * @param function {@link ExprValue} based no args function.
+   * @param returnType function return type.
+   * @return no args function implementation.
+   */
   public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
-  queryContextFunction(SerializableFunction<QueryContext, ExprValue> function, ExprType returnType) {
+      queryContextFunction(SerializableFunction<QueryContext, ExprValue> function,
+                       ExprType returnType) {
     return functionName -> {
       FunctionSignature functionSignature =
           new FunctionSignature(functionName, Collections.emptyList());
       FunctionBuilder functionBuilder =
-          (qc, arguments) -> new FunctionExpression(functionName, Collections.emptyList()) {
+          (queryContext, arguments) -> new FunctionExpression(functionName, Collections.emptyList()) {
             @Override
             public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
-              return function.apply(qc);
+              return function.apply(queryContext);
             }
 
             @Override
@@ -116,6 +133,7 @@ public class FunctionDSL {
       return Pair.of(functionSignature, functionBuilder);
     };
   }
+
   /**
    * No Arg Function Implementation.
    *
@@ -131,7 +149,7 @@ public class FunctionDSL {
       FunctionSignature functionSignature =
           new FunctionSignature(functionName, Collections.emptyList());
       FunctionBuilder functionBuilder =
-          (qc, arguments) -> new FunctionExpression(functionName, Collections.emptyList()) {
+          (queryContext, arguments) -> new FunctionExpression(functionName, Collections.emptyList()) {
             @Override
             public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
               return function.get();
@@ -168,7 +186,7 @@ public class FunctionDSL {
       FunctionSignature functionSignature =
           new FunctionSignature(functionName, Collections.singletonList(argsType));
       FunctionBuilder functionBuilder =
-          (qc, arguments) -> new FunctionExpression(functionName, arguments) {
+          (queryContext, arguments) -> new FunctionExpression(functionName, arguments) {
             @Override
             public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
               ExprValue value = arguments.get(0).valueOf(valueEnv);
@@ -211,7 +229,7 @@ public class FunctionDSL {
       FunctionSignature functionSignature =
           new FunctionSignature(functionName, Arrays.asList(args1Type, args2Type));
       FunctionBuilder functionBuilder =
-          (qc, arguments) -> new FunctionExpression(functionName, arguments) {
+          (queryContext, arguments) -> new FunctionExpression(functionName, arguments) {
             @Override
             public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
               ExprValue arg1 = arguments.get(0).valueOf(valueEnv);
@@ -254,7 +272,7 @@ public class FunctionDSL {
       FunctionSignature functionSignature =
           new FunctionSignature(functionName, Arrays.asList(args1Type, args2Type, args3Type));
       FunctionBuilder functionBuilder =
-          (qc, arguments) -> new FunctionExpression(functionName, arguments) {
+          (queryContext, arguments) -> new FunctionExpression(functionName, arguments) {
             @Override
             public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
               ExprValue arg1 = arguments.get(0).valueOf(valueEnv);

--- a/core/src/main/java/org/opensearch/sql/expression/function/QueryContext.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/QueryContext.java
@@ -1,11 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.expression.function;
 
 import java.time.Clock;
 
 /**
- * Class to capture values that may be necessary to implement SQL functions.
- * An example is query execution start time to implement
+ * Class to capture values that may be necessary to implement some functions.
+ * An example would be query execution start time to implement now().
  */
 public interface QueryContext {
+  /**
+   * Method to get time when query began execution.
+   * @return a clock provided at the start of query execution.
+   */
   Clock getQueryStartTime();
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/QueryContext.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/QueryContext.java
@@ -1,0 +1,11 @@
+package org.opensearch.sql.expression.function;
+
+import java.time.Clock;
+
+/**
+ * Class to capture values that may be necessary to implement SQL functions.
+ * An example is query execution start time to implement
+ */
+public interface QueryContext {
+  Clock getQueryStartTime();
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
@@ -48,7 +48,7 @@ public class RelevanceFunctionResolver
     }
 
     FunctionBuilder buildFunction =
-        (qc, args) -> new OpenSearchFunctions.OpenSearchFunction(functionName, args);
+        (queryContext, args) -> new OpenSearchFunctions.OpenSearchFunction(functionName, args);
     return Pair.of(unresolvedSignature, buildFunction);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
@@ -48,7 +48,7 @@ public class RelevanceFunctionResolver
     }
 
     FunctionBuilder buildFunction =
-        args -> new OpenSearchFunctions.OpenSearchFunction(functionName, args);
+        (qc, args) -> new OpenSearchFunctions.OpenSearchFunction(functionName, args);
     return Pair.of(unresolvedSignature, buildFunction);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/TableFunctionImplementation.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/TableFunctionImplementation.java
@@ -1,0 +1,19 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.expression.function;
+
+import org.opensearch.sql.storage.Table;
+
+/**
+ * Interface for table function which returns Table when executed.
+ */
+public interface TableFunctionImplementation extends FunctionImplementation {
+
+  Table applyArguments();
+
+}

--- a/core/src/main/java/org/opensearch/sql/expression/window/WindowFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/window/WindowFunctions.java
@@ -54,7 +54,7 @@ public class WindowFunctions {
   private DefaultFunctionResolver rankingFunction(FunctionName functionName,
                                                   Supplier<RankingWindowFunction> constructor) {
     FunctionSignature functionSignature = new FunctionSignature(functionName, emptyList());
-    FunctionBuilder functionBuilder = (qc, arguments) -> constructor.get();
+    FunctionBuilder functionBuilder = (queryContext, arguments) -> constructor.get();
     return new DefaultFunctionResolver(functionName,
         ImmutableMap.of(functionSignature, functionBuilder));
   }

--- a/core/src/main/java/org/opensearch/sql/expression/window/WindowFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/window/WindowFunctions.java
@@ -54,9 +54,8 @@ public class WindowFunctions {
   private DefaultFunctionResolver rankingFunction(FunctionName functionName,
                                                   Supplier<RankingWindowFunction> constructor) {
     FunctionSignature functionSignature = new FunctionSignature(functionName, emptyList());
-    FunctionBuilder functionBuilder = arguments -> constructor.get();
+    FunctionBuilder functionBuilder = (qc, arguments) -> constructor.get();
     return new DefaultFunctionResolver(functionName,
         ImmutableMap.of(functionSignature, functionBuilder));
   }
-
 }

--- a/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
+++ b/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
@@ -6,6 +6,10 @@
 
 package org.opensearch.sql.storage;
 
+import java.util.Collection;
+import java.util.Collections;
+import org.opensearch.sql.expression.function.FunctionResolver;
+
 /**
  * Storage engine for different storage to provide data access API implementation.
  */
@@ -15,4 +19,14 @@ public interface StorageEngine {
    * Get {@link Table} from storage engine.
    */
   Table getTable(String name);
+
+  /**
+   * Get list of catalog related functions.
+   *
+   * @return FunctionResolvers of catalog functions.
+   */
+  default Collection<FunctionResolver> getFunctions() {
+    return Collections.emptyList();
+  }
+
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -22,6 +22,8 @@ import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 import static org.opensearch.sql.ast.dsl.AstDSL.span;
+import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
 import static org.opensearch.sql.ast.tree.Sort.NullOrder;
 import static org.opensearch.sql.ast.tree.Sort.SortOption;
 import static org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_ASC;
@@ -40,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -56,6 +59,7 @@ import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.HighlightExpression;
@@ -64,6 +68,7 @@ import org.opensearch.sql.expression.window.WindowDefinition;
 import org.opensearch.sql.planner.logical.LogicalAD;
 import org.opensearch.sql.planner.logical.LogicalMLCommons;
 import org.opensearch.sql.planner.logical.LogicalPlanDSL;
+import org.opensearch.sql.planner.logical.LogicalRelation;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -925,9 +930,9 @@ class AnalyzerTest extends AnalyzerTestBase {
   @Test
   public void ad_batchRCF_relation() {
     Map<String, Literal> argumentMap =
-            new HashMap<String, Literal>() {{
-                put("shingle_size", new Literal(8, DataType.INTEGER));
-            }};
+        new HashMap<String, Literal>() {{
+            put("shingle_size", new Literal(8, DataType.INTEGER));
+          }};
     assertAnalyzeEqual(
         new LogicalAD(LogicalPlanDSL.relation("schema", table), argumentMap),
         new AD(AstDSL.relation("schema"), argumentMap)
@@ -947,4 +952,51 @@ class AnalyzerTest extends AnalyzerTestBase {
         new AD(AstDSL.relation("schema"), argumentMap)
     );
   }
+
+
+  @Test
+  public void table_function() {
+    assertAnalyzeEqual(new LogicalRelation("query_range", table),
+        AstDSL.tableFunction(List.of("prometheus", "query_range"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("starttime", intLiteral(12345)),
+            unresolvedArg("endtime", intLiteral(12345)),
+            unresolvedArg("step", intLiteral(14))));
+  }
+
+  @Test
+  public void table_function_with_no_catalog() {
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> analyze(AstDSL.tableFunction(List.of("query_range"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg(null, intLiteral(14)))));
+    assertEquals("unsupported function name: query_range",
+        exception.getMessage());
+  }
+
+  @Test
+  public void table_function_with_wrong_catalog() {
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> analyze(AstDSL.tableFunction(Arrays.asList("prome", "query_range"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg(null, intLiteral(14)))));
+    assertEquals("unsupported function name: prome.query_range", exception.getMessage());
+  }
+
+  @Test
+  public void table_function_with_wrong_table_function() {
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> analyze(AstDSL.tableFunction(Arrays.asList("prometheus", "queryrange"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg(null, intLiteral(14)))));
+    assertEquals("unsupported function name: queryrange", exception.getMessage());
+  }
+
+
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -138,7 +138,7 @@ public class AnalyzerTestBase {
         FunctionSignature functionSignature =
             new FunctionSignature(functionName, List.of(STRING, LONG, LONG, LONG));
         return Pair.of(functionSignature,
-            args -> new TestTableFunctionImplementation(functionName, args, table));
+            (queryContext, args) -> new TestTableFunctionImplementation(functionName, args, table));
       }
 
       @Override

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -7,13 +7,19 @@
 package org.opensearch.sql.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.swing.JTable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.analysis.symbol.Namespace;
 import org.opensearch.sql.analysis.symbol.Symbol;
 import org.opensearch.sql.analysis.symbol.SymbolTable;
+import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.catalog.CatalogService;
 import org.opensearch.sql.config.TestConfig;
@@ -24,6 +30,11 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.StorageEngine;
@@ -115,9 +126,27 @@ public class AnalyzerTestBase {
 
   @Bean
   protected Analyzer analyzer(ExpressionAnalyzer expressionAnalyzer, CatalogService catalogService,
-                              StorageEngine storageEngine) {
+                      StorageEngine storageEngine, BuiltinFunctionRepository functionRepository,
+                      Table table) {
     catalogService.registerOpenSearchStorageEngine(storageEngine);
-    return new Analyzer(expressionAnalyzer, catalogService);
+    functionRepository.register("prometheus", new FunctionResolver() {
+
+      @Override
+      public Pair<FunctionSignature, FunctionBuilder> resolve(
+          FunctionSignature unresolvedSignature) {
+        FunctionName functionName = FunctionName.of("query_range");
+        FunctionSignature functionSignature =
+            new FunctionSignature(functionName, List.of(STRING, LONG, LONG, LONG));
+        return Pair.of(functionSignature,
+            args -> new TestTableFunctionImplementation(functionName, args, table));
+      }
+
+      @Override
+      public FunctionName getFunctionName() {
+        return FunctionName.of("query_range");
+      }
+    });
+    return new Analyzer(expressionAnalyzer, catalogService, functionRepository);
   }
 
   @Bean
@@ -160,6 +189,37 @@ public class AnalyzerTestBase {
     @Override
     public void registerOpenSearchStorageEngine(StorageEngine storageEngine) {
       this.storageEngine = storageEngine;
+    }
+  }
+
+  private class TestTableFunctionImplementation implements TableFunctionImplementation {
+
+    private FunctionName functionName;
+
+    private List<Expression> arguments;
+
+    private Table table;
+
+    public TestTableFunctionImplementation(FunctionName functionName, List<Expression> arguments,
+                                           Table table) {
+      this.functionName = functionName;
+      this.arguments = arguments;
+      this.table = table;
+    }
+
+    @Override
+    public FunctionName getFunctionName() {
+      return functionName;
+    }
+
+    @Override
+    public List<Expression> getArguments() {
+      return this.arguments;
+    }
+
+    @Override
+    public Table applyArguments() {
+      return table;
     }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -6,11 +6,13 @@
 package org.opensearch.sql.expression.datetime;
 
 import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.expression.function.BuiltinFunctionRepository.DEFAULT_NAMESPACE;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -45,7 +47,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   protected BuiltinFunctionRepository functionRepository;
 
   protected FunctionExpression maketime(Expression hour, Expression minute, Expression second) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("maketime"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("maketime"),
         List.of(DOUBLE, DOUBLE, DOUBLE)));
     return (FunctionExpression)func.apply(List.of(hour, minute, second));
   }
@@ -56,7 +59,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression makedate(Expression year, Expression dayOfYear) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("makedate"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("makedate"),
         List.of(DOUBLE, DOUBLE)));
     return (FunctionExpression)func.apply(List.of(year, dayOfYear));
   }
@@ -66,7 +70,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression unixTimeStampExpr() {
-    var func = functionRepository.resolve(
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
         new FunctionSignature(new FunctionName("unix_timestamp"), List.of()));
     return (FunctionExpression)func.apply(List.of());
   }
@@ -76,7 +80,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression unixTimeStampOf(Expression value) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("unix_timestamp"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("unix_timestamp"),
         List.of(value.type())));
     return (FunctionExpression)func.apply(List.of(value));
   }
@@ -98,13 +103,15 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression fromUnixTime(Expression value) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("from_unixtime"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("from_unixtime"),
         List.of(value.type())));
     return (FunctionExpression)func.apply(List.of(value));
   }
 
   protected FunctionExpression fromUnixTime(Expression value, Expression format) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("from_unixtime"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("from_unixtime"),
         List.of(value.type(), format.type())));
     return (FunctionExpression)func.apply(List.of(value, format));
   }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.expression.datetime;
 
 import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
-import static org.opensearch.sql.expression.function.BuiltinFunctionRepository.DEFAULT_NAMESPACE;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -19,6 +18,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprMissingValue;
+import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.DSL;
@@ -26,6 +27,7 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionTestBase;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.FunctionSignature;
@@ -37,20 +39,15 @@ public class DateTimeTestBase extends ExpressionTestBase {
   @Mock
   protected Environment<Expression, ExprValue> env;
 
-  @Mock
-  protected Expression nullRef;
+  protected Expression nullRef = DSL.literal(ExprNullValue.of());
 
-  @Mock
-  protected Expression missingRef;
+  protected Expression missingRef = DSL.literal(ExprMissingValue.of());
 
   @Autowired
   protected BuiltinFunctionRepository functionRepository;
 
   protected FunctionExpression maketime(Expression hour, Expression minute, Expression second) {
-    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
-        new FunctionSignature(new FunctionName("maketime"),
-        List.of(DOUBLE, DOUBLE, DOUBLE)));
-    return (FunctionExpression)func.apply(List.of(hour, minute, second));
+    return (FunctionExpression) functionRepository.compile(BuiltinFunctionName.MAKETIME, List.of(hour, minute, second));
   }
 
   protected LocalTime maketime(Double hour, Double minute, Double second) {
@@ -59,10 +56,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression makedate(Expression year, Expression dayOfYear) {
-    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
-        new FunctionSignature(new FunctionName("makedate"),
-        List.of(DOUBLE, DOUBLE)));
-    return (FunctionExpression)func.apply(List.of(year, dayOfYear));
+    return (FunctionExpression)
+        functionRepository.compile(BuiltinFunctionName.MAKEDATE, List.of(year, dayOfYear));
   }
 
   protected LocalDate makedate(Double year, Double dayOfYear) {
@@ -70,9 +65,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression unixTimeStampExpr() {
-    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
-        new FunctionSignature(new FunctionName("unix_timestamp"), List.of()));
-    return (FunctionExpression)func.apply(List.of());
+    return (FunctionExpression)
+        functionRepository.compile(BuiltinFunctionName.UNIX_TIMESTAMP, List.of());
   }
 
   protected Long unixTimeStamp() {
@@ -80,10 +74,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression unixTimeStampOf(Expression value) {
-    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
-        new FunctionSignature(new FunctionName("unix_timestamp"),
-        List.of(value.type())));
-    return (FunctionExpression)func.apply(List.of(value));
+    return (FunctionExpression)
+        functionRepository.compile(BuiltinFunctionName.UNIX_TIMESTAMP, List.of(value));
   }
 
   protected Double unixTimeStampOf(Double value) {
@@ -103,17 +95,13 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression fromUnixTime(Expression value) {
-    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
-        new FunctionSignature(new FunctionName("from_unixtime"),
-        List.of(value.type())));
-    return (FunctionExpression)func.apply(List.of(value));
+    return (FunctionExpression)
+        functionRepository.compile(BuiltinFunctionName.FROM_UNIXTIME, List.of(value));
   }
 
   protected FunctionExpression fromUnixTime(Expression value, Expression format) {
-    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
-        new FunctionSignature(new FunctionName("from_unixtime"),
-        List.of(value.type(), format.type())));
-    return (FunctionExpression)func.apply(List.of(value, format));
+    return (FunctionExpression)
+        functionRepository.compile(BuiltinFunctionName.FROM_UNIXTIME, List.of(value, format));
   }
 
   protected LocalDateTime fromUnixTime(Long value) {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -47,7 +47,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   protected BuiltinFunctionRepository functionRepository;
 
   protected FunctionExpression maketime(Expression hour, Expression minute, Expression second) {
-    return (FunctionExpression) functionRepository.compile(BuiltinFunctionName.MAKETIME, List.of(hour, minute, second));
+    return (FunctionExpression)
+        functionRepository.compile(BuiltinFunctionName.MAKETIME, List.of(hour, minute, second));
   }
 
   protected LocalTime maketime(Double hour, Double minute, Double second) {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/MakeDateTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/MakeDateTest.java
@@ -60,8 +60,6 @@ public class MakeDateTest extends DateTimeTestBase {
 
   @Test
   public void checkMissingValues() {
-    when(missingRef.valueOf(env)).thenReturn(missingValue());
-
     assertEquals(missingValue(), eval(makedate(missingRef, DSL.literal(42.))));
     assertEquals(missingValue(), eval(makedate(DSL.literal(42.), missingRef)));
     assertEquals(missingValue(), eval(makedate(missingRef, missingRef)));

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/MakeTimeTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/MakeTimeTest.java
@@ -58,8 +58,6 @@ public class MakeTimeTest extends DateTimeTestBase {
 
   @Test
   public void checkNullValues() {
-    when(nullRef.valueOf(env)).thenReturn(nullValue());
-
     assertEquals(nullValue(), eval(maketime(nullRef, DSL.literal(42.), DSL.literal(42.))));
     assertEquals(nullValue(), eval(maketime(DSL.literal(42.), nullRef, DSL.literal(42.))));
     assertEquals(nullValue(), eval(maketime(DSL.literal(42.), DSL.literal(42.), nullRef)));
@@ -71,8 +69,6 @@ public class MakeTimeTest extends DateTimeTestBase {
 
   @Test
   public void checkMissingValues() {
-    when(missingRef.valueOf(env)).thenReturn(missingValue());
-
     assertEquals(missingValue(), eval(maketime(missingRef, DSL.literal(42.), DSL.literal(42.))));
     assertEquals(missingValue(), eval(maketime(DSL.literal(42.), missingRef, DSL.literal(42.))));
     assertEquals(missingValue(), eval(maketime(DSL.literal(42.), DSL.literal(42.), missingRef)));

--- a/core/src/test/java/org/opensearch/sql/expression/function/BuiltinFunctionRepositoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/BuiltinFunctionRepositoryTest.java
@@ -95,7 +95,7 @@ class BuiltinFunctionRepositoryTest {
     when(mockNamespaceMap.put(eq(TEST_NAMESPACE), any())).thenReturn(null);
     when(mockNamespaceMap.get(TEST_NAMESPACE)).thenReturn(mockMap);
     when(mockfunctionResolver.getFunctionName()).thenReturn(mockFunctionName);
-    BuiltinFunctionRepository repo = new BuiltinFunctionRepository(mockNamespaceMap);
+    BuiltinFunctionRepository repo = new BuiltinFunctionRepository(mockNamespaceMap, queryContext);
     repo.register(TEST_NAMESPACE, mockfunctionResolver);
 
     verify(mockNamespaceMap, times(1)).put(eq(TEST_NAMESPACE), any());
@@ -137,7 +137,7 @@ class BuiltinFunctionRepositoryTest {
     repo.register(TEST_NAMESPACE, mockfunctionResolver);
 
     repo.compile(TEST_NAMESPACE, mockFunctionName, Arrays.asList(mockExpression));
-    verify(functionExpressionBuilder, times(1)).apply(any());
+    verify(functionExpressionBuilder, times(1)).apply(same(queryContext), any());
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.storage;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StorageEngineTest {
+
+
+  @Test
+  void testFunctionsMethod() {
+    StorageEngine k = new StorageEngine() {
+      @Override
+      public Table getTable(String name) {
+        return null;
+      }
+    };
+    Assertions.assertEquals(Collections.emptyList(), k.getFunctions());
+  }
+
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     api project(":ppl")
     api project(':legacy')
     api project(':opensearch')
+    api project(':prometheus')
 }
 
 test {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -181,7 +181,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin, Rel
 
   @Override
   public void reload(Settings settings) {
-    CatalogServiceImpl.getInstance().loadConnectors(clusterService.getSettings());
+    CatalogServiceImpl.getInstance().loadConnectors(settings);
     CatalogServiceImpl.getInstance().registerOpenSearchStorageEngine(openSearchStorageEngine());
   }
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/catalog/CatalogServiceImpl.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/catalog/CatalogServiceImpl.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,6 +28,9 @@ import org.opensearch.sql.catalog.CatalogService;
 import org.opensearch.sql.catalog.model.CatalogMetadata;
 import org.opensearch.sql.catalog.model.ConnectorType;
 import org.opensearch.sql.opensearch.security.SecurityAccess;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.client.PrometheusClientImpl;
+import org.opensearch.sql.prometheus.storage.PrometheusStorageEngine;
 import org.opensearch.sql.storage.StorageEngine;
 
 /**
@@ -113,7 +118,11 @@ public class CatalogServiceImpl implements CatalogService {
     ConnectorType connector = catalog.getConnector();
     switch (connector) {
       case PROMETHEUS:
-        storageEngine = null;
+        PrometheusClient
+            prometheusClient =
+            new PrometheusClientImpl(new OkHttpClient(),
+                new URI(catalog.getUri()));
+        storageEngine = new PrometheusStorageEngine(prometheusClient);
         break;
       default:
         LOG.info(

--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -11,4 +11,6 @@ grant {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "getClassLoader";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.net.NetPermission "getProxySelector";
+  permission java.net.SocketPermission "*", "accept,connect,resolve";
 };

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -147,6 +147,8 @@ adParameter
 fromClause
     : SOURCE EQUAL tableSourceClause
     | INDEX EQUAL tableSourceClause
+    | SOURCE EQUAL tableFunction
+    | INDEX EQUAL tableFunction
     ;
 
 tableSourceClause
@@ -273,6 +275,10 @@ tableSource
     | ID_DATE_SUFFIX
     ;
 
+tableFunction
+    : qualifiedName LT_PRTHS functionArgs RT_PRTHS
+    ;
+
 /** fields */
 fieldList
     : fieldExpression (COMMA fieldExpression)*
@@ -342,7 +348,7 @@ functionArgs
     ;
 
 functionArg
-    : valueExpression
+    : (ident EQUAL)? valueExpression
     ;
 
 relevanceArg

--- a/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
@@ -86,7 +86,7 @@ public class PPLService {
         anonymizer.anonymizeData(ast));
     // 2.Analyze abstract syntax to generate logical plan
     LogicalPlan logicalPlan =
-        new Analyzer(new ExpressionAnalyzer(repository), catalogService).analyze(
+        new Analyzer(new ExpressionAnalyzer(repository), catalogService, repository).analyze(
             UnresolvedPlanHelper.addSelectAll(ast),
             new AnalysisContext());
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/config/PPLServiceConfig.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/config/PPLServiceConfig.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.ppl.config;
 
 import org.opensearch.sql.catalog.CatalogService;
+import org.opensearch.sql.catalog.model.ConnectorType;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
@@ -38,6 +39,10 @@ public class PPLServiceConfig {
    */
   @Bean
   public PPLService pplService() {
+    catalogService.getCatalogs()
+        .forEach(catalog -> catalogService.getStorageEngine(catalog)
+            .getFunctions()
+            .forEach(functionResolver -> functionRepository.register(catalog, functionResolver)));
     return new PPLService(new PPLSyntaxParser(), executionEngine,
             functionRepository, catalogService);
   }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -39,6 +39,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
@@ -76,6 +77,16 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
   @Override
   public String visitRelation(Relation node, String context) {
     return StringUtils.format("source=%s", node.getTableName());
+  }
+
+  @Override
+  public String visitTableFunction(TableFunction node, String context) {
+    String arguments =
+        node.getArguments().stream()
+            .map(unresolvedExpression
+                -> this.expressionAnalyzer.analyze(unresolvedExpression, context))
+            .collect(Collectors.joining(","));
+    return StringUtils.format("source=%s(%s)", node.getFunctionName().toString(), arguments);
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
@@ -8,11 +8,14 @@ package org.opensearch.sql.ppl;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +30,12 @@ import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponseNode;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.ppl.config.PPLServiceConfig;
 import org.opensearch.sql.ppl.domain.PPLQueryRequest;
@@ -50,6 +59,12 @@ public class PPLServiceTest {
   private CatalogService catalogService;
 
   @Mock
+  private BuiltinFunctionRepository functionRepository;
+
+  @Mock
+  private DSL dsl;
+
+  @Mock
   private Table table;
 
   @Mock
@@ -57,6 +72,9 @@ public class PPLServiceTest {
 
   @Mock
   private ExecutionEngine.Schema schema;
+
+  @Mock
+  private FunctionResolver functionResolver;
 
   /**
    * Setup the test context.
@@ -66,6 +84,9 @@ public class PPLServiceTest {
     when(table.getFieldTypes()).thenReturn(ImmutableMap.of("a", ExprCoreType.INTEGER));
     when(table.implement(any())).thenReturn(plan);
     when(storageEngine.getTable(any())).thenReturn(table);
+    when(catalogService.getCatalogs()).thenReturn(Set.of("prometheus"));
+    when(catalogService.getStorageEngine("prometheus")).thenReturn(storageEngine);
+    when(storageEngine.getFunctions()).thenReturn(Collections.singleton(functionResolver));
 
     context.registerBean(StorageEngine.class, () -> storageEngine);
     context.registerBean(ExecutionEngine.class, () -> executionEngine);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -38,9 +38,12 @@ import static org.opensearch.sql.ast.dsl.AstDSL.rename;
 import static org.opensearch.sql.ast.dsl.AstDSL.sort;
 import static org.opensearch.sql.ast.dsl.AstDSL.span;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.tableFunction;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +94,29 @@ public class AstBuilderTest {
     assertEqual("search source = http_requests_total.test",
         relation(qualifiedName("http_requests_total","test"))
     );
+  }
+
+  @Test
+  public void testSearchWithPrometheusQueryRangeWithPositionedArguments() {
+    assertEqual("search source = prometheus.query_range(\"test{code='200'}\",1234, 12345, 3)",
+        tableFunction(Arrays.asList("prometheus", "query_range"),
+            unresolvedArg(null, stringLiteral("test{code='200'}")),
+            unresolvedArg(null, intLiteral(1234)),
+            unresolvedArg(null, intLiteral(12345)),
+            unresolvedArg(null, intLiteral(3))
+    ));
+  }
+
+  @Test
+  public void testSearchWithPrometheusQueryRangeWithNamedArguments() {
+    assertEqual("search source = prometheus.query_range(query = \"test{code='200'}\", "
+            + "starttime = 1234, step=3, endtime=12345)",
+        tableFunction(Arrays.asList("prometheus", "query_range"),
+            unresolvedArg("query", stringLiteral("test{code='200'}")),
+            unresolvedArg("starttime", intLiteral(1234)),
+            unresolvedArg("step", intLiteral(3)),
+            unresolvedArg("endtime", intLiteral(12345))
+        ));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -39,6 +39,13 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testTableFunctionCommand() {
+    assertEquals("source=prometheus.query_range(***,***,***,***)",
+        anonymize("source=prometheus.query_range('afsd',123,123,3)")
+    );
+  }
+
+  @Test
   public void testPrometheusPPLCommand() {
     assertEquals("source=prometheus.http_requests_process",
         anonymize("source=prometheus.http_requests_process")

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/implementation/QueryRangeFunctionImplementation.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/implementation/QueryRangeFunctionImplementation.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions.implementation;
+
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.ENDTIME;
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.QUERY;
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.STARTTIME;
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.STEP;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricTable;
+import org.opensearch.sql.storage.Table;
+
+public class QueryRangeFunctionImplementation extends FunctionExpression implements
+    TableFunctionImplementation {
+
+  private final FunctionName functionName;
+  private final List<Expression> arguments;
+  private final PrometheusClient prometheusClient;
+
+  /**
+   * Required argument constructor.
+   *
+   * @param functionName name of the function
+   * @param arguments    a list of expressions
+   */
+  public QueryRangeFunctionImplementation(FunctionName functionName, List<Expression> arguments,
+                                          PrometheusClient prometheusClient) {
+    super(functionName, arguments);
+    this.functionName = functionName;
+    this.arguments = arguments;
+    this.prometheusClient = prometheusClient;
+  }
+
+  @Override
+  public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+    throw new UnsupportedOperationException(String.format(
+        "Prometheus defined function [%s] is only "
+            + "supported in SOURCE clause with prometheus connector catalog",
+        functionName));
+  }
+
+  @Override
+  public ExprType type() {
+    return ExprCoreType.STRUCT;
+  }
+
+  @Override
+  public String toString() {
+    List<String> args = arguments.stream()
+        .map(arg -> String.format("%s=%s", ((NamedArgumentExpression) arg)
+            .getArgName(), ((NamedArgumentExpression) arg).getValue().toString()))
+        .collect(Collectors.toList());
+    return String.format("%s(%s)", functionName, String.join(", ", args));
+  }
+
+  @Override
+  public Table applyArguments() {
+    return new PrometheusMetricTable(prometheusClient, buildQueryFromQueryRangeFunction(arguments));
+  }
+
+  private PrometheusQueryRequest buildQueryFromQueryRangeFunction(List<Expression> arguments) {
+
+    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
+    arguments.forEach(arg -> {
+      String argName = ((NamedArgumentExpression) arg).getArgName();
+      Expression argValue = ((NamedArgumentExpression) arg).getValue();
+      ExprValue literalValue = argValue.valueOf(null);
+      switch (argName) {
+        case QUERY:
+          prometheusQueryRequest
+              .getPromQl().append((String) literalValue.value());
+          break;
+        case STARTTIME:
+          prometheusQueryRequest.setStartTime(((Number) literalValue.value()).longValue());
+          break;
+        case ENDTIME:
+          prometheusQueryRequest.setEndTime(((Number) literalValue.value()).longValue());
+          break;
+        case STEP:
+          prometheusQueryRequest.setStep(literalValue.value().toString());
+          break;
+        default:
+          throw new ExpressionEvaluationException(
+              String.format("Invalid Function Argument:%s", argName));
+      }
+    });
+    return prometheusQueryRequest;
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/resolver/QueryRangeTableFunctionResolver.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/resolver/QueryRangeTableFunctionResolver.java
@@ -46,7 +46,7 @@ public class QueryRangeTableFunctionResolver implements FunctionResolver {
         new FunctionSignature(functionName, List.of(STRING, LONG, LONG, LONG));
     final List<String> argumentNames = List.of(QUERY, STARTTIME, ENDTIME, STEP);
 
-    FunctionBuilder functionBuilder = arguments -> {
+    FunctionBuilder functionBuilder = (queryContext, arguments) -> {
       Boolean argumentsPassedByName = arguments.stream()
           .noneMatch(arg -> StringUtils.isEmpty(((NamedArgumentExpression) arg).getArgName()));
       Boolean argumentsPassedByPosition = arguments.stream()

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/resolver/QueryRangeTableFunctionResolver.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/resolver/QueryRangeTableFunctionResolver.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions.resolver;
+
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
+
+@RequiredArgsConstructor
+public class QueryRangeTableFunctionResolver implements FunctionResolver {
+
+  private final PrometheusClient prometheusClient;
+
+  public static final String QUERY_RANGE = "query_range";
+  public static final String QUERY = "query";
+  public static final String STARTTIME = "starttime";
+  public static final String ENDTIME = "endtime";
+  public static final String STEP = "step";
+
+  @Override
+  public Pair<FunctionSignature, FunctionBuilder> resolve(FunctionSignature unresolvedSignature) {
+    FunctionName functionName = FunctionName.of(QUERY_RANGE);
+    FunctionSignature functionSignature =
+        new FunctionSignature(functionName, List.of(STRING, LONG, LONG, LONG));
+    final List<String> argumentNames = List.of(QUERY, STARTTIME, ENDTIME, STEP);
+
+    FunctionBuilder functionBuilder = arguments -> {
+      Boolean argumentsPassedByName = arguments.stream()
+          .noneMatch(arg -> StringUtils.isEmpty(((NamedArgumentExpression) arg).getArgName()));
+      Boolean argumentsPassedByPosition = arguments.stream()
+          .allMatch(arg -> StringUtils.isEmpty(((NamedArgumentExpression) arg).getArgName()));
+      if (!(argumentsPassedByName || argumentsPassedByPosition)) {
+        throw new SemanticCheckException("Arguments should be either passed by name or position");
+      }
+
+      if (arguments.size() != argumentNames.size()) {
+        throw new SemanticCheckException(
+            generateErrorMessageForMissingArguments(argumentsPassedByPosition, arguments,
+                argumentNames));
+      }
+
+      if (argumentsPassedByPosition) {
+        List<Expression> namedArguments = new ArrayList<>();
+        for (int i = 0; i < arguments.size(); i++) {
+          namedArguments.add(new NamedArgumentExpression(argumentNames.get(i),
+              ((NamedArgumentExpression) arguments.get(i)).getValue()));
+        }
+        return new QueryRangeFunctionImplementation(functionName, namedArguments, prometheusClient);
+      }
+      return new QueryRangeFunctionImplementation(functionName, arguments, prometheusClient);
+    };
+    return Pair.of(functionSignature, functionBuilder);
+  }
+
+  private String generateErrorMessageForMissingArguments(Boolean argumentsPassedByPosition,
+                                                         List<Expression> arguments,
+                                                         List<String> argumentNames) {
+    if (argumentsPassedByPosition) {
+      return String.format("Missing arguments:[%s]",
+          String.join(",", argumentNames.subList(arguments.size(), argumentNames.size())));
+    } else {
+      Set<String> requiredArguments = new HashSet<>(argumentNames);
+      Set<String> providedArguments =
+          arguments.stream().map(expression -> ((NamedArgumentExpression) expression).getArgName())
+              .collect(Collectors.toSet());
+      requiredArguments.removeAll(providedArguments);
+      return String.format("Missing arguments:[%s]", String.join(",", requiredArguments));
+    }
+  }
+
+  @Override
+  public FunctionName getFunctionName() {
+    return FunctionName.of(QUERY_RANGE);
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/request/PrometheusQueryRequest.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/request/PrometheusQueryRequest.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.prometheus.request;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,6 +19,7 @@ import org.opensearch.common.unit.TimeValue;
 @EqualsAndHashCode
 @Getter
 @ToString
+@AllArgsConstructor
 public class PrometheusQueryRequest {
 
   public static final TimeValue DEFAULT_QUERY_TIMEOUT = TimeValue.timeValueMinutes(1L);

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScan.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScan.java
@@ -11,6 +11,7 @@ import java.security.PrivilegedAction;
 import java.util.Iterator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,8 +33,9 @@ public class PrometheusMetricScan extends TableScanOperator {
 
   @EqualsAndHashCode.Include
   @Getter
+  @Setter
   @ToString.Include
-  private final PrometheusQueryRequest request;
+  private PrometheusQueryRequest request;
 
   private Iterator<ExprValue> iterator;
 

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTable.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTable.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.prometheus.storage;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.request.PrometheusDescribeMetricRequest;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.implementor.PrometheusDefaultImplementor;
+import org.opensearch.sql.storage.Table;
+
+/**
+ * Prometheus table (metric) implementation.
+ */
+public class PrometheusMetricTable implements Table {
+
+  private final PrometheusClient prometheusClient;
+
+  @Getter
+  private final Optional<String> metricName;
+
+  @Getter
+  private final Optional<PrometheusQueryRequest> prometheusQueryRequest;
+
+
+  /**
+   * The cached mapping of field and type in index.
+   */
+  private Map<String, ExprType> cachedFieldTypes = null;
+
+  /**
+   * Constructor only with metric name.
+   */
+  public PrometheusMetricTable(PrometheusClient prometheusService, @Nonnull String metricName) {
+    this.prometheusClient = prometheusService;
+    this.metricName = Optional.of(metricName);
+    this.prometheusQueryRequest = Optional.empty();
+  }
+
+  /**
+   * Constructor for entire promQl Request.
+   */
+  public PrometheusMetricTable(PrometheusClient prometheusService,
+                               @Nonnull PrometheusQueryRequest prometheusQueryRequest) {
+    this.prometheusClient = prometheusService;
+    this.metricName = Optional.empty();
+    this.prometheusQueryRequest = Optional.of(prometheusQueryRequest);
+  }
+
+  @Override
+  public Map<String, ExprType> getFieldTypes() {
+    if (cachedFieldTypes == null) {
+      cachedFieldTypes =
+          new PrometheusDescribeMetricRequest(prometheusClient,
+              metricName.orElse(null)).getFieldTypes();
+    }
+    return cachedFieldTypes;
+  }
+
+  @Override
+  public PhysicalPlan implement(LogicalPlan plan) {
+    PrometheusMetricScan metricScan =
+        new PrometheusMetricScan(prometheusClient);
+    prometheusQueryRequest.ifPresent(metricScan::setRequest);
+    return plan.accept(new PrometheusDefaultImplementor(), metricScan);
+  }
+
+  @Override
+  public LogicalPlan optimize(LogicalPlan plan) {
+    return plan;
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.storage;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver;
+import org.opensearch.sql.storage.StorageEngine;
+import org.opensearch.sql.storage.Table;
+
+
+/**
+ * Prometheus storage engine implementation.
+ */
+public class PrometheusStorageEngine implements StorageEngine {
+
+  private final PrometheusClient prometheusClient;
+
+  public PrometheusStorageEngine(PrometheusClient prometheusClient) {
+    this.prometheusClient = prometheusClient;
+  }
+
+  @Override
+  public Table getTable(String name) {
+    return null;
+  }
+
+  @Override
+  public Collection<FunctionResolver> getFunctions() {
+    return Collections.singletonList(new QueryRangeTableFunctionResolver(prometheusClient));
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.storage.implementor;
+
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.METRIC;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.TIMESTAMP;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.VALUE;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.planner.DefaultImplementor;
+import org.opensearch.sql.planner.logical.LogicalProject;
+import org.opensearch.sql.planner.logical.LogicalRelation;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.planner.physical.ProjectOperator;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricScan;
+
+/**
+ * Default Implementor of Logical plan for prometheus.
+ */
+@RequiredArgsConstructor
+public class PrometheusDefaultImplementor
+    extends DefaultImplementor<PrometheusMetricScan> {
+
+  @Override
+  public PhysicalPlan visitRelation(LogicalRelation node,
+                                    PrometheusMetricScan context) {
+    return context;
+  }
+
+  // Since getFieldTypes include labels
+  // we are explicitly specifying the output column names;
+  @Override
+  public PhysicalPlan visitProject(LogicalProject node, PrometheusMetricScan context) {
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(
+        new NamedExpression(METRIC, new ReferenceExpression(METRIC, ExprCoreType.STRING)));
+    finalProjectList.add(
+        new NamedExpression(TIMESTAMP,
+            new ReferenceExpression(TIMESTAMP, ExprCoreType.TIMESTAMP)));
+    finalProjectList.add(
+        new NamedExpression(VALUE, new ReferenceExpression(VALUE, ExprCoreType.DOUBLE)));
+    return new ProjectOperator(visitChild(node, context), finalProjectList,
+        node.getNamedParseExpressions());
+  }
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeFunctionImplementationTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeFunctionImplementationTest.java
@@ -1,0 +1,95 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricTable;
+
+
+@ExtendWith(MockitoExtension.class)
+class QueryRangeFunctionImplementationTest {
+
+  @Mock
+  private PrometheusClient client;
+
+
+  @Test
+  void testValueOfAndTypeAndToString() {
+    FunctionName functionName = new FunctionName("query_range");
+    List<Expression> namedArgumentExpressionList
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("endtime", DSL.literal(12345)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    QueryRangeFunctionImplementation queryRangeFunctionImplementation
+        = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
+    UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+        () -> queryRangeFunctionImplementation.valueOf(null));
+    assertEquals("Prometheus defined function [query_range] is only "
+        + "supported in SOURCE clause with prometheus connector catalog", exception.getMessage());
+    assertEquals("query_range(query=\"http_latency\", starttime=12345, endtime=12345, step=14)",
+        queryRangeFunctionImplementation.toString());
+    assertEquals(ExprCoreType.STRUCT, queryRangeFunctionImplementation.type());
+  }
+
+  @Test
+  void testApplyArguments() {
+    FunctionName functionName = new FunctionName("query_range");
+    List<Expression> namedArgumentExpressionList
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("endtime", DSL.literal(1234)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    QueryRangeFunctionImplementation queryRangeFunctionImplementation
+        = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) queryRangeFunctionImplementation.applyArguments();
+    assertFalse(prometheusMetricTable.getMetricName().isPresent());
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest
+        = prometheusMetricTable.getPrometheusQueryRequest().get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345, prometheusQueryRequest.getStartTime());
+    assertEquals(1234, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+  @Test
+  void testApplyArgumentsException() {
+    FunctionName functionName = new FunctionName("query_range");
+    List<Expression> namedArgumentExpressionList
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("end_time", DSL.literal(1234)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    QueryRangeFunctionImplementation queryRangeFunctionImplementation
+        = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> queryRangeFunctionImplementation.applyArguments());
+    assertEquals("Invalid Function Argument:end_time", exception.getMessage());
+  }
+
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeTableFunctionResolverTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeTableFunctionResolverTest.java
@@ -26,6 +26,7 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.function.FunctionBuilder;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.QueryContext;
 import org.opensearch.sql.expression.function.TableFunctionImplementation;
 import org.opensearch.sql.prometheus.client.PrometheusClient;
 import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
@@ -38,6 +39,9 @@ class QueryRangeTableFunctionResolverTest {
 
   @Mock
   private PrometheusClient client;
+
+  @Mock
+  private QueryContext queryContext;
 
   @Test
   void testResolve() {
@@ -58,7 +62,7 @@ class QueryRangeTableFunctionResolverTest {
     assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
     FunctionBuilder functionBuilder = resolution.getValue();
     TableFunctionImplementation functionImplementation
-        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+        = (TableFunctionImplementation) functionBuilder.apply(queryContext, expressions);
     assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
     PrometheusMetricTable prometheusMetricTable
         = (PrometheusMetricTable) functionImplementation.applyArguments();
@@ -93,7 +97,7 @@ class QueryRangeTableFunctionResolverTest {
     assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
     FunctionBuilder functionBuilder = resolution.getValue();
     TableFunctionImplementation functionImplementation
-        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+        = (TableFunctionImplementation) functionBuilder.apply(queryContext, expressions);
     assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
     PrometheusMetricTable prometheusMetricTable
         = (PrometheusMetricTable) functionImplementation.applyArguments();
@@ -129,7 +133,7 @@ class QueryRangeTableFunctionResolverTest {
     assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
     FunctionBuilder functionBuilder = resolution.getValue();
     TableFunctionImplementation functionImplementation
-        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+        = (TableFunctionImplementation) functionBuilder.apply(queryContext, expressions);
     assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
     PrometheusMetricTable prometheusMetricTable
         = (PrometheusMetricTable) functionImplementation.applyArguments();
@@ -162,7 +166,7 @@ class QueryRangeTableFunctionResolverTest {
     assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
     assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
     SemanticCheckException exception = assertThrows(SemanticCheckException.class,
-        () -> resolution.getValue().apply(expressions));
+        () -> resolution.getValue().apply(queryContext, expressions));
 
     assertEquals("Arguments should be either passed by name or position", exception.getMessage());
   }
@@ -184,7 +188,7 @@ class QueryRangeTableFunctionResolverTest {
     assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
     assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
     SemanticCheckException exception = assertThrows(SemanticCheckException.class,
-        () -> resolution.getValue().apply(expressions));
+        () -> resolution.getValue().apply(queryContext, expressions));
 
     assertEquals("Missing arguments:[endtime,starttime]", exception.getMessage());
   }
@@ -206,7 +210,7 @@ class QueryRangeTableFunctionResolverTest {
     assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
     assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
     SemanticCheckException exception = assertThrows(SemanticCheckException.class,
-        () -> resolution.getValue().apply(expressions));
+        () -> resolution.getValue().apply(queryContext, expressions));
 
     assertEquals("Missing arguments:[endtime,step]", exception.getMessage());
   }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeTableFunctionResolverTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeTableFunctionResolverTest.java
@@ -1,0 +1,214 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
+import org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricTable;
+
+@ExtendWith(MockitoExtension.class)
+class QueryRangeTableFunctionResolverTest {
+
+  @Mock
+  private PrometheusClient client;
+
+  @Test
+  void testResolve() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("endtime", DSL.literal(12345)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    FunctionBuilder functionBuilder = resolution.getValue();
+    TableFunctionImplementation functionImplementation
+        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+    assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) functionImplementation.applyArguments();
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest =
+        prometheusMetricTable.getPrometheusQueryRequest()
+            .get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345L, prometheusQueryRequest.getStartTime());
+    assertEquals(12345L, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+  @Test
+  void testArgumentsPassedByPosition() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument(null, DSL.literal("http_latency")),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(14)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    FunctionBuilder functionBuilder = resolution.getValue();
+    TableFunctionImplementation functionImplementation
+        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+    assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) functionImplementation.applyArguments();
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest =
+        prometheusMetricTable.getPrometheusQueryRequest()
+            .get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345L, prometheusQueryRequest.getStartTime());
+    assertEquals(12345L, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+
+  @Test
+  void testArgumentsPassedByNameWithDifferentOrder() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("endtime", DSL.literal(12345)),
+        DSL.namedArgument("step", DSL.literal(14)),
+        DSL.namedArgument("starttime", DSL.literal(12345)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    FunctionBuilder functionBuilder = resolution.getValue();
+    TableFunctionImplementation functionImplementation
+        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+    assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) functionImplementation.applyArguments();
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest =
+        prometheusMetricTable.getPrometheusQueryRequest()
+            .get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345L, prometheusQueryRequest.getStartTime());
+    assertEquals(12345L, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+  @Test
+  void testMixedArgumentTypes() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(14)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    SemanticCheckException exception = assertThrows(SemanticCheckException.class,
+        () -> resolution.getValue().apply(expressions));
+
+    assertEquals("Arguments should be either passed by name or position", exception.getMessage());
+  }
+
+  @Test
+  void testWrongArgumentsSizeWhenPassedByName() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("step", DSL.literal(12345)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    SemanticCheckException exception = assertThrows(SemanticCheckException.class,
+        () -> resolution.getValue().apply(expressions));
+
+    assertEquals("Missing arguments:[endtime,starttime]", exception.getMessage());
+  }
+
+  @Test
+  void testWrongArgumentsSizeWhenPassedByPosition() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument(null, DSL.literal("http_latency")),
+        DSL.namedArgument(null, DSL.literal(12345)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    SemanticCheckException exception = assertThrows(SemanticCheckException.class,
+        () -> resolution.getValue().apply(expressions));
+
+    assertEquals("Missing arguments:[endtime,step]", exception.getMessage());
+  }
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.prometheus.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.planner.logical.LogicalPlanDSL.project;
+import static org.opensearch.sql.planner.logical.LogicalPlanDSL.relation;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.METRIC;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.TIMESTAMP;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.VALUE;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.planner.physical.ProjectOperator;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.constants.TestConstants;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusMetricTableTest {
+
+  @Mock
+  private PrometheusClient client;
+
+  @Test
+  @SneakyThrows
+  void getFieldTypesFromMetric() {
+    when(client.getLabels(TestConstants.METRIC_NAME)).thenReturn(List.of("label1", "label2"));
+    PrometheusMetricTable prometheusMetricTable
+        = new PrometheusMetricTable(client, TestConstants.METRIC_NAME);
+    Map<String, ExprType> expectedFieldTypes = new HashMap<>();
+    expectedFieldTypes.put("label1", ExprCoreType.STRING);
+    expectedFieldTypes.put("label2", ExprCoreType.STRING);
+    expectedFieldTypes.put(VALUE, ExprCoreType.DOUBLE);
+    expectedFieldTypes.put(TIMESTAMP, ExprCoreType.TIMESTAMP);
+    expectedFieldTypes.put(METRIC, ExprCoreType.STRING);
+
+    Map<String, ExprType> fieldTypes = prometheusMetricTable.getFieldTypes();
+
+    assertEquals(expectedFieldTypes, fieldTypes);
+    verify(client, times(1)).getLabels(TestConstants.METRIC_NAME);
+    assertFalse(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    assertTrue(prometheusMetricTable.getMetricName().isPresent());
+    fieldTypes = prometheusMetricTable.getFieldTypes();
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  @SneakyThrows
+  void getFieldTypesFromPrometheusQueryRequest() {
+    PrometheusMetricTable prometheusMetricTable
+        = new PrometheusMetricTable(client, new PrometheusQueryRequest());
+    Map<String, ExprType> expectedFieldTypes = new HashMap<>();
+    expectedFieldTypes.put(VALUE, ExprCoreType.DOUBLE);
+    expectedFieldTypes.put(TIMESTAMP, ExprCoreType.TIMESTAMP);
+    expectedFieldTypes.put(METRIC, ExprCoreType.STRING);
+
+    Map<String, ExprType> fieldTypes = prometheusMetricTable.getFieldTypes();
+
+    assertEquals(expectedFieldTypes, fieldTypes);
+    verifyNoMoreInteractions(client);
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    assertFalse(prometheusMetricTable.getMetricName().isPresent());
+  }
+
+  @Test
+  void testImplement() {
+    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, prometheusQueryRequest);
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(
+        new NamedExpression(METRIC, new ReferenceExpression(METRIC, ExprCoreType.STRING)));
+    PhysicalPlan plan = prometheusMetricTable.implement(
+        project(relation("query_range", prometheusMetricTable),
+            finalProjectList, null));
+
+
+    assertTrue(plan instanceof ProjectOperator);
+    List<NamedExpression> projectList = ((ProjectOperator) plan).getProjectList();
+    List<String> outputFields
+        = projectList.stream().map(NamedExpression::getName).collect(Collectors.toList());
+    assertEquals(List.of(METRIC, TIMESTAMP, VALUE), outputFields);
+    assertTrue(((ProjectOperator) plan).getInput() instanceof PrometheusMetricScan);
+    PrometheusMetricScan prometheusMetricScan =
+        (PrometheusMetricScan) ((ProjectOperator) plan).getInput();
+    assertEquals(prometheusQueryRequest, prometheusMetricScan.getRequest());
+  }
+
+  @Test
+  void testOptimize() {
+    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, prometheusQueryRequest);
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(
+        new NamedExpression(METRIC, new ReferenceExpression(METRIC, ExprCoreType.STRING)));
+    LogicalPlan inputPlan = project(relation("query_range", prometheusMetricTable),
+        finalProjectList, null);
+    LogicalPlan optimizedPlan = prometheusMetricTable.optimize(
+        inputPlan);
+    assertEquals(inputPlan, optimizedPlan);
+  }
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.prometheus.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver;
+import org.opensearch.sql.storage.Table;
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusStorageEngineTest {
+
+  @Mock
+  private PrometheusClient client;
+
+  @Test
+  public void getTable() {
+    PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
+    Table table = engine.getTable("test");
+    assertNull(table);
+  }
+
+  @Test
+  public void getFunctions() {
+    PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
+    Collection<FunctionResolver> functionResolverCollection = engine.getFunctions();
+    assertNotNull(functionResolverCollection);
+    assertEquals(1, functionResolverCollection.size());
+    assertTrue(
+        functionResolverCollection.iterator().next() instanceof QueryRangeTableFunctionResolver);
+  }
+
+}

--- a/sql-cli/src/opensearch_sql_cli/main.py
+++ b/sql-cli/src/opensearch_sql_cli/main.py
@@ -61,7 +61,7 @@ click.disable_unicode_literals_warning = True
     "use_aws_authentication",
     is_flag=True,
     default=False,
-    help="Use AWS sigV4 to connect to AWS ELasticsearch domain",
+    help="Use AWS sigV4 to connect to AWS OpenSearch domain",
 )
 @click.option(
     "-l",

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -58,7 +58,7 @@ class OpenSearchConnection:
         region = session.region_name
 
         if credentials is not None:
-            self.aws_auth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service)
+            self.aws_auth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
         else:
             click.secho(
                 message="Can not retrieve your AWS credentials, check your AWS config",

--- a/sql/src/main/java/org/opensearch/sql/sql/config/SQLServiceConfig.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/config/SQLServiceConfig.java
@@ -14,7 +14,6 @@ import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.sql.SQLService;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
-import org.opensearch.sql.storage.StorageEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +37,8 @@ public class SQLServiceConfig {
 
   @Bean
   public Analyzer analyzer() {
-    return new Analyzer(new ExpressionAnalyzer(functionRepository), catalogService);
+    return new Analyzer(new ExpressionAnalyzer(functionRepository), catalogService,
+        functionRepository);
   }
 
   /**


### PR DESCRIPTION
- Add QueryContext interface to capture query metadata and provide it to
function implementations.
- Update FunctionBuilder to take QueryContext in addition to function arguments when evaluating a SQL function.
- Implement constant date time functions using QueryContext.

Signed-off-by: MaxKsyunz <maxk@bitquilltech.com>

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).