### PR TITLE
Added Query Function As Query_string Function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -707,6 +707,10 @@ public class DSL {
     return compile(BuiltinFunctionName.SIMPLE_QUERY_STRING, args);
   }
 
+  public FunctionExpression query(Expression... args) {
+    return compile(BuiltinFunctionName.QUERY, args);
+  }
+
   public FunctionExpression query_string(Expression... args) {
     return compile(BuiltinFunctionName.QUERY_STRING, args);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -30,6 +30,7 @@ public class OpenSearchFunctions {
     repository.register(match());
     repository.register(multi_match());
     repository.register(simple_query_string());
+    repository.register(query());
     repository.register(query_string());
     // Register MATCHPHRASE as MATCH_PHRASE as well for backwards
     // compatibility.
@@ -66,6 +67,11 @@ public class OpenSearchFunctions {
   private static FunctionResolver simple_query_string() {
     FunctionName funcName = BuiltinFunctionName.SIMPLE_QUERY_STRING.getName();
     return new RelevanceFunctionResolver(funcName, STRUCT);
+  }
+
+  private static FunctionResolver query() {
+    FunctionName funcName = BuiltinFunctionName.QUERY.getName();
+    return new RelevanceFunctionResolver(funcName, STRING);
   }
 
   private static FunctionResolver query_string() {

--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -488,6 +488,15 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
   }
 
   @Test
+  void query_expression() {
+    assertAnalyzeEqual(
+            dsl.query(
+                    dsl.namedArgument("query", DSL.literal("field:query"))),
+            AstDSL.function("query",
+                    AstDSL.unresolvedArg("query", stringLiteral("field:query"))));
+  }
+
+  @Test
   void query_string_expression() {
     assertAnalyzeEqual(
         dsl.query_string(

--- a/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
@@ -184,6 +184,13 @@ public class OpenSearchFunctionsTest extends ExpressionTestBase {
   }
 
   @Test
+  void query() {
+    FunctionExpression expr = dsl.query(query);
+    assertEquals(String.format("query(query=%s)", query.getValue()),
+            expr.toString());
+  }
+
+  @Test
   void query_string() {
     FunctionExpression expr = dsl.query_string(fields, query);
     assertEquals(String.format("query_string(fields=%s, query=%s)",

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -3017,6 +3017,67 @@ Another example to show how to set custom values for the optional parameters::
     +------+--------------------------+----------------------+
 
 
+QUERY
+-----
+
+Description
+>>>>>>>>>>>
+
+``query("query_expression" [, option=<option_value>]*)``
+
+The `query` function is an alternative syntax to the `query_string`_ function. It maps to the query_string query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given query expression.
+``query_expression`` must be a string provided in Lucene query string syntax. Please refer to examples below:
+
+| ``query('Tags:taste OR Body:taste', ...)``
+| ``query("Tags:taste AND Body:taste", ...)``
+
+Available parameters include:
+
+- analyzer
+- escape
+- allow_leading_wildcard
+- analyze_wildcard
+- auto_generate_synonyms_phrase_query
+- boost
+- default_operator
+- enable_position_increments
+- fuzziness
+- fuzzy_max_expansions
+- fuzzy_prefix_length
+- fuzzy_transpositions
+- fuzzy_rewrite
+- tie_breaker
+- lenient
+- type
+- max_determinized_states
+- minimum_should_match
+- quote_analyzer
+- phrase_slop
+- quote_field_suffix
+- rewrite
+- time_zone
+
+Example with only ``query_expressions``, and all other parameters are set default values::
+
+    os> select * from books where query('title:Pooh House');
+    fetched rows / total rows = 2/2
+    +------+--------------------------+----------------------+
+    | id   | title                    | author               |
+    |------+--------------------------+----------------------|
+    | 1    | The House at Pooh Corner | Alan Alexander Milne |
+    | 2    | Winnie-the-Pooh          | Alan Alexander Milne |
+    +------+--------------------------+----------------------+
+
+Another example to show how to set custom values for the optional parameters::
+
+    os> select * from books where query('title:Pooh House', default_operator='AND');
+    fetched rows / total rows = 1/1
+    +------+--------------------------+----------------------+
+    | id   | title                    | author               |
+    |------+--------------------------+----------------------|
+    | 1    | The House at Pooh Corner | Alan Alexander Milne |
+    +------+--------------------------+----------------------+
+
 HIGHLIGHT
 ------------
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/MethodQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/MethodQueryIT.java
@@ -38,7 +38,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
         "select address from %s where query('address:880 Holmes Lane') limit 3",
         TestsConstants.TEST_INDEX_ACCOUNT));
     Assert.assertThat(result,
-        containsString("query_string\":{\"query\":\"address:880 Holmes Lane"));
+        containsString("query_string\\\":{\\\"query\\\":\\\"address:880 Holmes Lane"));
 
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.sql;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+public class QueryIT extends SQLIntegTestCase {
+    @Override
+    public void init() throws IOException {
+        loadIndex(Index.BEER);
+    }
+
+    @Test
+    public void all_fields_test() throws IOException {
+        String query = "SELECT * FROM "
+                + TEST_INDEX_BEER + " WHERE query('*:taste')";
+        JSONObject result = executeJdbcRequest(query);
+        assertEquals(16, result.getInt("total"));
+    }
+
+    @Test
+    public void mandatory_params_test() throws IOException {
+        String query = "SELECT Id FROM "
+                + TEST_INDEX_BEER + " WHERE query('Tags:taste OR Body:taste')";
+        JSONObject result = executeJdbcRequest(query);
+        assertEquals(16, result.getInt("total"));
+    }
+
+    @Test
+    public void all_params_test() throws IOException {
+        String query = "SELECT Id FROM " + TEST_INDEX_BEER
+                + " WHERE query('Tags:taste', escape=false,"
+                + "allow_leading_wildcard=true, enable_position_increments=true,"
+                + "fuzziness= 1, fuzzy_rewrite='constant_score', max_determinized_states = 10000,"
+                + "analyzer='standard', analyze_wildcard = false, quote_field_suffix = '.exact',"
+                + "auto_generate_synonyms_phrase_query=true, boost = 0.77,"
+                + "quote_analyzer='standard', phrase_slop=0, rewrite='constant_score', type='best_fields',"
+                + "tie_breaker=0.3, time_zone='Canada/Pacific', default_operator='or',"
+                + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
+                + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7);";
+        JSONObject result = executeJdbcRequest(query);
+        assertEquals(8, result.getInt("total"));
+    }
+
+    @Test
+    public void wildcard_test() throws IOException {
+        String query1 = "SELECT Id FROM "
+                + TEST_INDEX_BEER + " WHERE query('Tags:taste')";
+        JSONObject result1 = executeJdbcRequest(query1);
+        String query2 = "SELECT Id FROM "
+                + TEST_INDEX_BEER + " WHERE query('*:taste')";
+        JSONObject result2 = executeJdbcRequest(query2);
+        assertNotEquals(result2.getInt("total"), result1.getInt("total"));
+
+        String query3 = "SELECT Id FROM " + TEST_INDEX_BEER
+                + " WHERE query('Tags:tas*');";
+        JSONObject result3 = executeJdbcRequest(query3);
+        assertEquals(8, result3.getInt("total"));
+
+        String query4 = "SELECT Id FROM " + TEST_INDEX_BEER
+                + " WHERE query('Tags:tas?e');";
+        JSONObject result4 = executeJdbcRequest(query3);
+        assertEquals(8, result4.getInt("total"));
+    }
+
+    @Test
+    public void query_string_and_query_return_the_same_results_test() throws IOException {
+        String query1 = "SELECT Id FROM "
+                + TEST_INDEX_BEER + " WHERE query('Tags:taste')";
+        JSONObject result1 = executeJdbcRequest(query1);
+        String query2 = "SELECT Id FROM "
+                + TEST_INDEX_BEER + " WHERE query_string(['Tags'],'taste')";
+        JSONObject result2 = executeJdbcRequest(query2);
+        assertEquals(result2.getInt("total"), result1.getInt("total"));
+    }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -34,6 +34,7 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.Matc
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhraseQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MultiMatchQuery;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.QueryQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.QueryStringQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.SimpleQueryStringQuery;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
@@ -60,7 +61,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.MATCH.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_PHRASE.getName(), new MatchPhraseQuery())
           .put(BuiltinFunctionName.MATCHPHRASE.getName(), new MatchPhraseQuery())
-          .put(BuiltinFunctionName.QUERY.getName(), new MatchQuery())
+          .put(BuiltinFunctionName.QUERY.getName(), new QueryQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MULTI_MATCH.getName(), new MultiMatchQuery())

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+
+/**
+ * Base class to represent relevance queries that search multiple fields.
+ *
+ * @param <T> The builder class for the OpenSearch query.
+ */
+abstract class NoFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T> {
+  public NoFieldQuery(Map<String, QueryBuilderStep<T>> queryBuildActions) {
+    super(queryBuildActions);
+  }
+
+  @Override
+  protected void ignoreArguments(List<NamedArgumentExpression> arguments) {
+    arguments.removeIf(a -> a.getArgName().equalsIgnoreCase("query"));
+  }
+
+  @Override
+  protected void checkValidArguments(String argNormalized, T queryBuilder) {
+    if (!getQueryBuildActions().containsKey(argNormalized)) {
+      throw new SemanticCheckException(
+              String.format("Parameter %s is invalid for %s function.",
+                      argNormalized, getQueryName()));
+    }
+  }
+  /**
+   * Override build function because RelevanceQuery requires 2 fields,
+   * but NoFieldQuery must have no fields.
+   *
+   * @param func : Contains function name and passed in arguments.
+   * @return : QueryBuilder object
+   */
+
+  @Override
+  public QueryBuilder build(FunctionExpression func) {
+    var arguments = func.getArguments().stream().map(
+        a -> (NamedArgumentExpression) a).collect(Collectors.toList());
+    if (arguments.size() < 1) {
+      throw new SyntaxCheckException(String.format(
+          "%s requires at least one parameter", func.getFunctionName()));
+    }
+
+    return loadArguments(arguments);
+  }
+
+
+  @Override
+  public T createQueryBuilder(List<NamedArgumentExpression> arguments) {
+    // Extract 'query'
+    var query = arguments.stream().filter(a -> a.getArgName().equalsIgnoreCase("query")).findFirst()
+        .orElseThrow(() -> new SemanticCheckException("'query' parameter is missing"));
+
+    return createBuilder(query.getValue().valueOf(null).stringValue());
+  }
+
+  protected abstract T createBuilder(String query);
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/QueryQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/QueryQuery.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+
+/**
+ * Class for Lucene query that builds the query_string query.
+ */
+public class QueryQuery extends NoFieldQuery<QueryStringQueryBuilder> {
+
+  final String queryQueryName = "query";
+
+  /**
+   * Default constructor for QueryQuery configures how RelevanceQuery.build() handles
+   * named arguments by calling the constructor of QueryStringQuery.
+   */
+  public QueryQuery() {
+    super(FunctionParameterRepository.QueryStringQueryBuildActions);
+  }
+
+  /**
+   * Builds QueryBuilder with query value and other default parameter values set.
+   *
+   * @param query : Query value for query_string query
+   * @return : Builder for query query
+   */
+  protected QueryStringQueryBuilder createBuilder(String query) {
+    return QueryBuilders.queryStringQuery(query);
+  }
+
+  @Override
+  public String getQueryName() {
+    return queryQueryName;
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
@@ -24,17 +25,24 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
  */
 @RequiredArgsConstructor
 public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery {
+  @Getter
   private final Map<String, QueryBuilderStep<T>> queryBuildActions;
 
-  @Override
-  public QueryBuilder build(FunctionExpression func) {
-    var arguments = func.getArguments().stream()
-        .map(a -> (NamedArgumentExpression)a).collect(Collectors.toList());
-    if (arguments.size() < 2) {
-      throw new SyntaxCheckException(
-          String.format("%s requires at least two parameters", getQueryName()));
-    }
+  protected void ignoreArguments(List<NamedArgumentExpression> arguments) {
+    arguments.removeIf(a -> a.getArgName().equalsIgnoreCase("field")
+            || a.getArgName().equalsIgnoreCase("fields")
+            || a.getArgName().equalsIgnoreCase("query"));
+  }
 
+  protected void checkValidArguments(String argNormalized, T queryBuilder) {
+    if (!queryBuildActions.containsKey(argNormalized)) {
+      throw new SemanticCheckException(
+              String.format("Parameter %s is invalid for %s function.",
+                      argNormalized, queryBuilder.getWriteableName()));
+    }
+  }
+
+  protected T loadArguments(List<NamedArgumentExpression> arguments) throws SemanticCheckException {
     // Aggregate parameters by name, so getting a Map<Name:String, List>
     arguments.stream().collect(Collectors.groupingBy(a -> a.getArgName().toLowerCase()))
         .forEach((k, v) -> {
@@ -46,31 +54,44 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
 
     T queryBuilder = createQueryBuilder(arguments);
 
-    arguments.removeIf(a -> a.getArgName().equalsIgnoreCase("field")
-        || a.getArgName().equalsIgnoreCase("fields")
-        || a.getArgName().equalsIgnoreCase("query"));
+    ignoreArguments(arguments);
 
     var iterator = arguments.listIterator();
     while (iterator.hasNext()) {
       NamedArgumentExpression arg = iterator.next();
       String argNormalized = arg.getArgName().toLowerCase();
 
-      if (!queryBuildActions.containsKey(argNormalized)) {
-        throw new SemanticCheckException(
-            String.format("Parameter %s is invalid for %s function.",
-                argNormalized, queryBuilder.getWriteableName()));
-      }
+      checkValidArguments(argNormalized, queryBuilder);
+
       (Objects.requireNonNull(
           queryBuildActions
               .get(argNormalized)))
           .apply(queryBuilder, arg.getValue().valueOf(null));
     }
+
     return queryBuilder;
+  }
+
+  @Override
+  public QueryBuilder build(FunctionExpression func) {
+    var arguments = func.getArguments().stream()
+        .map(a -> (NamedArgumentExpression)a).collect(Collectors.toList());
+    if (arguments.size() < 2) {
+      throw new SyntaxCheckException(
+          String.format("%s requires at least two parameters", getQueryName()));
+    }
+
+    return loadArguments(arguments);
+
   }
 
   protected abstract T createQueryBuilder(List<NamedArgumentExpression> arguments);
 
   protected abstract String getQueryName();
+
+  public Map<String, QueryBuilderStep<T>> getQueryBuildActions() {
+    return queryBuildActions;
+  }
 
   /**
    * Convenience interface for a function that updates a QueryBuilder

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -48,7 +48,6 @@ import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
-import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
@@ -412,6 +411,15 @@ class FilterQueryBuilderTest {
   }
 
   @Test
+  void match_missing_query() {
+    FunctionExpression expr = dsl.match(
+            dsl.namedArgument("field", literal("field1")),
+            dsl.namedArgument("analyzer", literal("keyword")));
+    var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
+    assertEquals("'query' parameter is missing", msg);
+  }
+
+  @Test
   void should_build_match_phrase_query_with_default_parameters() {
     assertJsonEquals(
             "{\n"
@@ -624,6 +632,93 @@ class FilterQueryBuilderTest {
                 dsl.namedArgument("analyzer", literal("keyword")),
                 dsl.namedArgument("slop", literal("2")),
                 dsl.namedArgument("zero_terms_query", literal("ALL")))));
+  }
+
+  @Test
+  void query_invalid_parameter() {
+    FunctionExpression expr = dsl.query(
+            dsl.namedArgument("invalid_parameter", literal("invalid_value")));
+    assertThrows(SemanticCheckException.class, () -> buildQuery(expr),
+            "Parameter invalid_parameter is invalid for query function.");
+  }
+
+  @Test
+  void query_invalid_fields_parameter_exception_message() {
+    FunctionExpression expr = dsl.query(
+        dsl.namedArgument("fields", literal("field1")),
+        dsl.namedArgument("query", literal("search query")));
+
+    var exception = assertThrows(SemanticCheckException.class, () -> buildQuery(expr));
+    assertEquals("Parameter fields is invalid for query function.", exception.getMessage());
+  }
+
+  @Test
+  void should_build_query_query_with_default_parameters() {
+    var expected = "{\n"
+            + "  \"query_string\" : {\n"
+            + "    \"query\" : \"field1:query_value\",\n"
+            + "    \"fields\" : [],\n"
+            + "    \"type\" : \"best_fields\",\n"
+            + "    \"default_operator\" : \"or\",\n"
+            + "    \"max_determinized_states\" : 10000,\n"
+            + "    \"enable_position_increments\" : true,\n"
+            + "    \"fuzziness\" : \"AUTO\",\n"
+            + "    \"fuzzy_prefix_length\" : 0,\n"
+            + "    \"fuzzy_max_expansions\" : 50,\n"
+            + "    \"phrase_slop\" : 0,\n"
+            + "    \"escape\" : false,\n"
+            + "    \"auto_generate_synonyms_phrase_query\" : true,\n"
+            + "    \"fuzzy_transpositions\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+
+    assertJsonEquals(expected, buildQuery(dsl.query(
+            dsl.namedArgument("query", literal("field1:query_value")))));
+  }
+
+  @Test
+  void should_build_query_query_with_custom_parameters() {
+    var expected = "{\n"
+            + "  \"query_string\" : {\n"
+            + "    \"query\" : \"field1:query_value\",\n"
+            + "    \"fields\" : [],\n"
+            + "    \"type\" : \"cross_fields\",\n"
+            + "    \"tie_breaker\" : 1.3,\n"
+            + "    \"default_operator\" : \"and\",\n"
+            + "    \"analyzer\" : \"keyword\",\n"
+            + "    \"max_determinized_states\" : 10000,\n"
+            + "    \"enable_position_increments\" : true,\n"
+            + "    \"fuzziness\" : \"AUTO\",\n"
+            + "    \"fuzzy_prefix_length\" : 2,\n"
+            + "    \"fuzzy_max_expansions\" : 10,\n"
+            + "    \"phrase_slop\" : 0,\n"
+            + "    \"analyze_wildcard\" : true,\n"
+            + "    \"minimum_should_match\" : \"3\",\n"
+            + "    \"lenient\" : false,\n"
+            + "    \"escape\" : false,\n"
+            + "    \"auto_generate_synonyms_phrase_query\" : false,\n"
+            + "    \"fuzzy_transpositions\" : false,\n"
+            + "    \"boost\" : 2.0,\n"
+            + "  }\n"
+            + "}";
+    var actual = buildQuery(
+            dsl.query(
+                    dsl.namedArgument("query", literal("field1:query_value")),
+                    dsl.namedArgument("analyze_wildcard", literal("true")),
+                    dsl.namedArgument("analyzer", literal("keyword")),
+                    dsl.namedArgument("auto_generate_synonyms_phrase_query", literal("false")),
+                    dsl.namedArgument("default_operator", literal("AND")),
+                    dsl.namedArgument("fuzzy_max_expansions", literal("10")),
+                    dsl.namedArgument("fuzzy_prefix_length", literal("2")),
+                    dsl.namedArgument("fuzzy_transpositions", literal("false")),
+                    dsl.namedArgument("lenient", literal("false")),
+                    dsl.namedArgument("minimum_should_match", literal("3")),
+                    dsl.namedArgument("tie_breaker", literal("1.3")),
+                    dsl.namedArgument("type", literal("cross_fields")),
+                    dsl.namedArgument("boost", literal("2.0"))));
+
+    assertJsonEquals(expected, actual);
   }
 
   @Test
@@ -979,6 +1074,18 @@ class FilterQueryBuilderTest {
         dsl.namedArgument("analyzer", literal("keyword")));
     var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
     assertEquals("'fields' parameter is missing.", msg);
+  }
+
+  @Test
+  void multi_match_missing_query_even_with_struct() {
+    FunctionExpression expr = dsl.multi_match(
+            dsl.namedArgument("fields", DSL.literal(
+                    new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
+                            "field1", ExprValueUtils.floatValue(1.F),
+                            "field2", ExprValueUtils.floatValue(.3F)))))),
+            dsl.namedArgument("analyzer", literal("keyword")));
+    var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
+    assertEquals("'query' parameter is missing", msg);
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/QueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/QueryTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.QueryQuery;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class QueryTest {
+  private static final DSL dsl = new ExpressionConfig()
+      .dsl(new ExpressionConfig().functionRepository());
+  private final QueryQuery queryQuery = new QueryQuery();
+  private final FunctionName queryFunc = FunctionName.of("query");
+  private static final LiteralExpression query_value = DSL.literal("title:query_value");
+
+  static Stream<List<Expression>> generateValidData() {
+    Expression query = dsl.namedArgument("query", query_value);
+    return List.of(
+        dsl.namedArgument("analyzer", DSL.literal("standard")),
+        dsl.namedArgument("analyze_wildcard", DSL.literal("true")),
+        dsl.namedArgument("allow_leading_wildcard", DSL.literal("true")),
+        dsl.namedArgument("auto_generate_synonyms_phrase_query", DSL.literal("true")),
+        dsl.namedArgument("boost", DSL.literal("1")),
+        dsl.namedArgument("default_operator", DSL.literal("AND")),
+        dsl.namedArgument("default_operator", DSL.literal("and")),
+        dsl.namedArgument("enable_position_increments", DSL.literal("true")),
+        dsl.namedArgument("escape", DSL.literal("false")),
+        dsl.namedArgument("fuzziness", DSL.literal("1")),
+        dsl.namedArgument("fuzzy_rewrite", DSL.literal("constant_score")),
+        dsl.namedArgument("fuzzy_max_expansions", DSL.literal("42")),
+        dsl.namedArgument("fuzzy_prefix_length", DSL.literal("42")),
+        dsl.namedArgument("fuzzy_transpositions", DSL.literal("true")),
+        dsl.namedArgument("lenient", DSL.literal("true")),
+        dsl.namedArgument("max_determinized_states", DSL.literal("10000")),
+        dsl.namedArgument("minimum_should_match", DSL.literal("4")),
+        dsl.namedArgument("quote_analyzer", DSL.literal("standard")),
+        dsl.namedArgument("phrase_slop", DSL.literal("0")),
+        dsl.namedArgument("quote_field_suffix", DSL.literal(".exact")),
+        dsl.namedArgument("rewrite", DSL.literal("constant_score")),
+        dsl.namedArgument("type", DSL.literal("best_fields")),
+        dsl.namedArgument("tie_breaker", DSL.literal("0.3")),
+        dsl.namedArgument("time_zone", DSL.literal("Canada/Pacific")),
+        dsl.namedArgument("ANALYZER", DSL.literal("standard")),
+        dsl.namedArgument("ANALYZE_wildcard", DSL.literal("true")),
+        dsl.namedArgument("Allow_Leading_wildcard", DSL.literal("true")),
+        dsl.namedArgument("Auto_Generate_Synonyms_Phrase_Query", DSL.literal("true")),
+        dsl.namedArgument("Boost", DSL.literal("1"))
+    ).stream().map(arg -> List.of(query, arg));
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateValidData")
+  public void test_valid_parameters(List<Expression> validArgs) {
+    Assertions.assertNotNull(queryQuery.build(
+        new QueryExpression(validArgs)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_no_arguments() {
+    List<Expression> arguments = List.of();
+    assertThrows(SyntaxCheckException.class,
+        () -> queryQuery.build(new QueryExpression(arguments)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_field_argument() {
+    List<Expression> arguments = List.of(
+        namedArgument("fields", "invalid argument"),
+        namedArgument("query", query_value));
+    assertThrows(SemanticCheckException.class,
+        () -> queryQuery.build(new QueryExpression(arguments)));
+  }
+
+  @Test
+  public void test_SemanticCheckException_when_invalid_parameter() {
+    List<Expression> arguments = List.of(
+        namedArgument("query", query_value),
+        namedArgument("unsupported", "unsupported_value"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> queryQuery.build(new QueryExpression(arguments)));
+  }
+
+  @Test
+  public void test_SemanticCheckException_when_sending_parameter_multiple_times() {
+    List<Expression> arguments = List.of(
+            namedArgument("query", query_value),
+            namedArgument("allow_leading_wildcard", DSL.literal("true")),
+            namedArgument("allow_leading_wildcard", DSL.literal("true")));
+    Assertions.assertThrows(SemanticCheckException.class,
+            () -> queryQuery.build(new QueryExpression(arguments)));
+  }
+
+  private NamedArgumentExpression namedArgument(String name, String value) {
+    return dsl.namedArgument(name, DSL.literal(value));
+  }
+
+  private NamedArgumentExpression namedArgument(String name, LiteralExpression value) {
+    return dsl.namedArgument(name, value);
+  }
+
+  private class QueryExpression extends FunctionExpression {
+    public QueryExpression(List<Expression> arguments) {
+      super(QueryTest.this.queryFunc, arguments);
+    }
+
+    @Override
+    public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+      throw new UnsupportedOperationException("Invalid function call, "
+          + "valueOf function need implementation only to support Expression interface");
+    }
+
+    @Override
+    public ExprType type() {
+      throw new UnsupportedOperationException("Invalid function call, "
+          + "type function need implementation only to support Expression interface");
+    }
+  }
+
+  @Test
+  public void test_can_get_query_name() {
+    List<Expression> arguments = List.of(namedArgument("query", query_value));
+    queryQuery.build(new QueryExpression(arguments));
+    Assertions.assertEquals("query",
+            queryQuery.getQueryName());
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQueryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.config.ExpressionConfig;
+
+class NoFieldQueryTest {
+  NoFieldQuery query;
+  private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+  private final String testQueryName = "test_query";
+  private final Map<String, RelevanceQuery.QueryBuilderStep> actionMap
+      = ImmutableMap.of("paramA", (o, v) -> o);
+
+  @BeforeEach
+  void setUp() {
+    query = mock(NoFieldQuery.class,
+        Mockito.withSettings().useConstructor(actionMap)
+            .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    when(query.getQueryName()).thenReturn(testQueryName);
+  }
+
+  @Test
+  void createQueryBuilderTest() {
+    String sampleQuery = "field:query";
+
+    query.createQueryBuilder(List.of(
+        dsl.namedArgument("query",
+            new LiteralExpression(ExprValueUtils.stringValue(sampleQuery)))));
+
+    verify(query).createBuilder(eq(sampleQuery));
+  }
+}

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -335,7 +335,11 @@ specificFunction
     ;
 
 relevanceFunction
-    : singleFieldRelevanceFunction | multiFieldRelevanceFunction
+    : noFieldRelevanceFunction | singleFieldRelevanceFunction | multiFieldRelevanceFunction
+    ;
+
+noFieldRelevanceFunction
+    : noFieldRelevanceFunctionName LR_BRACKET query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
     ;
 
 // Field is a single column
@@ -416,6 +420,10 @@ textFunctionName
 
 flowControlFunctionName
     : IF | IFNULL | NULLIF | ISNULL
+    ;
+
+noFieldRelevanceFunctionName
+    : QUERY
     ;
 
 systemFunctionName

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -382,6 +382,14 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   }
 
   @Override
+  public UnresolvedExpression visitNoFieldRelevanceFunction(
+          OpenSearchSQLParser.NoFieldRelevanceFunctionContext ctx) {
+    return new Function(
+            ctx.noFieldRelevanceFunctionName().getText().toLowerCase(),
+            noFieldRelevanceArguments(ctx));
+  }
+
+  @Override
   public UnresolvedExpression visitSingleFieldRelevanceFunction(
       SingleFieldRelevanceFunctionContext ctx) {
     return new Function(
@@ -438,6 +446,24 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     );
   }
 
+  private void fillRelevanceArgs(List<OpenSearchSQLParser.RelevanceArgContext> args,
+                                 ImmutableList.Builder<UnresolvedExpression> builder) {
+    args.forEach(v -> builder.add(new UnresolvedArgument(
+            v.relevanceArgName().getText().toLowerCase(), new Literal(StringUtils.unquoteText(
+                    v.relevanceArgValue().getText()), DataType.STRING))));
+  }
+
+  private List<UnresolvedExpression> noFieldRelevanceArguments(
+          OpenSearchSQLParser.NoFieldRelevanceFunctionContext ctx) {
+    // all the arguments are defaulted to string values
+    // to skip environment resolving and function signature resolving
+    ImmutableList.Builder<UnresolvedExpression> builder = ImmutableList.builder();
+    builder.add(new UnresolvedArgument("query",
+            new Literal(StringUtils.unquoteText(ctx.query.getText()), DataType.STRING)));
+    fillRelevanceArgs(ctx.relevanceArg(), builder);
+    return builder.build();
+  }
+
   private List<UnresolvedExpression> singleFieldRelevanceArguments(
         OpenSearchSQLParser.SingleFieldRelevanceFunctionContext ctx) {
     // all the arguments are defaulted to string values
@@ -447,11 +473,11 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
         new Literal(StringUtils.unquoteText(ctx.field.getText()), DataType.STRING)));
     builder.add(new UnresolvedArgument("query",
         new Literal(StringUtils.unquoteText(ctx.query.getText()), DataType.STRING)));
-    ctx.relevanceArg().forEach(v -> builder.add(new UnresolvedArgument(
-        v.relevanceArgName().getText().toLowerCase(), new Literal(StringUtils.unquoteText(
-            v.relevanceArgValue().getText()), DataType.STRING))));
+    fillRelevanceArgs(ctx.relevanceArg(), builder);
     return builder.build();
   }
+
+
 
   private List<UnresolvedExpression> multiFieldRelevanceArguments(
       OpenSearchSQLParser.MultiFieldRelevanceFunctionContext ctx) {
@@ -467,9 +493,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     builder.add(new UnresolvedArgument("fields", fields));
     builder.add(new UnresolvedArgument("query",
         new Literal(StringUtils.unquoteText(ctx.query.getText()), DataType.STRING)));
-    ctx.relevanceArg().forEach(v -> builder.add(new UnresolvedArgument(
-        v.relevanceArgName().getText().toLowerCase(), new Literal(StringUtils.unquoteText(
-            v.relevanceArgValue().getText()), DataType.STRING))));
+    fillRelevanceArgs(ctx.relevanceArg(), builder);
     return builder.build();
   }
 }

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -325,6 +325,49 @@ class SQLSyntaxParserTest {
             + "operator='AND', tie_breaker=0.3, type = \"most_fields\", fuzziness = 4)"));
   }
 
+
+  @Test
+  public void can_parse_query_relevance_function() {
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query('address:query')"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query('address:query OR notes:query')"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(\"address:query\")"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(\"address:query OR notes:query\")"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(`address:query`)"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(`address:query OR notes:query`)"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query('*:query')"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(\"*:query\")"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(`*:query`)"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query('address:*uery OR notes:?uery')"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(\"address:*uery OR notes:?uery\")"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(`address:*uery OR notes:?uery`)"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query('address:qu*ry OR notes:qu?ry')"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(\"address:qu*ry OR notes:qu?ry\")"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(`address:qu*ry OR notes:qu?ry`)"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query('address:query notes:query')"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE query(\"address:query notes:query\")"));
+    assertNotNull(parser.parse(
+            "SELECT id FROM test WHERE "
+                    + "query(\"Body:\'taste beer\' Tags:\'taste beer\'  Title:\'taste beer\'\")"));
+  }
+
+
   @Test
   public void can_parse_match_relevance_function() {
     assertNotNull(parser.parse("SELECT * FROM test WHERE match(column, \"this is a test\")"));

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -544,6 +544,22 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void relevanceQuery() {
+    assertEquals(AstDSL.function("query",
+                    unresolvedArg("query", stringLiteral("field1:query OR field2:query"))),
+            buildExprAst("query('field1:query OR field2:query')")
+    );
+
+    assertEquals(AstDSL.function("query",
+                    unresolvedArg("query", stringLiteral("search query")),
+                    unresolvedArg("analyzer", stringLiteral("keyword")),
+                    unresolvedArg("time_zone", stringLiteral("Canada/Pacific")),
+                    unresolvedArg("tie_breaker", stringLiteral("1.3"))),
+            buildExprAst("query('search query',"
+                    + "analyzer='keyword', time_zone='Canada/Pacific', tie_breaker='1.3')"));
+  }
+
+  @Test
   public void canBuildInClause() {
     assertEquals(
         AstDSL.in(qualifiedName("age"), AstDSL.intLiteral(20), AstDSL.intLiteral(30)),


### PR DESCRIPTION
### Description
Added query function to SQL plugin. Achieved by routing function calls from the SQL plugin to the query_string function which currently exists in OpenSearch.
 
Currently blocked by https://github.com/opensearch-project/sql/pull/839. PR to upstream will be made once PR #839 is merged.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).