### PR TITLE
Add datetime aggregation fixes

### DIFF
--- a/core/src/main/java/org/opensearch/sql/data/model/ExprDateValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprDateValue.java
@@ -11,7 +11,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -67,7 +66,7 @@ public class ExprDateValue extends AbstractExprValue {
 
   @Override
   public Instant timestampValue() {
-    return ZonedDateTime.of(date, timeValue(), ZoneId.systemDefault()).toInstant();
+    return ZonedDateTime.of(date, timeValue(), ExprTimestampValue.ZONE).toInstant();
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprDatetimeValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprDatetimeValue.java
@@ -11,7 +11,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -71,7 +70,7 @@ public class ExprDatetimeValue extends AbstractExprValue {
 
   @Override
   public Instant timestampValue() {
-    return ZonedDateTime.of(datetime, ZoneId.of("UTC")).toInstant();
+    return ZonedDateTime.of(datetime, ExprTimestampValue.ZONE).toInstant();
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
@@ -30,7 +30,7 @@ public class ExprTimestampValue extends AbstractExprValue {
   /**
    * todo. only support UTC now.
    */
-  private static final ZoneId ZONE = ZoneId.of("UTC");
+  public static final ZoneId ZONE = ZoneId.of("UTC");
 
   private final Instant timestamp;
 

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java
@@ -69,6 +69,14 @@ public class AggregatorFunction {
         new ImmutableMap.Builder<FunctionSignature, FunctionBuilder>()
             .put(new FunctionSignature(functionName, Collections.singletonList(DOUBLE)),
                 arguments -> new AvgAggregator(arguments, DOUBLE))
+            .put(new FunctionSignature(functionName, Collections.singletonList(DATE)),
+                arguments -> new AvgAggregator(arguments, DATE))
+            .put(new FunctionSignature(functionName, Collections.singletonList(DATETIME)),
+                arguments -> new AvgAggregator(arguments, DATETIME))
+            .put(new FunctionSignature(functionName, Collections.singletonList(TIME)),
+                arguments -> new AvgAggregator(arguments, TIME))
+            .put(new FunctionSignature(functionName, Collections.singletonList(TIMESTAMP)),
+                arguments -> new AvgAggregator(arguments, TIMESTAMP))
             .build()
     );
   }

--- a/core/src/test/java/org/opensearch/sql/data/model/DateTimeValueTest.java
+++ b/core/src/test/java/org/opensearch/sql/data/model/DateTimeValueTest.java
@@ -15,7 +15,6 @@ import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
@@ -43,7 +42,7 @@ public class DateTimeValueTest {
 
     assertEquals(TIMESTAMP, timestampValue.type());
     assertEquals(ZonedDateTime.of(LocalDateTime.parse("2020-07-07T01:01:01"),
-        ZoneId.of("UTC")).toInstant(), timestampValue.timestampValue());
+        ExprTimestampValue.ZONE).toInstant(), timestampValue.timestampValue());
     assertEquals("2020-07-07 01:01:01", timestampValue.value());
     assertEquals("TIMESTAMP '2020-07-07 01:01:01'", timestampValue.toString());
     assertEquals(LocalDate.parse("2020-07-07"), timestampValue.dateValue());
@@ -61,7 +60,7 @@ public class DateTimeValueTest {
     assertEquals(LocalTime.parse("00:00:00"), dateValue.timeValue());
     assertEquals(LocalDateTime.parse("2012-07-07T00:00:00"), dateValue.datetimeValue());
     assertEquals(ZonedDateTime.of(LocalDateTime.parse("2012-07-07T00:00:00"),
-        ZoneId.systemDefault()).toInstant(), dateValue.timestampValue());
+        ExprTimestampValue.ZONE).toInstant(), dateValue.timestampValue());
     ExpressionEvaluationException exception =
         assertThrows(ExpressionEvaluationException.class, () -> integerValue(1).dateValue());
     assertEquals("invalid to get dateValue from value of type INTEGER",
@@ -76,7 +75,7 @@ public class DateTimeValueTest {
     assertEquals(LocalDate.parse("2020-08-17"), datetimeValue.dateValue());
     assertEquals(LocalTime.parse("19:44:00"), datetimeValue.timeValue());
     assertEquals(ZonedDateTime.of(LocalDateTime.parse("2020-08-17T19:44:00"),
-        ZoneId.of("UTC")).toInstant(), datetimeValue.timestampValue());
+        ExprTimestampValue.ZONE).toInstant(), datetimeValue.timestampValue());
     assertEquals("DATETIME '2020-08-17 19:44:00'", datetimeValue.toString());
     assertThrows(ExpressionEvaluationException.class, () -> integerValue(1).datetimeValue(),
         "invalid to get datetimeValue from value of type INTEGER");

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -163,7 +163,7 @@ SUM
 Description
 >>>>>>>>>>>
 
-Usage: SUM(expr). Returns the sum of expr.
+Usage: SUM(expr). Returns the sum of `expr`. `expr` could be of any of the numeric data types.
 
 Example::
 
@@ -182,7 +182,7 @@ AVG
 Description
 >>>>>>>>>>>
 
-Usage: AVG(expr). Returns the average value of expr.
+Usage: AVG(expr). Returns the average value of `expr`. `expr` could be of any of the numeric and datetime data types. Datetime aggregation perfomed with milliseconds precision.
 
 Example::
 
@@ -201,7 +201,7 @@ MAX
 Description
 >>>>>>>>>>>
 
-Usage: MAX(expr). Returns the maximum value of expr.
+Usage: MAX(expr). Returns the maximum value of `expr`. `expr` could be of any of the numeric and datetime data types. Datetime aggregation perfomed with milliseconds precision.
 
 Example::
 
@@ -219,7 +219,7 @@ MIN
 Description
 >>>>>>>>>>>
 
-Usage: MIN(expr). Returns the minimum value of expr.
+Usage: MIN(expr). Returns the minimum value of `expr`. `expr` could be of any of the numeric and datetime data types. Datetime aggregation perfomed with milliseconds precision.
 
 Example::
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java
@@ -162,13 +162,68 @@ public class AggregationIT extends SQLIntegTestCase {
   }
 
   @Test
-  public void testPushDownAggregationOnNullValuesReturnsNull() throws IOException {
+  public void testPushDownAggregationOnNullNumericValuesReturnsNull() throws IOException {
     var response = executeQuery(String.format("SELECT "
         + "max(int0), min(int0), avg(int0) from %s where int0 IS NULL;", TEST_INDEX_CALCS));
     verifySchema(response,
         schema("max(int0)", null, "integer"),
         schema("min(int0)", null, "integer"),
         schema("avg(int0)", null, "double"));
+    verifyDataRows(response, rows(null, null, null));
+  }
+
+  @Test
+  public void testPushDownAggregationOnNullDateTimeValuesFromTableReturnsNull() throws IOException {
+    var response = executeQuery(String.format("SELECT "
+        + "max(datetime1), min(datetime1), avg(datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(datetime1)", null, "timestamp"),
+        schema("min(datetime1)", null, "timestamp"),
+        schema("avg(datetime1)", null, "timestamp"));
+    verifyDataRows(response, rows(null, null, null));
+  }
+
+  @Test
+  public void testPushDownAggregationOnNullDateValuesReturnsNull() throws IOException {
+    var response = executeQuery(String.format("SELECT "
+        + "max(CAST(NULL AS date)), min(CAST(NULL AS date)), avg(CAST(NULL AS date)) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(CAST(NULL AS date))", null, "date"),
+        schema("min(CAST(NULL AS date))", null, "date"),
+        schema("avg(CAST(NULL AS date))", null, "date"));
+    verifyDataRows(response, rows(null, null, null));
+  }
+
+  @Test
+  public void testPushDownAggregationOnNullTimeValuesReturnsNull() throws IOException {
+    var response = executeQuery(String.format("SELECT "
+        + "max(CAST(NULL AS time)), min(CAST(NULL AS time)), avg(CAST(NULL AS time)) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(CAST(NULL AS time))", null, "time"),
+        schema("min(CAST(NULL AS time))", null, "time"),
+        schema("avg(CAST(NULL AS time))", null, "time"));
+    verifyDataRows(response, rows(null, null, null));
+  }
+
+  @Test
+  public void testPushDownAggregationOnNullTimeStampValuesReturnsNull() throws IOException {
+    var response = executeQuery(String.format("SELECT "
+        + "max(CAST(NULL AS timestamp)), min(CAST(NULL AS timestamp)), avg(CAST(NULL AS timestamp)) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(CAST(NULL AS timestamp))", null, "timestamp"),
+        schema("min(CAST(NULL AS timestamp))", null, "timestamp"),
+        schema("avg(CAST(NULL AS timestamp))", null, "timestamp"));
+    verifyDataRows(response, rows(null, null, null));
+  }
+
+  @Test
+  public void testPushDownAggregationOnNullDateTimeValuesReturnsNull() throws IOException {
+    var response = executeQuery(String.format("SELECT "
+        + "max(datetime(NULL)), min(datetime(NULL)), avg(datetime(NULL)) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(datetime(NULL))", null, "datetime"),
+        schema("min(datetime(NULL))", null, "datetime"),
+        schema("avg(datetime(NULL))", null, "datetime"));
     verifyDataRows(response, rows(null, null, null));
   }
 
@@ -223,6 +278,303 @@ public class AggregationIT extends SQLIntegTestCase {
           ((Number)responsePushDown.query("/datarows/0/" + i)).doubleValue(),
           0.0000001); // a minor delta is affordable
     }
+  }
+
+  public void testMinIntegerPushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT min(int2)"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("min(int2)", null, "integer"));
+    verifyDataRows(response, rows(-9));
+  }
+
+  @Test
+  public void testMaxIntegerPushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT max(int2)"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("max(int2)", null, "integer"));
+    verifyDataRows(response, rows(9));
+  }
+
+  @Test
+  public void testAvgIntegerPushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(int2)"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("avg(int2)", null, "double"));
+    verifyDataRows(response, rows(-0.8235294117647058D));
+  }
+
+  @Test
+  public void testMinDoublePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT min(num3)"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("min(num3)", null, "double"));
+    verifyDataRows(response, rows(-19.96D));
+  }
+
+  @Test
+  public void testMaxDoublePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT max(num3)"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("max(num3)", null, "double"));
+    verifyDataRows(response, rows(12.93D));
+  }
+
+  @Test
+  public void testAvgDoublePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(num3)"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("avg(num3)", null, "double"));
+    verifyDataRows(response, rows(-6.12D));
+  }
+
+  @Test
+  public void testMinIntegerInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT min(int2)"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("min(int2) OVER(PARTITION BY datetime1)", null, "integer"));
+    verifySome(response.getJSONArray("datarows"), rows(-9));
+  }
+
+  @Test
+  public void testMaxIntegerInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT max(int2)"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(int2) OVER(PARTITION BY datetime1)", null, "integer"));
+    verifySome(response.getJSONArray("datarows"), rows(9));
+  }
+
+  @Test
+  public void testAvgIntegerInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(int2)"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("avg(int2) OVER(PARTITION BY datetime1)", null, "double"));
+    verifySome(response.getJSONArray("datarows"), rows(-0.8235294117647058D));
+  }
+
+  @Test
+  public void testMinDoubleInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT min(num3)"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("min(num3) OVER(PARTITION BY datetime1)", null, "double"));
+    verifySome(response.getJSONArray("datarows"), rows(-19.96D));
+  }
+
+  @Test
+  public void testMaxDoubleInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT max(num3)"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(num3) OVER(PARTITION BY datetime1)", null, "double"));
+    verifySome(response.getJSONArray("datarows"), rows(12.93D));
+  }
+
+  @Test
+  public void testAvgDoubleInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(num3)"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("avg(num3) OVER(PARTITION BY datetime1)", null, "double"));
+    verifySome(response.getJSONArray("datarows"), rows(-6.12D));
+  }
+
+  @Test
+  public void testMaxDatePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT max(CAST(date0 AS date))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("max(CAST(date0 AS date))", null, "date"));
+    verifyDataRows(response, rows("2004-06-19"));
+  }
+
+  @Test
+  public void testAvgDatePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(CAST(date0 AS date))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("avg(CAST(date0 AS date))", null, "date"));
+    verifyDataRows(response, rows("1992-04-23"));
+  }
+
+  @Test
+  public void testMinDateTimePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT min(datetime(CAST(time0 AS STRING)))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("min(datetime(CAST(time0 AS STRING)))", null, "datetime"));
+    verifyDataRows(response, rows("1899-12-30 21:07:32"));
+  }
+
+  @Test
+  public void testMaxDateTimePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT max(datetime(CAST(time0 AS STRING)))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("max(datetime(CAST(time0 AS STRING)))", null, "datetime"));
+    verifyDataRows(response, rows("1900-01-01 20:36:00"));
+  }
+
+  @Test
+  public void testAvgDateTimePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(datetime(CAST(time0 AS STRING)))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("avg(datetime(CAST(time0 AS STRING)))", null, "datetime"));
+    verifyDataRows(response, rows("1900-01-01 03:35:00.236"));
+  }
+
+  @Test
+  public void testMinTimePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT min(CAST(time1 AS time))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("min(CAST(time1 AS time))", null, "time"));
+    verifyDataRows(response, rows("00:05:57"));
+  }
+
+  @Test
+  public void testMaxTimePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT max(CAST(time1 AS time))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("max(CAST(time1 AS time))", null, "time"));
+    verifyDataRows(response, rows("22:50:16"));
+  }
+
+  @Test
+  public void testAvgTimePushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(CAST(time1 AS time))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("avg(CAST(time1 AS time))", null, "time"));
+    verifyDataRows(response, rows("13:06:36.25"));
+  }
+
+  @Test
+  public void testMinTimeStampPushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT min(CAST(datetime0 AS timestamp))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("min(CAST(datetime0 AS timestamp))", null, "timestamp"));
+    verifyDataRows(response, rows("2004-07-04 22:49:28"));
+  }
+
+  @Test
+  public void testMaxTimeStampPushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT max(CAST(datetime0 AS timestamp))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("max(CAST(datetime0 AS timestamp))", null, "timestamp"));
+    verifyDataRows(response, rows("2004-08-02 07:59:23"));
+  }
+
+  @Test
+  public void testAvgTimeStampPushedDown() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(CAST(datetime0 AS timestamp))"
+        + " from %s", TEST_INDEX_CALCS));
+    verifySchema(response, schema("avg(CAST(datetime0 AS timestamp))", null, "timestamp"));
+    verifyDataRows(response, rows("2004-07-20 10:38:09.705"));
+  }
+
+  @Test
+  public void testMinDateInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT min(CAST(date0 AS date))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("min(CAST(date0 AS date)) OVER(PARTITION BY datetime1)", null, "date"));
+    verifySome(response.getJSONArray("datarows"), rows("1972-07-04"));
+  }
+
+  @Test
+  public void testMaxDateInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT max(CAST(date0 AS date))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(CAST(date0 AS date)) OVER(PARTITION BY datetime1)", null, "date"));
+    verifySome(response.getJSONArray("datarows"), rows("2004-06-19"));
+  }
+
+  @Test
+  public void testAvgDateInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(CAST(date0 AS date))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("avg(CAST(date0 AS date)) OVER(PARTITION BY datetime1)", null, "date"));
+    verifySome(response.getJSONArray("datarows"), rows("1992-04-23"));
+  }
+
+  @Test
+  public void testMinDateTimeInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT min(datetime(CAST(time0 AS STRING)))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("min(datetime(CAST(time0 AS STRING))) OVER(PARTITION BY datetime1)", null, "datetime"));
+    verifySome(response.getJSONArray("datarows"), rows("1899-12-30 21:07:32"));
+  }
+
+  @Test
+  public void testMaxDateTimeInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT max(datetime(CAST(time0 AS STRING)))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(datetime(CAST(time0 AS STRING))) OVER(PARTITION BY datetime1)", null, "datetime"));
+    verifySome(response.getJSONArray("datarows"), rows("1900-01-01 20:36:00"));
+  }
+
+  @Test
+  public void testAvgDateTimeInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(datetime(CAST(time0 AS STRING)))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("avg(datetime(CAST(time0 AS STRING))) OVER(PARTITION BY datetime1)", null, "datetime"));
+    verifySome(response.getJSONArray("datarows"), rows("1900-01-01 03:35:00.235"));
+  }
+
+  @Test
+  public void testMinTimeInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT min(CAST(time1 AS time))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("min(CAST(time1 AS time)) OVER(PARTITION BY datetime1)", null, "time"));
+    verifySome(response.getJSONArray("datarows"), rows("00:05:57"));
+  }
+
+  @Test
+  public void testMaxTimeInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT max(CAST(time1 AS time))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(CAST(time1 AS time)) OVER(PARTITION BY datetime1)", null, "time"));
+    verifySome(response.getJSONArray("datarows"), rows("22:50:16"));
+  }
+
+  @Test
+  public void testAvgTimeInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(CAST(time1 AS time))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("avg(CAST(time1 AS time)) OVER(PARTITION BY datetime1)", null, "time"));
+    verifySome(response.getJSONArray("datarows"), rows("13:06:36.25"));
+  }
+
+  @Test
+  public void testMinTimeStampInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT min(CAST(datetime0 AS timestamp))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("min(CAST(datetime0 AS timestamp)) OVER(PARTITION BY datetime1)", null, "timestamp"));
+    verifySome(response.getJSONArray("datarows"), rows("2004-07-04 22:49:28"));
+  }
+
+  @Test
+  public void testMaxTimeStampInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT max(CAST(datetime0 AS timestamp))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("max(CAST(datetime0 AS timestamp)) OVER(PARTITION BY datetime1)", null, "timestamp"));
+    verifySome(response.getJSONArray("datarows"), rows("2004-08-02 07:59:23"));
+  }
+
+  @Test
+  public void testAvgTimeStampInMemory() throws IOException {
+    var response = executeQuery(String.format("SELECT avg(CAST(datetime0 AS timestamp))"
+        + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    verifySchema(response,
+        schema("avg(CAST(datetime0 AS timestamp)) OVER(PARTITION BY datetime1)", null, "timestamp"));
+    verifySome(response.getJSONArray("datarows"), rows("2004-07-20 10:38:09.706"));
   }
 
   protected JSONObject executeQuery(String query) throws IOException {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -175,27 +175,26 @@ public class OpenSearchExprValueFactory {
    * https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html
    * The customized date_format is not supported.
    */
-  private ExprValue constructTimestamp(String value) {
-    try {
-      return new ExprTimestampValue(
-          // Using OpenSearch DateFormatters for now.
-          DateFormatters.from(DATE_TIME_FORMATTER.parse(value)).toInstant());
-    } catch (DateTimeParseException e) {
-      throw new IllegalStateException(
-          String.format(
-              "Construct ExprTimestampValue from \"%s\" failed, unsupported date format.", value),
-          e);
-    }
-  }
-
   private ExprValue parseTimestamp(Content value) {
+    if (value.isString()) {
+      // value may contain epoch millis as a string, trying to extract it
+      try {
+        return parseTimestamp(new ObjectContent(Long.parseLong(value.stringValue())));
+      } catch (NumberFormatException ignored) { /* nothing to do, try another format */ }
+      try {
+        return new ExprTimestampValue(
+            // Using OpenSearch DateFormatters for now.
+            DateFormatters.from(DATE_TIME_FORMATTER.parse(value.stringValue())).toInstant());
+      } catch (DateTimeParseException e) {
+        throw new IllegalStateException(String.format(
+            "Construct ExprTimestampValue from \"%s\" failed, unsupported date format.",
+            value.stringValue()), e);
+      }
+    }
     if (value.isNumber()) {
       return new ExprTimestampValue(Instant.ofEpochMilli(value.longValue()));
-    } else if (value.isString()) {
-      return constructTimestamp(value.stringValue());
-    } else {
-      return new ExprTimestampValue((Instant) value.objectValue());
     }
+    return new ExprTimestampValue((Instant) value.objectValue());
   }
 
   private ExprValue parseStruct(Content content, String prefix) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/ExpressionAggregationScript.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/ExpressionAggregationScript.java
@@ -6,6 +6,11 @@
 
 package org.opensearch.sql.opensearch.storage.script.aggregation;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import org.apache.lucene.index.LeafReaderContext;
@@ -13,8 +18,10 @@ import org.opensearch.script.AggregationScript;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.storage.script.core.ExpressionScript;
 
 /**
@@ -42,7 +49,22 @@ public class ExpressionAggregationScript extends AggregationScript {
 
   @Override
   public Object execute() {
-    return expressionScript.execute(this::getDoc, this::evaluateExpression).value();
+    var expr = expressionScript.execute(this::getDoc, this::evaluateExpression);
+    if (expr.type() instanceof OpenSearchDataType) {
+      return expr.value();
+    }
+    switch ((ExprCoreType)expr.type()) {
+      case TIME:
+        // workaround for session context issue
+        // TODO remove once fixed
+        return MILLIS.between(LocalTime.MIN, expr.timeValue());
+      case DATE:
+      case DATETIME:
+      case TIMESTAMP:
+        return expr.timestampValue().toEpochMilli();
+      default:
+        return expr.value();
+    }
   }
 
   private ExprValue evaluateExpression(Expression expression, Environment<Expression,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -199,6 +199,9 @@ class OpenSearchExprValueFactoryTest {
         constructFromObject("timestampV", 1420070400001L));
     assertEquals(
         new ExprTimestampValue(Instant.ofEpochMilli(1420070400001L)),
+        constructFromObject("timestampV", "1420070400001"));
+    assertEquals(
+        new ExprTimestampValue(Instant.ofEpochMilli(1420070400001L)),
         constructFromObject("timestampV", Instant.ofEpochMilli(1420070400001L)));
     assertEquals(
         new ExprTimestampValue("2015-01-01 12:10:30"),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/ExpressionAggregationScriptTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/ExpressionAggregationScriptTest.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.opensearch.storage.script.aggregation;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,9 +17,12 @@ import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.expression.DSL.literal;
 import static org.opensearch.sql.expression.DSL.ref;
+import static org.opensearch.sql.opensearch.data.type.OpenSearchDataType.OPENSEARCH_TEXT;
 import static org.opensearch.sql.opensearch.data.type.OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD;
 
 import com.google.common.collect.ImmutableMap;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.LeafReaderContext;
@@ -32,6 +36,10 @@ import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.search.lookup.LeafDocLookup;
 import org.opensearch.search.lookup.LeafSearchLookup;
 import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
@@ -101,6 +109,53 @@ class ExpressionAggregationScriptTest {
         .evaluate(DSL.regex(DSL.ref("age_string", STRING), DSL.literal("age: (?<age>\\d+)"),
             DSL.literal("age")))
         .shouldMatch("30");
+  }
+
+  @Test
+  void can_execute_expression_interpret_dates_for_aggregation() {
+    assertThat()
+        .docValues("date", "1961-04-12")
+        .evaluate(
+            dsl.date(ref("date", STRING)))
+        .shouldMatch(new ExprDateValue(LocalDate.of(1961, 4, 12))
+            .timestampValue().toEpochMilli());
+  }
+
+  @Test
+  void can_execute_expression_interpret_datetimes_for_aggregation() {
+    assertThat()
+        .docValues("datetime", "1984-03-17 22:16:42")
+        .evaluate(
+            dsl.datetime(ref("datetime", STRING)))
+        .shouldMatch(new ExprDatetimeValue("1984-03-17 22:16:42")
+            .timestampValue().toEpochMilli());
+  }
+
+  @Test
+  void can_execute_expression_interpret_times_for_aggregation() {
+    assertThat()
+        .docValues("time", "22:13:42")
+        .evaluate(
+            dsl.time(ref("time", STRING)))
+        .shouldMatch(MILLIS.between(LocalTime.MIN, LocalTime.of(22, 13, 42)));
+  }
+
+  @Test
+  void can_execute_expression_interpret_timestamps_for_aggregation() {
+    assertThat()
+        .docValues("timestamp", "1984-03-17 22:16:42")
+        .evaluate(
+            dsl.timestamp(ref("timestamp", STRING)))
+        .shouldMatch(new ExprTimestampValue("1984-03-17 22:16:42")
+            .timestampValue().toEpochMilli());
+  }
+
+  @Test
+  void can_execute_expression_interpret_non_core_type_for_aggregation() {
+    assertThat()
+        .docValues("text", "pewpew")
+        .evaluate(ref("text", OPENSEARCH_TEXT))
+        .shouldMatch("pewpew");
   }
 
   private ExprScriptAssertion assertThat() {


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Make listed aggregations work with datetime types.

#### Fixes
* `min`
* `max`
* `avg`

#### Not included
* `var_samp`
* `var_pop`
* `stddev_samp`
* `stddev_pop`
* `sum` [1]

### Implementation details:
#### Presicion
Aggregation done with milliseconds precision - this follows OpenSearch approach. See code snippets: [one](https://github.com/opensearch-project/OpenSearch/blob/140e8d3e6c91519edc47be07b4cd053fdfac1769/server/src/main/java/org/opensearch/search/aggregations/support/values/ScriptDoubleValues.java#L71-L76), [two](https://github.com/opensearch-project/OpenSearch/blob/140e8d3e6c91519edc47be07b4cd053fdfac1769/server/src/main/java/org/opensearch/search/aggregations/support/values/ScriptDoubleValues.java#L109-L115).
We convert datetimes to millis and back on our own (see below), so we can scale up to nanoseconds. Such fix requires additional changes - few tests fail.

#### `ExpressionAggregationScript::execute`
A callback function, called by OpenSearch node to extract a value during processing aggregation script.
This added for backward compatibility:
https://github.com/Bit-Quill/opensearch-project-sql/blob/272bf67c9009727a7ce24958b58f0357f4e1dc4e/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/ExpressionAggregationScript.java#L53-L55
This - to extract value. Fortunately, `toEpochMilli()` returns negative values for pre-Epoch timestamps, so we are able to use it for group/compare any values.
https://github.com/Bit-Quill/opensearch-project-sql/blob/272bf67c9009727a7ce24958b58f0357f4e1dc4e/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/ExpressionAggregationScript.java#L56-L67
OpenSearch accepts dates in `Joda` lib types and converts to milliseconds since Epoch. We have java datetime types, to I do conversion there.
https://github.com/opensearch-project/OpenSearch/blob/140e8d3e6c91519edc47be07b4cd053fdfac1769/server/src/main/java/org/opensearch/search/aggregations/support/values/ScriptDoubleValues.java#L123

#### `OpenSearchExprValueFactory` `parseTimestamp` and `constructTimestamp`
OpenSearch returns aggregated values as strings, even milliseconds since Epoch. I have to extract it, so I combined these functions together.
https://github.com/Bit-Quill/opensearch-project-sql/blob/975317c134c6de65b4b499be2959690bdcb5b667/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java#L178-L198

#### `ExprValueUtils`
These two methods used by `avg` in-memory aggregation for datetime types.
https://github.com/Bit-Quill/opensearch-project-sql/blob/272bf67c9009727a7ce24958b58f0357f4e1dc4e/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java#L190
https://github.com/Bit-Quill/opensearch-project-sql/blob/272bf67c9009727a7ce24958b58f0357f4e1dc4e/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java#L213

#### `AvgAggregator`
1. Added new field to store which type is being aggregated
2. `AvgState` was renamed to `DoubleAvgState`
3. `DateTimeAvgState` does the same logic, but for datetime types.
https://github.com/Bit-Quill/opensearch-project-sql/blob/272bf67c9009727a7ce24958b58f0357f4e1dc4e/core/src/main/java/org/opensearch/sql/expression/aggregation/AvgAggregator.java#L105-L117
4. Added abstract class `AvgState`

#### `AggregatorFunction`
New signature were added.
https://github.com/Bit-Quill/opensearch-project-sql/blob/272bf67c9009727a7ce24958b58f0357f4e1dc4e/core/src/main/java/org/opensearch/sql/expression/aggregation/AggregatorFunction.java#L69-L76
Actually, plugin was able to do push down aggregation on datetime types, but this weren't accepted.

[1] It works on MySQL, but I don't see any reason to implement this for datetime types.

### Test queries
#### In-memory aggregation
https://github.com/Bit-Quill/opensearch-project-sql/blob/17e1ae98bd7e403bc94043a607ae1993d5062422/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java#L196-L199
```sql
SELECT avg(CAST(time1 AS time)) OVER(PARTITION BY datetime1) from calcs;
```
(cast required to ensure that you're working with `TIME`).
To try other types, use
```sql
CAST(date0 AS date)            
datetime(CAST(time0 AS STRING))
CAST(time1 AS time)            
CAST(datetime0 AS timestamp)   
```

#### Push Down aggregation (`metric`)
```sql
SELECT min(CAST(date0 AS date)) from calcs;
```

#### Push Down aggregation (`composite_buckets`)
```sql
SELECT CAST(datetime0 AS timestamp) FROM bank GROUP BY 1;
```

### Issues Resolved
https://github.com/opensearch-project/sql/issues/645
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).