### PR TITLE
Fix Relevance Fields Permissive When Fields are Missing.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -11,18 +11,10 @@ import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_LAST;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder.ASC;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
 import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
-import static org.opensearch.sql.utils.MLCommonsConstants.ACTION;
-import static org.opensearch.sql.utils.MLCommonsConstants.MODELID;
-import static org.opensearch.sql.utils.MLCommonsConstants.PREDICT;
 import static org.opensearch.sql.utils.MLCommonsConstants.RCF_ANOMALOUS;
 import static org.opensearch.sql.utils.MLCommonsConstants.RCF_ANOMALY_GRADE;
 import static org.opensearch.sql.utils.MLCommonsConstants.RCF_SCORE;
-import static org.opensearch.sql.utils.MLCommonsConstants.RCF_TIMESTAMP;
-import static org.opensearch.sql.utils.MLCommonsConstants.STATUS;
-import static org.opensearch.sql.utils.MLCommonsConstants.TASKID;
 import static org.opensearch.sql.utils.MLCommonsConstants.TIME_FIELD;
-import static org.opensearch.sql.utils.MLCommonsConstants.TRAIN;
-import static org.opensearch.sql.utils.MLCommonsConstants.TRAINANDPREDICT;
 import static org.opensearch.sql.utils.SystemIndexUtils.CATALOGS_TABLE_NAME;
 
 import com.google.common.collect.ImmutableList;
@@ -76,6 +68,7 @@ import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
@@ -83,6 +76,7 @@ import org.opensearch.sql.expression.aggregation.Aggregator;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.OpenSearchFunctions;
 import org.opensearch.sql.expression.function.TableFunctionImplementation;
 import org.opensearch.sql.expression.parse.ParseExpression;
 import org.opensearch.sql.planner.logical.LogicalAD;
@@ -224,6 +218,8 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   public LogicalPlan visitFilter(Filter node, AnalysisContext context) {
     LogicalPlan child = node.getChild().get(0).accept(this, context);
     Expression condition = expressionAnalyzer.analyze(node.getCondition(), context);
+
+    OpenSearchFunctions.validateFieldList((FunctionExpression)condition, context);
 
     ExpressionReferenceOptimizer optimizer =
         new ExpressionReferenceOptimizer(expressionAnalyzer.getRepository(), child);

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
+import org.opensearch.sql.legacy.utils.StringUtils;
 
 public class MatchIT extends SQLIntegTestCase {
   @Override
@@ -34,5 +35,15 @@ public class MatchIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " HAVING match(firstname, 'Nanette')");
     verifySchema(result, schema("lastname", "text"));
     verifyDataRows(result, rows("Bates"));
+  }
+
+  @Test
+  public void missing_field_test() {
+    String query = StringUtils.format("SELECT * FROM %s WHERE match(invalid, 'Bates')", TEST_INDEX_ACCOUNT);
+    final RuntimeException exception =
+        expectThrows(RuntimeException.class, () -> executeJdbcRequest(query));
+    assertTrue(exception.getMessage()
+        .contains("can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env") &&
+        exception.getMessage().contains("SemanticCheckException"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
+import org.opensearch.sql.legacy.utils.StringUtils;
 
 public class QueryStringIT extends SQLIntegTestCase {
   @Override
@@ -64,5 +65,15 @@ public class QueryStringIT extends SQLIntegTestCase {
         + " WHERE query_string(['*Date'], '2014-01-22');";
     JSONObject result3 = executeJdbcRequest(query3);
     assertEquals(10, result3.getInt("total"));
+  }
+
+  @Test
+  public void missing_field_test() {
+    String query = StringUtils.format("SELECT * FROM %s WHERE query_string([invalid], 'beer')", TEST_INDEX_BEER);
+    final RuntimeException exception =
+        expectThrows(RuntimeException.class, () -> executeJdbcRequest(query));
+    assertTrue(exception.getMessage()
+        .contains("can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env") &&
+        exception.getMessage().contains("SemanticCheckException"));
   }
 }


### PR DESCRIPTION
Signed-off-by: forestmvey <forestv@bitquilltech.com>

### Description
Relevance functions that query a field should act similar to how a `SELECT` query works. If a field is queried that does not exist, a `SemanticCheckException` should be thrown.

### Example Queryies
`SELECT * FROM stackexchange_beer WHERE query_string([invalid], 'beer');`
```
{'reason': 'Invalid SQL query', 'details': "can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env", 'type': 'SemanticCheckException'}
```
`SELECT * FROM stackexchange_beer WHERE match(invalid, 'beer');`
```
{'reason': 'Invalid SQL query', 'details': "can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env", 'type': 'SemanticCheckException'}
```
 
### Issues Resolved
[Issue: 613](https://github.com/opensearch-project/sql/issues/613)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).