### PR TITLE
Add support for metadata fields (_id) to be used as QualifiedName

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -153,6 +153,13 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     }
     table.getFieldTypes().forEach((k, v) -> curEnv.define(new Symbol(Namespace.FIELD_NAME, k), v));
 
+    // add OpenSearch metadata types
+    curEnv.define(new Symbol(Namespace.FIELD_NAME, "_index"), ExprCoreType.STRING);
+    curEnv.define(new Symbol(Namespace.FIELD_NAME, "_id"), ExprCoreType.STRING);
+    curEnv.define(new Symbol(Namespace.FIELD_NAME, "_score"), ExprCoreType.FLOAT);
+    curEnv.define(new Symbol(Namespace.FIELD_NAME, "_maxscore"), ExprCoreType.FLOAT);
+    curEnv.define(new Symbol(Namespace.FIELD_NAME, "_sort"), ExprCoreType.LONG);
+
     // Put index name or its alias in index namespace on type environment so qualifier
     // can be removed when analyzing qualified name. The value (expr type) here doesn't matter.
     curEnv.define(new Symbol(Namespace.INDEX_NAME,

--- a/core/src/main/java/org/opensearch/sql/ast/expression/QualifiedName.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/QualifiedName.java
@@ -25,14 +25,27 @@ import org.opensearch.sql.ast.AbstractNodeVisitor;
 public class QualifiedName extends UnresolvedExpression {
   private final List<String> parts;
 
+  @Getter
+  private final Boolean isMetadataField;
+
   public QualifiedName(String name) {
+    this(name, Boolean.FALSE);
+  }
+
+  public QualifiedName(String name, Boolean isMetadataField) {
     this.parts = Collections.singletonList(name);
+    this.isMetadataField = isMetadataField;
+  }
+
+  public QualifiedName(Iterable<String> parts) {
+    this(parts, Boolean.FALSE);
   }
 
   /**
    * QualifiedName Constructor.
    */
-  public QualifiedName(Iterable<String> parts) {
+  public QualifiedName(Iterable<String> parts, Boolean isMetadataField) {
+    this.isMetadataField = isMetadataField;
     List<String> partsList = StreamSupport.stream(parts.spliterator(), false).collect(toList());
     if (partsList.isEmpty()) {
       throw new IllegalArgumentException("parts is empty");
@@ -110,4 +123,6 @@ public class QualifiedName extends UnresolvedExpression {
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
     return nodeVisitor.visitQualifiedName(this, context);
   }
+
+  public Boolean isMetadataField() { return Boolean.TRUE; }
 }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/mapping/FieldMapping.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/mapping/FieldMapping.java
@@ -88,7 +88,7 @@ public class FieldMapping {
     }
 
     /**
-     * Is field meta field, such as _id, _index, _source etc.
+     * Is field meta field, such as _id, _index, _score etc.
      *
      * @return true for meta field
      */

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/system/OpenSearchDescribeIndexRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/system/OpenSearchDescribeIndexRequest.java
@@ -118,6 +118,11 @@ public class OpenSearchDescribeIndexRequest implements OpenSearchSystemRequest {
               .filter(entry -> !ExprCoreType.UNKNOWN.equals(entry.getValue()))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
+    fieldTypes.put("_index", ExprCoreType.STRING);
+    fieldTypes.put("_id", ExprCoreType.STRING);
+    fieldTypes.put("_score", ExprCoreType.FLOAT);
+    fieldTypes.put("_maxscore", ExprCoreType.FLOAT);
+    fieldTypes.put("_sort", ExprCoreType.LONG);
     return fieldTypes;
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
@@ -17,6 +17,9 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprFloatValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
@@ -92,14 +95,25 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
         return (ExprValue) ExprTupleValue.fromExprValueMap(builder.build());
       }).iterator();
     } else {
+      float maxScore = hits.getMaxScore();
       return Arrays.stream(hits.getHits())
           .map(hit -> {
-            ExprValue docData = exprValueFactory.construct(hit.getSourceAsString());
-            if (hit.getHighlightFields().isEmpty()) {
-              return docData;
-            } else {
-              ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
-              builder.putAll(docData.tupleValue());
+            String source = hit.getSourceAsString();
+            ExprValue docData = exprValueFactory.construct(source);
+
+            ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
+            builder.putAll(docData.tupleValue());
+            builder.put("_index", new ExprStringValue(hit.getIndex()));
+            builder.put("_id", new ExprStringValue(hit.getId()));
+            if (!Float.isNaN(hit.getScore())) {
+                builder.put("_score", new ExprFloatValue(hit.getScore()));
+            }
+            if (!Float.isNaN(maxScore)) {
+                builder.put("_maxscore", new ExprLongValue(maxScore));
+            }
+            builder.put("_sort", new ExprLongValue(hit.getSeqNo()));
+
+            if (!hit.getHighlightFields().isEmpty()) {
               var hlBuilder = ImmutableMap.<String, ExprValue>builder();
               for (var es : hit.getHighlightFields().entrySet()) {
                 hlBuilder.put(es.getKey(), ExprValueUtils.collectionValue(
@@ -107,8 +121,8 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
                         t -> (t.toString())).collect(Collectors.toList())));
               }
               builder.put("_highlight", ExprTupleValue.fromExprValueMap(hlBuilder.build()));
-              return ExprTupleValue.fromExprValueMap(builder.build());
             }
+            return (ExprValue) ExprTupleValue.fromExprValueMap(builder.build());
           }).iterator();
     }
   }

--- a/sql/src/main/antlr/OpenSearchSQLIdentifierParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLIdentifierParser.g4
@@ -54,7 +54,16 @@ qualifiedName
 ident
     : DOT? ID
     | BACKTICK_QUOTE_ID
+    | metadataField
     | keywordsCanBeId
+    ;
+
+metadataField
+    : META_INDEX
+    | META_ID
+    | META_SCORE
+    | META_MAXSCORE
+    | META_SORT
     ;
 
 keywordsCanBeId

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -135,6 +135,15 @@ SUBSTRING:                          'SUBSTRING';
 TRIM:                               'TRIM';
 
 
+// Metadata fields can be ID
+
+META_INDEX:                         '_ID';
+META_ID:                            '_ID';
+META_SCORE:                         '_SCORE';
+META_MAXSCORE:                      '_MAXSCORE';
+META_SORT:                          '_SORT';
+
+
 // Keywords, but can be ID
 // Common Keywords, but can be ID
 
@@ -441,13 +450,16 @@ BACKTICK_QUOTE_ID:                  BQUOTA_STRING;
 
 // Fragments for Literal primitives
 fragment EXPONENT_NUM_PART:         'E' [-+]? DEC_DIGIT+;
-fragment ID_LITERAL:                [@*A-Z]+?[*A-Z_\-0-9]*;
 fragment DQUOTA_STRING:             '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 fragment SQUOTA_STRING:             '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 fragment BQUOTA_STRING:             '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';
 fragment HEX_DIGIT:                 [0-9A-F];
 fragment DEC_DIGIT:                 [0-9];
 fragment BIT_STRING_L:              'B' '\'' [01]+ '\'';
+
+// Identifiers cannot start with a single '_' since this an OpebSearch reserved
+// metadata field.  Two underscores (or more) is acceptable, such as '__field'.
+fragment ID_LITERAL:                ([_][_]|[@*A-Z])+?[*A-Z_\-0-9]*;
 
 // Last tokens must generate Errors
 

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -430,12 +430,13 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   }
 
   private QualifiedName visitIdentifiers(List<IdentContext> identifiers) {
+    Boolean isMetadataField = identifiers.stream().filter(id -> id.metadataField() != null).findFirst().isPresent();
     return new QualifiedName(
-        identifiers.stream()
-                   .map(RuleContext::getText)
-                   .map(StringUtils::unquoteIdentifier)
-                   .collect(Collectors.toList())
-    );
+      identifiers.stream()
+                 .map(RuleContext::getText)
+                 .map(StringUtils::unquoteIdentifier)
+                 .collect(Collectors.toList()),
+            isMetadataField);
   }
 
   private List<UnresolvedExpression> singleFieldRelevanceArguments(


### PR DESCRIPTION
### Description
OpenSearch reserved fields (_id, _score, _index, etc) are not allowed to be used in SQL clauses (SELECT, WHERE, ORDER BY) because the field format starting with underscore `_` is not allowed.  

This ticket adds specific identifiers to the language, and opens up support for OpenSearch reserved identifiers.  

As an aside, identifiers with double underscore at the start (such as `__myCoolField`) is acceptable as a indentifier. 

**Example**: 
`SELECT calcs.key, str0, _id, _score, _maxscore FROM calcs WHERE _id="5"`

**Result**: 
`
{
    "key04",
    "OFFICE SUPPLIES",
    "5",
    null,
    null
}
`

### Issues Resolved
[#639](https://github.com/opensearch-project/sql/issues/639)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).