### PR TITLE
Add timeout option to SQL CLI tool.

### DIFF
--- a/sql-cli/src/opensearch_sql_cli/main.py
+++ b/sql-cli/src/opensearch_sql_cli/main.py
@@ -71,6 +71,14 @@ click.disable_unicode_literals_warning = True
     default="sql",
     help="SQL OR PPL",
 )
+@click.option(
+    "-t",
+    "--timeout",
+    "response_timeout",
+    type=click.INT,
+    default=10,
+    help="Timeout to await a response from the server"
+)
 def cli(
     endpoint,
     query,
@@ -83,6 +91,7 @@ def cli(
     always_use_pager,
     use_aws_authentication,
     query_language,
+    response_timeout
 ):
     """
     Provide endpoint for OpenSearch client.
@@ -114,12 +123,9 @@ def cli(
         sys.exit(0)
 
     # use console to interact with user
-    opensearchsql_cli = OpenSearchSqlCli(
-        clirc_file=clirc,
-        always_use_pager=always_use_pager,
-        use_aws_authentication=use_aws_authentication,
-        query_language=query_language,
-    )
+    opensearchsql_cli = OpenSearchSqlCli(clirc_file=clirc, always_use_pager=always_use_pager,
+                                         use_aws_authentication=use_aws_authentication, query_language=query_language,
+                                         response_timeout=response_timeout)
     opensearchsql_cli.connect(endpoint, http_auth)
     opensearchsql_cli.run_cli()
 

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -27,6 +27,7 @@ class OpenSearchConnection:
         http_auth=None,
         use_aws_authentication=False,
         query_language="sql",
+        response_timeout=10
     ):
         """Initialize an OpenSearchConnection instance.
 
@@ -45,6 +46,7 @@ class OpenSearchConnection:
         self.http_auth = http_auth
         self.use_aws_authentication = use_aws_authentication
         self.query_language = query_language
+        self.response_timeout = response_timeout
 
     def get_indices(self):
         if self.client:
@@ -167,14 +169,14 @@ class OpenSearchConnection:
                 data = self.client.transport.perform_request(
                     url="/_plugins/_sql/_explain" if explain else "/_plugins/_sql/",
                     method="POST",
-                    params=None if explain else {"format": output_format},
+                    params=None if explain else {"format": output_format, "request_timeout": self.response_timeout},
                     body={"query": final_query},
                 )
             else:
                 data = self.client.transport.perform_request(
                     url="/_plugins/_ppl/_explain" if explain else "/_plugins/_ppl/",
                     method="POST",
-                    params=None if explain else {"format": output_format},
+                    params=None if explain else {"format": output_format, "request_timeout": self.response_timeout},
                     body={"query": final_query},
                 )
             return data

--- a/sql-cli/src/opensearch_sql_cli/opensearchsql_cli.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearchsql_cli.py
@@ -39,7 +39,8 @@ click.disable_unicode_literals_warning = True
 class OpenSearchSqlCli:
     """OpenSearchSqlCli instance is used to build and run the OpenSearch SQL CLI."""
 
-    def __init__(self, clirc_file=None, always_use_pager=False, use_aws_authentication=False, query_language="sql"):
+    def __init__(self, clirc_file=None, always_use_pager=False, use_aws_authentication=False, query_language="sql",
+                 response_timeout=10):
         # Load conf file
         config = self.config = get_config(clirc_file)
         literal = self.literal = self._get_literals()
@@ -49,6 +50,7 @@ class OpenSearchSqlCli:
         self.query_language = query_language
         self.always_use_pager = always_use_pager
         self.use_aws_authentication = use_aws_authentication
+        self.response_timeout = response_timeout
         self.keywords_list = literal["keywords"]
         self.functions_list = literal["functions"]
         self.syntax_style = config["main"]["syntax_style"]
@@ -160,7 +162,7 @@ class OpenSearchSqlCli:
 
     def connect(self, endpoint, http_auth=None):
         self.opensearch_executor = OpenSearchConnection(
-            endpoint, http_auth, self.use_aws_authentication, self.query_language
+            endpoint, http_auth, self.use_aws_authentication, self.query_language, self.response_timeout
         )
         self.opensearch_executor.set_connection()
 

--- a/sql-cli/tests/test_opensearchsql_cli.py
+++ b/sql-cli/tests/test_opensearchsql_cli.py
@@ -18,6 +18,7 @@ AUTH = None
 QUERY_WITH_CTRL_D = "select * from %s;\r\x04\r" % TEST_INDEX_NAME
 USE_AWS_CREDENTIALS = False
 QUERY_LANGUAGE = "sql"
+RESPONSE_TIMEOUT = 10
 
 
 @pytest.fixture()
@@ -34,7 +35,8 @@ class TestOpenSearchSqlCli:
         ) as mock_set_connectiuon:
             cli.connect(endpoint=ENDPOINT)
 
-            mock_OpenSearchConnection.assert_called_with(ENDPOINT, AUTH, USE_AWS_CREDENTIALS, QUERY_LANGUAGE)
+            mock_OpenSearchConnection.assert_called_with(ENDPOINT, AUTH, USE_AWS_CREDENTIALS, QUERY_LANGUAGE,
+                                                         RESPONSE_TIMEOUT)
             mock_set_connectiuon.assert_called()
 
     @estest


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Add response timeout option to SQL CLI tool. This is very handy for SQL plugin debugging purposes.
Imagine you are debugging a query and placed a breakpoint into the plugin code. While you are going step-by-step debugging, CLI times out.

New command line optional argument added:
```
-t <value in seconds>
```
If not given, SQL CLI works as usual. Default timeout is 10 sec.

**Before**
```
$ opensearchsql
...
opensearchsql> select 1;
fetched rows / total rows = 1/1      <--- response in 0-10 sec
+-----+
| 1   |
|-----|
| 1   |
+-----+
opensearchsql> select 1;
Reconnecting...
Reconnected! Please run query again      <--- response in 10-19 sec
opensearchsql> select 1;
Reconnecting...
Connection Failed. Check your OpenSearch is running and then come back     <---- 20+ sec
ConnectionTimeout('TIMEOUT', "HTTPConnectionPool(host='localhost', port=9200): Read timed out. (read timeout=10)", ReadTimeoutError("HTTPConnectionPool(host='localhost', port=9200): Read timed out. (read timeout=10)"))
opensearchsql>
```
**After**
```
$ opensearchsql -t 10000
...
opensearchsql> select 1;
fetched rows / total rows = 1/1          <---- 30 min of intensive debugging with breaks - no timeout!
+-----+
| 1   |
|-----|
| 1   |
+-----+
```

Parameter `request_timeout` is processed by underlying library:
https://github.com/opensearch-project/opensearch-py/blob/8879644ec404b3ab15b739b97775d7bd7e51018b/opensearchpy/transport.py#L457

### How to test
Ref: https://github.com/opensearch-project/sql/blob/2.x/sql-cli/development_guide.md#development-environment-set-up

Do once:
```
cd sql-cli
pip install virtualenv
virtualenv venv
pip install --editable .
```
Then every time you want to debug SQL CLI:
```
<checkout>
cd sql-cli
source ./venv/bin/activate
```
To exit from `venv`:
```
deactivate
```
You can run SQL CLI and switch branch. It will keep working with given timeout until closed.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).