### PR TITLE
Fix history file usage in SQL CLI tool.

### DIFF
--- a/sql-cli/src/opensearch_sql_cli/conf/clirc
+++ b/sql-cli/src/opensearch_sql_cli/conf/clirc
@@ -31,13 +31,13 @@ multi_line = True
 multi_line_mode = opensearchsql_cli
 
 # log_file location.
-# In Unix/Linux: ~/.conf/opensearchsql-cli/log
+# In Unix/Linux: ~/.config/opensearchsql-cli/log
 # In Windows: %USERPROFILE%\AppData\Local\dbcli\opensearchsql-cli\log
 # %USERPROFILE% is typically C:\Users\{username}
 log_file = default
 
 # history_file location.
-# In Unix/Linux: ~/.conf/opensearchsql-cli/history
+# In Unix/Linux: ~/.config/opensearchsql-cli/history
 # In Windows: %USERPROFILE%\AppData\Local\dbcli\opensearchsql-cli\history
 # %USERPROFILE% is typically C:\Users\{username}
 history_file = default


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Changes include:
* Fix usage of `FileHistory`.
* Fix reading `history_file` and `log_file` parameters from config.
* Fix interpreting the default or custom user value.

Config location: `~/.config/opensearchsql-cli/config`
Default location for saving history and log files: `~/.config/opensearchsql-cli`
Inspired by: https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/examples/prompts/history/persistent-history.py

### Test
1. Run SQL CLI in `venv` (see instructions below)
2. Run a query
3. Exit from SQL CLI
4. Open it back
5. Hit arrow-up keyboard button

### How to test
Ref: https://github.com/opensearch-project/sql/blob/2.x/sql-cli/development_guide.md#development-environment-set-up

Do once:
```
cd sql-cli
pip install virtualenv
virtualenv venv
pip install --editable .
```
Then every time you want to debug SQL CLI:
```
<checkout>
cd sql-cli
source ./venv/bin/activate
```
To exit from `venv`:
```
deactivate
```
You can run SQL CLI and switch branch. It will keep working with given timeout until closed.
 
### Issues Resolved
Query history didn't persist across SQL CLI runs.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).