### PR TITLE
Update Jackson Databind version to 2.13.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
         spring_version = "5.3.22"
         jackson_version = "2.13.4"
+        jackson_databind_version = "2.13.4.2"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     api "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
-    api "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    api "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     api "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     api project(':common')
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -60,7 +60,7 @@ configurations.all {
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
 }

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "io.github.resilience4j:resilience4j-retry:1.5.0"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     implementation group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -88,7 +88,7 @@ configurations.all {
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
 }
@@ -103,7 +103,7 @@ compileTestJava {
 dependencies {
     api group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     api "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
-    api "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    api "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     api "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
 
     api project(":ppl")

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "io.github.resilience4j:resilience4j-retry:1.5.0"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -31,7 +31,7 @@ plugins {
 dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation project(':core')
@@ -44,7 +44,7 @@ dependencies {
 }
 
 configurations.all {
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
 }
 
 test {


### PR DESCRIPTION
Signed-off-by: Margarit Hakobyan <margarith@bitquilltech.com>

### Description
[Jackson version used by SQL plugin must match Jackson version used by [OpenSearch 2.x.]
This PR is replacing the following one: https://github.com/Bit-Quill/opensearch-project-sql/pull/146]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).