### PR TITLE
Disallow unquoted literals in `LIKE` clause in `DESCRIBE` statement

### DIFF
--- a/docs/category.json
+++ b/docs/category.json
@@ -46,6 +46,7 @@
     "user/dql/window.rst",
     "user/beyond/partiql.rst",
     "user/dql/aggregations.rst",
-    "user/dql/complex.rst"
+    "user/dql/complex.rst",
+    "user/dql/metadata.rst"
   ]
 }

--- a/docs/user/dql/metadata.rst
+++ b/docs/user/dql/metadata.rst
@@ -36,21 +36,18 @@ Example 1: Show All Indices Information
 
 SQL query::
 
-	POST /_plugins/_sql
-	{
-	  "query" : "SHOW TABLES LIKE %"
-	}
-
-Result set:
-
-+---------+-----------+----------------+----------+-------+--------+----------+---------+-------------------------+--------------+
-|TABLE_CAT|TABLE_SCHEM|      TABLE_NAME|TABLE_TYPE|REMARKS|TYPE_CAT|TYPE_SCHEM|TYPE_NAME|SELF_REFERENCING_COL_NAME|REF_GENERATION|
-+=========+===========+================+==========+=======+========+==========+=========+=========================+==============+
-|integTest|       null|        accounts|BASE TABLE|   null|    null|      null|     null|                     null|          null|
-+---------+-----------+----------------+----------+-------+--------+----------+---------+-------------------------+--------------+
-|integTest|       null|employees_nested|BASE TABLE|   null|    null|      null|     null|                     null|          null|
-+---------+-----------+----------------+----------+-------+--------+----------+---------+-------------------------+--------------+
-
+    os> SHOW TABLES LIKE '%'
+    fetched rows / total rows = 6/6
+    +----------------+---------------+--------------+--------------+-----------+------------+--------------+-------------+-----------------------------+------------------+
+    | TABLE_CAT      | TABLE_SCHEM   | TABLE_NAME   | TABLE_TYPE   | REMARKS   | TYPE_CAT   | TYPE_SCHEM   | TYPE_NAME   | SELF_REFERENCING_COL_NAME   | REF_GENERATION   |
+    |----------------+---------------+--------------+--------------+-----------+------------+--------------+-------------+-----------------------------+------------------|
+    | docTestCluster | null          | account2     | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    | docTestCluster | null          | accounts     | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    | docTestCluster | null          | apache       | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    | docTestCluster | null          | books        | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    | docTestCluster | null          | nyc_taxi     | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    | docTestCluster | null          | people       | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    +----------------+---------------+--------------+--------------+-----------+------------+--------------+-------------+-----------------------------+------------------+
 
 Example 2: Show Specific Index Information
 ------------------------------------------
@@ -59,19 +56,14 @@ Here is an example that searches metadata for index name prefixed by 'acc'. Besi
 
 SQL query::
 
-	POST /_plugins/_sql
-	{
-	  "query" : "SHOW TABLES LIKE acc%"
-	}
-
-Result set:
-
-+---------+-----------+----------+----------+-------+--------+----------+---------+-------------------------+--------------+
-|TABLE_CAT|TABLE_SCHEM|TABLE_NAME|TABLE_TYPE|REMARKS|TYPE_CAT|TYPE_SCHEM|TYPE_NAME|SELF_REFERENCING_COL_NAME|REF_GENERATION|
-+=========+===========+==========+==========+=======+========+==========+=========+=========================+==============+
-|integTest|       null|  accounts|BASE TABLE|   null|    null|      null|     null|                     null|          null|
-+---------+-----------+----------+----------+-------+--------+----------+---------+-------------------------+--------------+
-
+    os> SHOW TABLES LIKE "acc%"
+    fetched rows / total rows = 2/2
+    +----------------+---------------+--------------+--------------+-----------+------------+--------------+-------------+-----------------------------+------------------+
+    | TABLE_CAT      | TABLE_SCHEM   | TABLE_NAME   | TABLE_TYPE   | REMARKS   | TYPE_CAT   | TYPE_SCHEM   | TYPE_NAME   | SELF_REFERENCING_COL_NAME   | REF_GENERATION   |
+    |----------------+---------------+--------------+--------------+-----------+------------+--------------+-------------+-----------------------------+------------------|
+    | docTestCluster | null          | account2     | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    | docTestCluster | null          | accounts     | BASE TABLE   | null      | null       | null         | null        | null                        | null             |
+    +----------------+---------------+--------------+--------------+-----------+------------+--------------+-------------+-----------------------------+------------------+
 
 Example 3: Describe Index Fields Information
 --------------------------------------------
@@ -80,37 +72,36 @@ Example 3: Describe Index Fields Information
 
 SQL query::
 
-	POST /_plugins/_sql
-	{
-	  "query" : "DESCRIBE TABLES LIKE accounts"
-	}
+    os> DESCRIBE TABLES LIKE 'accounts'
+    fetched rows / total rows = 11/11
+    +----------------+---------------+--------------+----------------+-------------+-------------+---------------+-----------------+------------------+------------------+------------+-----------+--------------+-----------------+--------------------+---------------------+--------------------+---------------+-----------------+----------------+---------------+--------------------+--------------------+----------------------+
+    | TABLE_CAT      | TABLE_SCHEM   | TABLE_NAME   | COLUMN_NAME    | DATA_TYPE   | TYPE_NAME   | COLUMN_SIZE   | BUFFER_LENGTH   | DECIMAL_DIGITS   | NUM_PREC_RADIX   | NULLABLE   | REMARKS   | COLUMN_DEF   | SQL_DATA_TYPE   | SQL_DATETIME_SUB   | CHAR_OCTET_LENGTH   | ORDINAL_POSITION   | IS_NULLABLE   | SCOPE_CATALOG   | SCOPE_SCHEMA   | SCOPE_TABLE   | SOURCE_DATA_TYPE   | IS_AUTOINCREMENT   | IS_GENERATEDCOLUMN   |
+    |----------------+---------------+--------------+----------------+-------------+-------------+---------------+-----------------+------------------+------------------+------------+-----------+--------------+-----------------+--------------------+---------------------+--------------------+---------------+-----------------+----------------+---------------+--------------------+--------------------+----------------------|
+    | docTestCluster | null          | accounts     | account_number | null        | long        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 0                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | firstname      | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 1                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | address        | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 2                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | balance        | null        | long        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 3                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | gender         | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 4                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | city           | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 5                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | employer       | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 6                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | state          | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 7                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | age            | null        | long        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 8                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | email          | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 9                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | lastname       | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 10                 |               | null            | null           | null          | null               | NO                 |                      |
+    +----------------+---------------+--------------+----------------+-------------+-------------+---------------+-----------------+------------------+------------------+------------+-----------+--------------+-----------------+--------------------+---------------------+--------------------+---------------+-----------------+----------------+---------------+--------------------+--------------------+----------------------+
 
-Result set:
+Example 4: Describe Index With Fields Filter
+--------------------------------------------
 
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|TABLE_CAT|TABLE_SCHEM|TABLE_NAME|   COLUMN_NAME|DATA_TYPE|TYPE_NAME|COLUMN_SIZE|BUFFER_LENGTH|DECIMAL_DIGITS|NUM_PREC_RADIX|NULLABLE|REMARKS|COLUMN_DEF|SQL_DATA_TYPE|SQL_DATETIME_SUB|CHAR_OCTET_LENGTH|ORDINAL_POSITION|IS_NULLABLE|SCOPE_CATALOG|SCOPE_SCHEMA|SCOPE_TABLE|SOURCE_DATA_TYPE|IS_AUTOINCREMENT|IS_GENERATEDCOLUMN|
-+=========+===========+==========+==============+=========+=========+===========+=============+==============+==============+========+=======+==========+=============+================+=================+================+===========+=============+============+===========+================+================+==================+
-|integTest|       null|  accounts|account_number|     null|     long|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               1|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|     firstname|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               2|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|       address|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               3|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|       balance|     null|     long|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               4|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|        gender|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               5|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|          city|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               6|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|      employer|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               7|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|         state|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               8|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|           age|     null|     long|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|               9|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|         email|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|              10|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
-|integTest|       null|  accounts|      lastname|     null|     text|       null|         null|          null|            10|       2|   null|      null|         null|            null|             null|              11|           |         null|        null|       null|            null|              NO|                  |
-+---------+-----------+----------+--------------+---------+---------+-----------+-------------+--------------+--------------+--------+-------+----------+-------------+----------------+-----------------+----------------+-----------+-------------+------------+-----------+----------------+----------------+------------------+
+``DESCRIBE`` statement fields that can match the search pattern for indices that can match the search pattern.
 
+SQL query::
 
+    os> DESCRIBE TABLES LIKE "accounts" COLUMNS LIKE "%name"
+    fetched rows / total rows = 2/2
+    +----------------+---------------+--------------+---------------+-------------+-------------+---------------+-----------------+------------------+------------------+------------+-----------+--------------+-----------------+--------------------+---------------------+--------------------+---------------+-----------------+----------------+---------------+--------------------+--------------------+----------------------+
+    | TABLE_CAT      | TABLE_SCHEM   | TABLE_NAME   | COLUMN_NAME   | DATA_TYPE   | TYPE_NAME   | COLUMN_SIZE   | BUFFER_LENGTH   | DECIMAL_DIGITS   | NUM_PREC_RADIX   | NULLABLE   | REMARKS   | COLUMN_DEF   | SQL_DATA_TYPE   | SQL_DATETIME_SUB   | CHAR_OCTET_LENGTH   | ORDINAL_POSITION   | IS_NULLABLE   | SCOPE_CATALOG   | SCOPE_SCHEMA   | SCOPE_TABLE   | SOURCE_DATA_TYPE   | IS_AUTOINCREMENT   | IS_GENERATEDCOLUMN   |
+    |----------------+---------------+--------------+---------------+-------------+-------------+---------------+-----------------+------------------+------------------+------------+-----------+--------------+-----------------+--------------------+---------------------+--------------------+---------------+-----------------+----------------+---------------+--------------------+--------------------+----------------------|
+    | docTestCluster | null          | accounts     | firstname     | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 1                  |               | null            | null           | null          | null               | NO                 |                      |
+    | docTestCluster | null          | accounts     | lastname      | null        | text        | null          | null            | null             | 10               | 2          | null      | null         | null            | null               | null                | 10                 |               | null            | null           | null          | null               | NO                 |                      |
+    +----------------+---------------+--------------+---------------+-------------+-------------+---------------+-----------------+------------------+------------------+------------+-----------+--------------+-----------------+--------------------+---------------------+--------------------+---------------+-----------------+----------------+---------------+--------------------+--------------------+----------------------+

--- a/integ-test/src/test/java/org/opensearch/sql/sql/AdminIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/AdminIT.java
@@ -7,17 +7,23 @@
 package org.opensearch.sql.sql;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.opensearch.sql.util.MatcherUtils.assertJsonEquals;
+import static org.opensearch.sql.util.TestUtils.getResponseBody;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestsConstants;
@@ -34,7 +40,7 @@ public class AdminIT extends SQLIntegTestCase {
   public void showSingleIndexAlias() throws IOException {
     String alias = "acc";
     addAlias(TestsConstants.TEST_INDEX_ACCOUNT, alias);
-    JSONObject response = new JSONObject(executeQuery("SHOW TABLES LIKE acc", "jdbc"));
+    JSONObject response = new JSONObject(executeQuery("SHOW TABLES LIKE 'acc'", "jdbc"));
 
     /*
      * Assumed indices of fields in dataRows based on "schema" output for SHOW given above:
@@ -48,7 +54,7 @@ public class AdminIT extends SQLIntegTestCase {
   public void describeSingleIndexAlias() throws IOException {
     String alias = "acc";
     addAlias(TestsConstants.TEST_INDEX_ACCOUNT, alias);
-    JSONObject response = new JSONObject(executeQuery("DESCRIBE TABLES LIKE acc", "jdbc"));
+    JSONObject response = new JSONObject(executeQuery("DESCRIBE TABLES LIKE 'acc'", "jdbc"));
 
     /*
      * Assumed indices of fields in dataRows based on "schema" output for DESCRIBE given above:
@@ -59,14 +65,24 @@ public class AdminIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void describeSingleIndexWildcard() throws IOException {
+    JSONObject response1 = executeQuery("DESCRIBE TABLES LIKE \\\"%account\\\"");
+    JSONObject response2 = executeQuery("DESCRIBE TABLES LIKE '%account'");
+    JSONObject response3 = executeQuery("DESCRIBE TABLES LIKE '%account' COLUMNS LIKE \\\"%name\\\"");
+    JSONObject response4 = executeQuery("DESCRIBE TABLES LIKE \\\"%account\\\" COLUMNS LIKE '%name'");
+    // 11 rows in the output, each corresponds to a column in the table
+    assertEquals(11, response1.getJSONArray("datarows").length());
+    assertTrue(response1.similar(response2));
+    // 2 columns should match the wildcard
+    assertEquals(2, response3.getJSONArray("datarows").length());
+    assertTrue(response3.similar(response4));
+  }
+
+  @Test
   public void explainShow() throws Exception {
     String expected = loadFromFile("expectedOutput/sql/explain_show.json");
-
-    final String actual = explainQuery("SHOW TABLES LIKE %");
-    assertJsonEquals(
-        expected,
-        explainQuery("SHOW TABLES LIKE %")
-    );
+    String actual = explainQuery("SHOW TABLES LIKE '%'");
+    assertTrue(new JSONObject(expected).similar(new JSONObject(actual)));
   }
 
   private void addAlias(String index, String alias) throws IOException {
@@ -76,5 +92,17 @@ public class AdminIT extends SQLIntegTestCase {
   private String loadFromFile(String filename) throws Exception {
     URI uri = Resources.getResource(filename).toURI();
     return new String(Files.readAllBytes(Paths.get(uri)));
+  }
+
+  protected JSONObject executeQuery(String query) throws IOException {
+    Request request = new Request("POST", QUERY_API_ENDPOINT);
+    request.setJsonEntity(String.format(Locale.ROOT, "{\n" + "  \"query\": \"%s\"\n" + "}", query));
+
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+
+    Response response = client().performRequest(request);
+    return new JSONObject(getResponseBody(response));
   }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -82,13 +82,8 @@ tableFilter
     ;
 
 showDescribePattern
-    : oldID=compatibleID | stringLiteral
+    : stringLiteral
     ;
-
-compatibleID
-    : (MODULE | ID)+?
-    ;
-
 //    Select Statement's Details
 
 querySpecification

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -165,11 +165,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitShowDescribePattern(
       ShowDescribePatternContext ctx) {
-    if (ctx.compatibleID() != null) {
-      return stringLiteral(ctx.compatibleID().getText());
-    } else {
-      return visit(ctx.stringLiteral());
-    }
+    return visit(ctx.stringLiteral());
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.sql.antlr;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -15,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -384,6 +384,38 @@ class SQLSyntaxParserTest {
     assertNotNull(
             parser.parse("SELECT * FROM test WHERE match_phrase(`column`, 'this is a test')"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match_phrase(column, 100500)"));
+  }
+
+  @Test
+  public void describe_request_accepts_only_quoted_string_literals() {
+    assertAll(
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("DESCRIBE TABLES LIKE bank")),
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("DESCRIBE TABLES LIKE %bank%")),
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("DESCRIBE TABLES LIKE `bank`")),
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("DESCRIBE TABLES LIKE %bank% COLUMNS LIKE %status%")),
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("DESCRIBE TABLES LIKE 'bank' COLUMNS LIKE status")),
+        () -> assertNotNull(parser.parse("DESCRIBE TABLES LIKE 'bank' COLUMNS LIKE \"status\"")),
+        () -> assertNotNull(parser.parse("DESCRIBE TABLES LIKE \"bank\" COLUMNS LIKE 'status'"))
+    );
+  }
+
+  @Test
+  public void show_request_accepts_only_quoted_string_literals() {
+    assertAll(
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("SHOW TABLES LIKE bank")),
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("SHOW TABLES LIKE %bank%")),
+        () -> assertThrows(SyntaxCheckException.class,
+            () -> parser.parse("SHOW TABLES LIKE `bank`")),
+        () -> assertNotNull(parser.parse("SHOW TABLES LIKE 'bank'")),
+        () -> assertNotNull(parser.parse("SHOW TABLES LIKE \"bank\""))
+    );
   }
 
   @ParameterizedTest

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -552,10 +552,6 @@ class AstBuilderTest {
     );
   }
 
-  /**
-   * Todo, ideally the identifier (%) couldn't be used in LIKE operator, only the string literal
-   * is allowed.
-   */
   @Test
   public void show_compatible_with_old_engine_syntax() {
     assertEquals(
@@ -566,18 +562,7 @@ class AstBuilderTest {
             ),
             AllFields.of()
         ),
-        buildAST("SHOW TABLES LIKE %")
-    );
-  }
-
-  @Test
-  public void describe_compatible_with_old_engine_syntax() {
-    assertEquals(
-        project(
-            relation(mappingTable("a_c%")),
-            AllFields.of()
-        ),
-        buildAST("DESCRIBE TABLES LIKE a_c%")
+        buildAST("SHOW TABLES LIKE '%'")
     );
   }
 
@@ -603,24 +588,6 @@ class AstBuilderTest {
             AllFields.of()
         ),
         buildAST("DESCRIBE TABLES LIKE 'a_c%' COLUMNS LIKE 'name%'")
-    );
-  }
-
-  /**
-   * Todo, ideally the identifier (%) couldn't be used in LIKE operator, only the string literal
-   * is allowed.
-   */
-  @Test
-  public void describe_and_column_compatible_with_old_engine_syntax() {
-    assertEquals(
-        project(
-            filter(
-                relation(mappingTable("a_c%")),
-                function("like", qualifiedName("COLUMN_NAME"), stringLiteral("name%"))
-            ),
-            AllFields.of()
-        ),
-        buildAST("DESCRIBE TABLES LIKE a_c% COLUMNS LIKE name%")
     );
   }
 


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Update SQL parser to disallow unquoted strings as identifiers wildcards clause.

To test this fix for #650 disable legacy engine first:
```diff
diff --git a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.>
index ab146404f..29c501117 100644
--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -161,10 +161,11 @@ public class RestSqlAction extends BaseRestHandler {
                             QueryContext.getRequestId());
                         result.accept(channel);
                     } else {
-                        LOG.debug("[{}] Request {} is not supported and falling back to old SQL engine",
+                        LOG.info("[{}] Request {} is not supported and falling back to nowhere",
                             QueryContext.getRequestId(), newSqlRequest);
-                        QueryAction queryAction = explainRequest(client, sqlRequest, format);
-                        executeSqlRequest(request, queryAction, client, channel);
+                        throw new SQLFeatureDisabledException("buuuu");
+                        //QueryAction queryAction = explainRequest(client, sqlRequest, format);
+                        //executeSqlRequest(request, queryAction, client, channel);
                     }
                 } catch (Exception e) {
                     logAndPublishMetrics(e);
(
```

**Before**
_With patch, without fix_
```sql
opensearchsql> DESCRIBE TABLES LIKE flights COLUMNS LIKE time%;
{'reason': 'Invalid SQL query', 'details': 'buuuu', 'type': 'SQLFeatureDisabledException'}
opensearchsql> DESCRIBE TABLES LIKE flights COLUMNS LIKE %time%;
{'reason': 'Invalid SQL query', 'details': 'buuuu', 'type': 'SQLFeatureDisabledException'}
opensearchsql> DESCRIBE TABLES LIKE calcs;
Output longer than terminal width
Do you want to display data vertically for better visual effect? [y/N]
```

**After**
```sql
opensearchsql> DESCRIBE TABLES LIKE flights COLUMNS LIKE time%;
{'reason': 'Invalid SQL query', 'details': 'buuuu', 'type': 'SQLFeatureDisabledException'}
opensearchsql> DESCRIBE TABLES LIKE flights COLUMNS LIKE %time%;
{'reason': 'Invalid SQL query', 'details': 'buuuu', 'type': 'SQLFeatureDisabledException'}
opensearchsql> DESCRIBE TABLES LIKE calcs;
{'reason': 'Invalid SQL query', 'details': 'buuuu', 'type': 'SQLFeatureDisabledException'}
```

Another queries for test:
```sql
DESCRIBE TABLES LIKE acc%;
SHOW TABLES LIKE %;
```
and
```sql
DESCRIBE TABLES LIKE 'acc%';
SHOW TABLES LIKE "%";
```

### Notes
As discussed, we should prohibit usage of raw identifies in SQL queries where wildcards are allowed. A user should specify string literal instead (a quoted string with `'` or `"`). Backtick quote `` ` `` is not accepted.
This behavior was copied from legacy engine and it is an erroneous approach.
The root cause of #650 is a `keywordsCanBeId` which was in the user query which cased V2 parser to fail and fall back to V1.


### Issues Resolved
https://github.com/opensearch-project/sql/issues/650
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).