### PR TITLE
Add SimpleQueryString As Alternate Syntax For Simple_Query_String

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -218,6 +218,7 @@ public enum BuiltinFunctionName {
    * Legacy Relevance Function.
    */
   QUERY(FunctionName.of("query")),
+  SIMPLEQUERYSTRING(FunctionName.of("simplequerystring")),
   MATCH_QUERY(FunctionName.of("match_query")),
   MATCHQUERY(FunctionName.of("matchquery")),
   MULTI_MATCH(FunctionName.of("multi_match"));

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -29,7 +29,8 @@ public class OpenSearchFunctions {
     repository.register(match_bool_prefix());
     repository.register(match());
     repository.register(multi_match());
-    repository.register(simple_query_string());
+    repository.register(simple_query_string(BuiltinFunctionName.SIMPLE_QUERY_STRING));
+    repository.register(simple_query_string(BuiltinFunctionName.SIMPLEQUERYSTRING));
     repository.register(query());
     repository.register(query_string());
     // Register MATCHPHRASE as MATCH_PHRASE as well for backwards
@@ -64,8 +65,8 @@ public class OpenSearchFunctions {
     return new RelevanceFunctionResolver(funcName, STRUCT);
   }
 
-  private static FunctionResolver simple_query_string() {
-    FunctionName funcName = BuiltinFunctionName.SIMPLE_QUERY_STRING.getName();
+  private static FunctionResolver simple_query_string(BuiltinFunctionName simpleQueryString) {
+    FunctionName funcName = simpleQueryString.getName();
     return new RelevanceFunctionResolver(funcName, STRUCT);
   }
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2955,6 +2955,58 @@ Another example to show how to set custom values for the optional parameters::
     +------+--------------------------+----------------------+
 
 
+SIMPLEQUERYSTRING
+-------------------
+
+Description
+>>>>>>>>>>>
+
+``simplequerystring([field_expression+], query_expression[, option=<option_value>]*)``
+
+The simplequerystring function maps to the simple_query_string query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given field or fields. This is an alternate syntax for `simple_query_string`_
+The **^** lets you *boost* certain fields. Boosts are multipliers that weigh matches in one field more heavily than matches in other fields. The syntax allows to specify the fields in double quotes, single quotes, in backtick or even without any wrap. All fields search using star ``"*"`` is also available (star symbol should be wrapped). The weight is optional and should be specified using after the field name, it could be delimeted by the `caret` character or by whitespace. Please, refer to examples below:
+
+| ``simplequerystring(["Tags" ^ 2, 'Title' 3.4, `Body`, Comments ^ 0.3], ...)``
+| ``simplequerystring(["*"], ...)``
+
+Available parameters include:
+
+- analyze_wildcard
+- analyzer
+- auto_generate_synonyms_phrase
+- flags
+- fuzziness
+- fuzzy_max_expansions
+- fuzzy_prefix_length
+- fuzzy_transpositions
+- lenient
+- default_operator
+- minimum_should_match
+- quote_field_suffix
+- boost
+
+Example with only ``fields`` and ``query`` expressions, and all other parameters are set default values::
+
+    os> select * from books where simplequerystring(['title'], 'Pooh House');
+    fetched rows / total rows = 2/2
+    +------+--------------------------+----------------------+
+    | id   | title                    | author               |
+    |------+--------------------------+----------------------|
+    | 1    | The House at Pooh Corner | Alan Alexander Milne |
+    | 2    | Winnie-the-Pooh          | Alan Alexander Milne |
+    +------+--------------------------+----------------------+
+
+Another example to show how to set custom values for the optional parameters::
+
+    os> select * from books where simplequerystring(['title'], 'Pooh House', flags='ALL', default_operator='AND');
+    fetched rows / total rows = 1/1
+    +------+--------------------------+----------------------+
+    | id   | title                    | author               |
+    |------+--------------------------+----------------------|
+    | 1    | The House at Pooh Corner | Alan Alexander Milne |
+    +------+--------------------------+----------------------+
+
+
 QUERY_STRING
 ------------
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -61,4 +61,41 @@ public class SimpleQueryStringIT extends SQLIntegTestCase {
     var result = new JSONObject(executeQuery(query, "jdbc"));
     assertEquals(10, result.getInt("total"));
   }
+
+  @Test
+  public void test_mandatory_params_simplequerystring() throws IOException {
+    String query = "SELECT Id FROM "
+        + TEST_INDEX_BEER + " WHERE simplequerystring([\\\"Tags\\\" ^ 1.5, Title, `Body` 4.2], 'taste')";
+    var result = new JSONObject(executeQuery(query, "jdbc"));
+    assertEquals(16, result.getInt("total"));
+  }
+
+  @Test
+  public void test_all_params_simplequerystring() throws IOException {
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE simplequerystring(['Body', Tags, Title], 'taste beer', default_operator='or',"
+        + "analyzer=english, analyze_wildcard = false, quote_field_suffix = '.exact',"
+        + "auto_generate_synonyms_phrase_query=true, boost = 0.77, flags='PREFIX',"
+        + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
+        + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7);";
+    var result = new JSONObject(executeQuery(query, "jdbc"));
+    assertEquals(49, result.getInt("total"));
+  }
+
+  @Test
+  public void verify_wildcard_test_simplequerystring() throws IOException {
+    String query1 = "SELECT Id FROM "
+        + TEST_INDEX_BEER + " WHERE simplequerystring(['Tags'], 'taste')";
+    var result1 = new JSONObject(executeQuery(query1, "jdbc"));
+    String query2 = "SELECT Id FROM "
+        + TEST_INDEX_BEER + " WHERE simplequerystring(['T*'], 'taste')";
+    var result2 = new JSONObject(executeQuery(query2, "jdbc"));
+    assertNotEquals(result2.getInt("total"), result1.getInt("total"));
+
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE simplequerystring(['*Date'], '2014-01-22');";
+    var result = new JSONObject(executeQuery(query, "jdbc"));
+    assertEquals(10, result.getInt("total"));
+  }
+
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -66,6 +66,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MULTI_MATCH.getName(), new MultiMatchQuery())
           .put(BuiltinFunctionName.SIMPLE_QUERY_STRING.getName(), new SimpleQueryStringQuery())
+          .put(BuiltinFunctionName.SIMPLEQUERYSTRING.getName(), new SimpleQueryStringQuery())
           .put(BuiltinFunctionName.QUERY_STRING.getName(), new QueryStringQuery())
           .put(BuiltinFunctionName.MATCH_BOOL_PREFIX.getName(), new MatchBoolPrefixQuery())
           .put(BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName(), new MatchPhrasePrefixQuery())

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/SimpleQueryStringTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/SimpleQueryStringTest.java
@@ -39,7 +39,12 @@ class SimpleQueryStringTest {
   private static final DSL dsl = new ExpressionConfig()
       .dsl(new ExpressionConfig().functionRepository());
   private final SimpleQueryStringQuery simpleQueryStringQuery = new SimpleQueryStringQuery();
-  private final FunctionName simpleQueryString = FunctionName.of("simple_query_string");
+  private final FunctionName simpleQueryStringWithUnderscoresName =
+      FunctionName.of("simple_query_string");
+  private final FunctionName simpleQueryStringName = FunctionName.of("simplequerystring");
+  private final FunctionName[] functionNames =
+      {simpleQueryStringWithUnderscoresName, simpleQueryStringName};
+
   private static final LiteralExpression fields_value = DSL.literal(
       new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
           "title", ExprValueUtils.floatValue(1.F),
@@ -157,22 +162,28 @@ class SimpleQueryStringTest {
   @ParameterizedTest
   @MethodSource("generateValidData")
   public void test_valid_parameters(List<Expression> validArgs) {
-    Assertions.assertNotNull(simpleQueryStringQuery.build(
-        new SimpleQueryStringExpression(validArgs)));
+    for (FunctionName funcName : functionNames) {
+      Assertions.assertNotNull(simpleQueryStringQuery.build(
+          new SimpleQueryStringExpression(validArgs, funcName)));
+    }
   }
 
   @Test
   public void test_SyntaxCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
-    assertThrows(SyntaxCheckException.class,
-        () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments)));
+    for (FunctionName funcName : functionNames) {
+      assertThrows(SyntaxCheckException.class,
+          () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments, funcName)));
+    }
   }
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
     List<Expression> arguments = List.of(namedArgument("fields", fields_value));
-    assertThrows(SyntaxCheckException.class,
-        () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments)));
+    for (FunctionName funcName : functionNames) {
+      assertThrows(SyntaxCheckException.class,
+          () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments, funcName)));
+    }
   }
 
   @Test
@@ -181,8 +192,10 @@ class SimpleQueryStringTest {
         namedArgument("fields", fields_value),
         namedArgument("query", query_value),
         namedArgument("unsupported", "unsupported_value"));
-    Assertions.assertThrows(SemanticCheckException.class,
-        () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments)));
+    for (FunctionName funcName : functionNames) {
+      Assertions.assertThrows(SemanticCheckException.class,
+          () -> simpleQueryStringQuery.build(new SimpleQueryStringExpression(arguments, funcName)));
+    }
   }
 
   private NamedArgumentExpression namedArgument(String name, String value) {
@@ -194,8 +207,8 @@ class SimpleQueryStringTest {
   }
 
   private class SimpleQueryStringExpression extends FunctionExpression {
-    public SimpleQueryStringExpression(List<Expression> arguments) {
-      super(SimpleQueryStringTest.this.simpleQueryString, arguments);
+    public SimpleQueryStringExpression(List<Expression> arguments, FunctionName funcName) {
+      super(funcName, arguments);
     }
 
     @Override

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -296,6 +296,7 @@ IN_TERMS:                           'IN_TERMS';
 MATCHPHRASE:                        'MATCHPHRASE';
 MATCH_PHRASE:                       'MATCH_PHRASE';
 SIMPLE_QUERY_STRING:                'SIMPLE_QUERY_STRING';
+SIMPLEQUERYSTRING:                  'SIMPLEQUERYSTRING';
 QUERY_STRING:                       'QUERY_STRING';
 MATCH_PHRASE_PREFIX:                'MATCH_PHRASE_PREFIX';
 MATCHQUERY:                         'MATCHQUERY';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -432,6 +432,7 @@ singleFieldRelevanceFunctionName
 multiFieldRelevanceFunctionName
     : MULTI_MATCH
     | SIMPLE_QUERY_STRING
+    | SIMPLEQUERYSTRING
     | QUERY_STRING
     ;
 

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -264,6 +264,42 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_simplequerystring_relevance_function() {
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring(['address'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring(['address', 'notes'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring([\"*\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring([\"address\"], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring([`address`], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring([address], 'query')"));
+
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE"
+            + " simplequerystring(['address' ^ 1.0, 'notes' ^ 2.2], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring(['address' ^ 1.1, 'notes'], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring(['address', 'notes' ^ 1.5], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring(['address', 'notes' 3], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE simplequerystring(['address' ^ .3, 'notes' 3], 'query')"));
+
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE"
+            + " simplequerystring([\"Tags\" ^ 1.5, Title, `Body` 4.2], 'query')"));
+    assertNotNull(parser.parse(
+        "SELECT id FROM test WHERE"
+            + " simplequerystring([\"Tags\" ^ 1.5, Title, `Body` 4.2], 'query', analyzer=keyword,"
+            + "flags='AND', quote_field_suffix=\".exact\", fuzzy_prefix_length = 4)"));
+  }
+
+  @Test
   public void can_parse_query_string_relevance_function() {
     assertNotNull(parser.parse(
         "SELECT id FROM test WHERE query_string(['*'], 'query')"));

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -524,6 +524,25 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void relevanceSimplequerystring() {
+    assertEquals(AstDSL.function("simplequerystring",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
+                "field2", 3.2F, "field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("simplequerystring(['field1', 'field2' ^ 3.2], 'search query')")
+    );
+
+    assertEquals(AstDSL.function("simplequerystring",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
+                "field2", 3.2F, "field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query")),
+            unresolvedArg("analyzer", stringLiteral("keyword")),
+            unresolvedArg("operator", stringLiteral("AND"))),
+        buildExprAst("simplequerystring(['field1', 'field2' ^ 3.2], 'search query',"
+            + "analyzer='keyword', operator='AND')"));
+  }
+
+  @Test
   public void relevanceQuery_string() {
     assertEquals(AstDSL.function("query_string",
             unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(


### PR DESCRIPTION
### Description
Adds `simplequerystring` as alternate syntax for the `simple_query_string` function which currently exists in the SQL plugin.
 
### Issues Resolved
[AOS-765](https://bitquill.atlassian.net/browse/AOS-765?atlOrigin=eyJpIjoiMDZjMjNkODcyMDQ0NDUxNDkxMGQyZDYxNWQxNjQyM2IiLCJwIjoiaiJ9)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).