### PR TITLE
Resolve Prometheus dependency for IT on non-Linux OS.

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import java.util.concurrent.Callable
+
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.opensearch.gradle.testclusters.RunTask
+import java.util.concurrent.Callable
 
 plugins {
     id 'base'
@@ -31,6 +33,7 @@ task startPrometheus(type: SpawnProcessTask) {
         download.run {
             src 'https://github.com/prometheus/prometheus/releases/download/v2.39.1/prometheus-2.39.1.linux-amd64.tar.gz'
             dest new File("$projectDir/bin", 'prometheus.tar.gz')
+            overwrite false
         }
         copy {
             from tarTree("$projectDir/bin/prometheus.tar.gz")
@@ -85,9 +88,11 @@ task stopPrometheus() {
 }
 
 stopPrometheus.mustRunAfter startPrometheus
-doctest.dependsOn startOpenSearch
+if (DefaultNativePlatform.currentOperatingSystem.isLinux()) {
+    doctest.dependsOn startOpenSearch
+    doctest.finalizedBy stopOpenSearch
+}
 startOpenSearch.dependsOn startPrometheus
-doctest.finalizedBy stopOpenSearch
 stopOpenSearch.finalizedBy stopPrometheus
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -4,9 +4,9 @@
  */
 
 
+import java.util.concurrent.Callable
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.opensearch.gradle.testclusters.RunTask
-import java.util.concurrent.Callable
 
 plugins {
     id 'base'

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -88,12 +88,18 @@ task stopPrometheus() {
 }
 
 stopPrometheus.mustRunAfter startPrometheus
+doctest.dependsOn startOpenSearch
+doctest.finalizedBy stopOpenSearch
+
+// OpenSearch designed to run on Linux only in production, so main CI workflows are on Linux too.
+// As of #977 gradle workflows which depend on Prometheus use hardcoded Linux version of it.
+// Auxiliary workflows and developers who use other OS should be able to run tests as well,
+// so this trick unblocks them to run doctests. Note: Prometheus related tests would fail.
 if (DefaultNativePlatform.currentOperatingSystem.isLinux()) {
-    doctest.dependsOn startOpenSearch
-    doctest.finalizedBy stopOpenSearch
+    startOpenSearch.dependsOn startPrometheus
+    stopOpenSearch.finalizedBy stopPrometheus
 }
-startOpenSearch.dependsOn startPrometheus
-stopOpenSearch.finalizedBy stopPrometheus
+
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -114,6 +114,7 @@ task startPrometheus(type: SpawnProcessTask) {
         download.run {
             src 'https://github.com/prometheus/prometheus/releases/download/v2.39.1/prometheus-2.39.1.linux-amd64.tar.gz'
             dest new File("$projectDir/bin", 'prometheus.tar.gz')
+            overwrite false
         }
         copy {
             from tarTree("$projectDir/bin/prometheus.tar.gz")
@@ -135,8 +136,11 @@ stopPrometheus.mustRunAfter startPrometheus
 // Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
 integTest {
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
-    dependsOn startPrometheus
-    finalizedBy stopPrometheus
+
+    if (DefaultNativePlatform.currentOperatingSystem.isLinux()) {
+        dependsOn startPrometheus
+        finalizedBy stopPrometheus
+    }
 
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -137,6 +137,10 @@ stopPrometheus.mustRunAfter startPrometheus
 integTest {
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
 
+    // OpenSearch designed to run on Linux only in production, so main CI workflows are on Linux too.
+    // As of #977 gradle workflows which depend on Prometheus use hardcoded Linux version of it.
+    // Auxiliary workflows and developers who use other OS should be able to run tests as well,
+    // so this trick unblocks them to run ITs. Note: Prometheus related tests would be skipped.
     if (DefaultNativePlatform.currentOperatingSystem.isLinux()) {
         dependsOn startPrometheus
         finalizedBy stopPrometheus

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -66,9 +66,6 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
   }
 
   protected static void wipeAllOpenSearchIndices() throws IOException {
-    if (client() == null) {
-      return;
-    }
     // include all the indices, included hidden indices.
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html#cat-indices-api-query-params
     Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -66,6 +66,9 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
   }
 
   protected static void wipeAllOpenSearchIndices() throws IOException {
+    if (client() == null) {
+      return;
+    }
     // include all the indices, included hidden indices.
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html#cat-indices-api-query-params
     Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/RestIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/RestIntegTestCase.java
@@ -123,6 +123,9 @@ public abstract class RestIntegTestCase extends OpenSearchSQLRestTestCase {
    */
   @AfterClass
   public static void cleanUpIndices() throws IOException {
+    if (client() == null) {
+      return;
+    }
     wipeAllOpenSearchIndices();
     wipeAllClusterSettings();
   }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -142,7 +142,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
    */
   @AfterClass
   public static void cleanUpIndices() throws IOException {
-    if (System.getProperty("tests.rest.bwcsuite") == null) {
+    if (System.getProperty("tests.rest.bwcsuite") == null && client() != null) {
       wipeAllOpenSearchIndices();
       wipeAllClusterSettings();
     }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowCatalogsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowCatalogsCommandIT.java
@@ -21,6 +21,12 @@ import org.junit.jupiter.api.Test;
 
 public class ShowCatalogsCommandIT extends PPLIntegTestCase {
 
+  /**
+   * OpenSearch designed to run on Linux only in production, so main CI workflows are on Linux too.
+   * As of #977 gradle workflows which depend on Prometheus use hardcoded Linux version of it.
+   * Auxiliary workflows and developers who use other OS should be able to run tests as well,
+   * so this trick skips Prometheus related tests to avoid failures.
+   */
   @BeforeClass
   public static void checkOs() {
     Assume.assumeTrue(SystemUtils.IS_OS_LINUX);

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowCatalogsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowCatalogsCommandIT.java
@@ -13,10 +13,18 @@ import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
 import java.io.IOException;
+import org.apache.commons.lang3.SystemUtils;
 import org.json.JSONObject;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Test;
 
 public class ShowCatalogsCommandIT extends PPLIntegTestCase {
+
+  @BeforeClass
+  public static void checkOs() {
+    Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
+  }
 
   @Test
   public void testShowCatalogsCommands() throws IOException {


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Unblock tests from Prometheus dependency - it is available on Linux only:
* Doctest would start, but would report one failure on another OS
* Integration tests would start and skip Prometheus related tests on another OS
* Minor fix - don't re-download Prometheus binaries.
 
### Issues Resolved
Proposed as a temporary solution while https://github.com/opensearch-project/sql/issues/982 isn't fixed.
Introduced by https://github.com/opensearch-project/sql/pull/977.
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).