### PR TITLE
Added Querystring As Alternate Syntax For Query_string

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -218,6 +218,7 @@ public enum BuiltinFunctionName {
    * Legacy Relevance Function.
    */
   QUERY(FunctionName.of("query")),
+  QUERYSTRING(FunctionName.of("querystring")),
   MATCH_QUERY(FunctionName.of("match_query")),
   MATCHQUERY(FunctionName.of("matchquery")),
   MULTI_MATCH(FunctionName.of("multi_match"));

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -31,7 +31,8 @@ public class OpenSearchFunctions {
     repository.register(multi_match());
     repository.register(simple_query_string());
     repository.register(query());
-    repository.register(query_string());
+    repository.register(query_string(BuiltinFunctionName.QUERY_STRING));
+    repository.register(query_string(BuiltinFunctionName.QUERYSTRING));
     // Register MATCHPHRASE as MATCH_PHRASE as well for backwards
     // compatibility.
     repository.register(match_phrase(BuiltinFunctionName.MATCH_PHRASE));
@@ -74,8 +75,8 @@ public class OpenSearchFunctions {
     return new RelevanceFunctionResolver(funcName, STRING);
   }
 
-  private static FunctionResolver query_string() {
-    FunctionName funcName = BuiltinFunctionName.QUERY_STRING.getName();
+  private static FunctionResolver query_string(BuiltinFunctionName queryString) {
+    FunctionName funcName = queryString.getName();
     return new RelevanceFunctionResolver(funcName, STRUCT);
   }
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -3017,6 +3017,68 @@ Another example to show how to set custom values for the optional parameters::
     +------+--------------------------+----------------------+
 
 
+QUERYSTRING
+------------
+
+Description
+>>>>>>>>>>>
+
+``querystring([field_expression+], query_expression[, option=<option_value>]*)``
+
+The querystring function maps to the query_string query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given field or fields. It is an alternate syntax for the `query_string`_ function.
+The **^** lets you *boost* certain fields. Boosts are multipliers that weigh matches in one field more heavily than matches in other fields. The syntax allows to specify the fields in double quotes, single quotes, backticks or without any wrap. All fields search using star ``"*"`` is also available (star symbol should be wrapped). The weight is optional and should be specified after the field name, it could be delimeted by the `caret` character or by whitespace. Please refer to examples below:
+
+| ``querystring(["Tags" ^ 2, 'Title' 3.4, `Body`, Comments ^ 0.3], ...)``
+| ``querystring(["*"], ...)``
+
+Available parameters include:
+
+- analyzer
+- escape
+- allow_leading_wildcard
+- analyze_wildcard
+- auto_generate_synonyms_phrase_query
+- boost
+- default_operator
+- enable_position_increments
+- fuzziness
+- fuzzy_max_expansions
+- fuzzy_prefix_length
+- fuzzy_transpositions
+- fuzzy_rewrite
+- tie_breaker
+- lenient
+- type
+- max_determinized_states
+- minimum_should_match
+- quote_analyzer
+- phrase_slop
+- quote_field_suffix
+- rewrite
+- time_zone
+
+Example with only ``fields`` and ``query`` expressions, and all other parameters are set default values::
+
+    os> select * from books where querystring(['title'], 'Pooh House');
+    fetched rows / total rows = 2/2
+    +------+--------------------------+----------------------+
+    | id   | title                    | author               |
+    |------+--------------------------+----------------------|
+    | 1    | The House at Pooh Corner | Alan Alexander Milne |
+    | 2    | Winnie-the-Pooh          | Alan Alexander Milne |
+    +------+--------------------------+----------------------+
+
+Another example to show how to set custom values for the optional parameters::
+
+    os> select * from books where querystring(['title'], 'Pooh House', default_operator='AND');
+    fetched rows / total rows = 1/1
+    +------+--------------------------+----------------------+
+    | id   | title                    | author               |
+    |------+--------------------------+----------------------|
+    | 1    | The House at Pooh Corner | Alan Alexander Milne |
+    +------+--------------------------+----------------------+
+
+
 QUERY
 -----
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
@@ -65,4 +65,52 @@ public class QueryStringIT extends SQLIntegTestCase {
     JSONObject result3 = executeJdbcRequest(query3);
     assertEquals(10, result3.getInt("total"));
   }
+
+  @Test
+  public void all_fields_test_querystring_syntax() throws IOException {
+    String query = "SELECT * FROM "
+        + TEST_INDEX_BEER + " WHERE querystring([`*`], 'taste')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(16, result.getInt("total"));
+  }
+
+  @Test
+  public void mandatory_params_test_querystring_syntax() throws IOException {
+    String query = "SELECT Id FROM "
+        + TEST_INDEX_BEER + " WHERE querystring([\\\"Tags\\\" ^ 1.5, Title, `Body` 4.2], 'taste')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(16, result.getInt("total"));
+  }
+
+  @Test
+  public void all_params_test_querystring_syntax() throws IOException {
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE querystring(['Body', Tags, Title], 'taste beer', escape=false,"
+        + "allow_leading_wildcard=true, enable_position_increments=true,"
+        + "fuzziness= 1, fuzzy_rewrite='constant_score', max_determinized_states = 10000,"
+        + "analyzer='english', analyze_wildcard = false, quote_field_suffix = '.exact',"
+        + "auto_generate_synonyms_phrase_query=true, boost = 0.77,"
+        + "quote_analyzer='standard', phrase_slop=0, rewrite='constant_score', type='best_fields',"
+        + "tie_breaker=0.3, time_zone='Canada/Pacific', default_operator='or',"
+        + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
+        + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7);";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(49, result.getInt("total"));
+  }
+
+  @Test
+  public void wildcard_test_querystring_syntax() throws IOException {
+    String query1 = "SELECT Id FROM "
+        + TEST_INDEX_BEER + " WHERE querystring(['Tags'], 'taste')";
+    JSONObject result1 = executeJdbcRequest(query1);
+    String query2 = "SELECT Id FROM "
+        + TEST_INDEX_BEER + " WHERE querystring(['T*'], 'taste')";
+    JSONObject result2 = executeJdbcRequest(query2);
+    assertNotEquals(result2.getInt("total"), result1.getInt("total"));
+
+    String query3 = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE querystring(['*Date'], '2014-01-22');";
+    JSONObject result3 = executeJdbcRequest(query3);
+    assertEquals(10, result3.getInt("total"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -67,6 +67,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.MULTI_MATCH.getName(), new MultiMatchQuery())
           .put(BuiltinFunctionName.SIMPLE_QUERY_STRING.getName(), new SimpleQueryStringQuery())
           .put(BuiltinFunctionName.QUERY_STRING.getName(), new QueryStringQuery())
+          .put(BuiltinFunctionName.QUERYSTRING.getName(), new QueryStringQuery())
           .put(BuiltinFunctionName.MATCH_BOOL_PREFIX.getName(), new MatchBoolPrefixQuery())
           .put(BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName(), new MatchPhrasePrefixQuery())
           .build();

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/QueryStringTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/QueryStringTest.java
@@ -40,7 +40,8 @@ class QueryStringTest {
   private final QueryStringQuery queryStringQuery = new QueryStringQuery();
   private final FunctionName queryStringFuncWithUnderscoreName = FunctionName.of("query_string");
   private final FunctionName queryStringFuncName = FunctionName.of("querystring");
-  private final FunctionName[] functionNames = {queryStringFuncWithUnderscoreName, queryStringFuncName};
+  private final FunctionName[] functionNames =
+      {queryStringFuncWithUnderscoreName, queryStringFuncName};
   private static final LiteralExpression fields_value = DSL.literal(
       new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
           "title", ExprValueUtils.floatValue(1.F),

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -297,6 +297,7 @@ MATCHPHRASE:                        'MATCHPHRASE';
 MATCH_PHRASE:                       'MATCH_PHRASE';
 SIMPLE_QUERY_STRING:                'SIMPLE_QUERY_STRING';
 QUERY_STRING:                       'QUERY_STRING';
+QUERYSTRING:                        'QUERYSTRING';
 MATCH_PHRASE_PREFIX:                'MATCH_PHRASE_PREFIX';
 MATCHQUERY:                         'MATCHQUERY';
 MATCH_QUERY:                        'MATCH_QUERY';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -433,6 +433,7 @@ multiFieldRelevanceFunctionName
     : MULTI_MATCH
     | SIMPLE_QUERY_STRING
     | QUERY_STRING
+    | QUERYSTRING
     ;
 
 legacyRelevanceFunctionName

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -325,6 +325,67 @@ class SQLSyntaxParserTest {
             + "operator='AND', tie_breaker=0.3, type = \"most_fields\", fuzziness = 4)"));
   }
 
+  @Test
+  public void can_parse_querystring_relevance_function() {
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['*'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['address'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['add*'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['*ess'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['address', 'notes'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([\"*\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([\"address\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([\"ad*\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([\"*s\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([\"address\", \"notes\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([`*`], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([`address`], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([`ad*`], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([`*ss`], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([`address`, `notes`], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([address], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([addr*], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([*ss], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring([address, notes], 'query')"));
+
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE"
+            + " querystring(['address' ^ 1.0, 'notes' ^ 2.2], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['address' ^ 1.1, 'notes'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['address', 'notes' ^ 1.5], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['address', 'notes' 3], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE querystring(['address' ^ .3, 'notes' 3], 'query')"));
+
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE"
+            + " querystring([\"Tags\" ^ 1.5, Title, `Body` 4.2], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE"
+            + " querystring([\"Tags\" ^ 1.5, Title, `Body` 4.2], 'query', analyzer=keyword,"
+            + "operator='AND', tie_breaker=0.3, type = \"most_fields\", fuzziness = 4)"));
+  }
 
   @Test
   public void can_parse_query_relevance_function() {

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -544,6 +544,26 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void relevanceQuerystring() {
+    assertEquals(AstDSL.function("querystring",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
+                "field2", 3.2F, "field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("querystring(['field1', 'field2' ^ 3.2], 'search query')")
+    );
+
+    assertEquals(AstDSL.function("querystring",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
+                "field2", 3.2F, "field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query")),
+            unresolvedArg("analyzer", stringLiteral("keyword")),
+            unresolvedArg("time_zone", stringLiteral("Canada/Pacific")),
+            unresolvedArg("tie_breaker", stringLiteral("1.3"))),
+        buildExprAst("querystring(['field1', 'field2' ^ 3.2], 'search query',"
+            + "analyzer='keyword', time_zone='Canada/Pacific', tie_breaker='1.3')"));
+  }
+
+  @Test
   public void relevanceQuery() {
     assertEquals(AstDSL.function("query",
                     unresolvedArg("query", stringLiteral("field1:query OR field2:query"))),


### PR DESCRIPTION
### Description
Added alternate syntax `querystring` for the `query_string` function which currently exists in the SQL plugin.
 
### Issues Resolved
[AOS-765](https://bitquill.atlassian.net/browse/AOS-765?atlOrigin=eyJpIjoiMDZjMjNkODcyMDQ0NDUxNDkxMGQyZDYxNWQxNjQyM2IiLCJwIjoiaiJ9)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).