### PR TITLE
Fix `FLOAT` -> `DOUBLE` cast.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/operator/convert/TypeCastOperator.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/convert/TypeCastOperator.java
@@ -125,7 +125,7 @@ public class TypeCastOperator {
         impl(nullMissingHandling(
             (v) -> new ExprFloatValue(Float.valueOf(v.stringValue()))), FLOAT, STRING),
         impl(nullMissingHandling(
-            (v) -> new ExprFloatValue(v.longValue())), FLOAT, DOUBLE),
+            (v) -> new ExprFloatValue(v.floatValue())), FLOAT, DOUBLE),
         impl(nullMissingHandling(
             (v) -> new ExprFloatValue(v.booleanValue() ? 1f : 0f)), FLOAT, BOOLEAN)
     );

--- a/core/src/test/java/org/opensearch/sql/expression/operator/convert/TypeCastOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/convert/TypeCastOperatorTest.java
@@ -48,8 +48,8 @@ class TypeCastOperatorTest {
 
   private static Stream<ExprValue> numberData() {
     return Stream.of(new ExprByteValue(3), new ExprShortValue(3),
-        new ExprIntegerValue(3), new ExprLongValue(3L), new ExprFloatValue(3f),
-        new ExprDoubleValue(3D));
+        new ExprIntegerValue(3), new ExprLongValue(3L), new ExprFloatValue(3.14f),
+        new ExprDoubleValue(3.1415D));
   }
 
   private static Stream<ExprValue> stringData() {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -172,7 +172,7 @@ public abstract class LuceneQuery {
       })
       .put(BuiltinFunctionName.CAST_TO_BOOLEAN.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return expr.valueOf(null).doubleValue() == 1
+          return expr.valueOf(null).doubleValue() != 0
               ? ExprBooleanValue.of(true) : ExprBooleanValue.of(false);
         } else if (expr.type().equals(ExprCoreType.STRING)) {
           return ExprBooleanValue.of(Boolean.valueOf(expr.valueOf(null).stringValue()));


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
* Fix `FLOAT` -> `DOUBLE` cast.
* Update tests.
* Update numeric -> `BOOLEAN` cast in `LuceneQuery` to comply with `TypeCastOperator`.

### Issues Resolved
https://github.com/opensearch-project/sql/issues/998
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).