### PR TITLE
[WIP] Use mapping format for reading `date` values

### DIFF
--- a/core/src/main/java/org/opensearch/sql/data/model/ExprTimeValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprTimeValue.java
@@ -58,6 +58,21 @@ public class ExprTimeValue extends AbstractExprValue {
   }
 
   @Override
+  public LocalDate dateValue() {
+    return LocalDate.now();
+  }
+
+  @Override
+  public LocalDateTime datetimeValue() {
+    return LocalDateTime.of(dateValue(), timeValue());
+  }
+
+  @Override
+  public Instant timestampValue() {
+    return ZonedDateTime.of(dateValue(), timeValue(), ExprTimestampValue.ZONE).toInstant();
+  }
+
+  @Override
   public String toString() {
     return String.format("TIME '%s'", value());
   }

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
@@ -30,7 +30,7 @@ public class ExprTimestampValue extends AbstractExprValue {
   /**
    * todo. only support UTC now.
    */
-  private static final ZoneId ZONE = ZoneId.of("UTC");
+  public static final ZoneId ZONE = ZoneId.of("UTC");
 
   private final Instant timestamp;
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -77,11 +77,7 @@ public class OpenSearchExprValueFactory {
   /**
    * The Mapping of Field and ExprType.
    */
-  @Setter
-  private Map<String, ExprType> typeMapping;
-
-
-  private Map<String, MappingEntry> typeMapping2;
+  private Map<String, MappingEntry> typeMapping;
 
   @Getter
   @Setter
@@ -116,15 +112,8 @@ public class OpenSearchExprValueFactory {
   /**
    * Constructor of OpenSearchExprValueFactory.
    */
-  public OpenSearchExprValueFactory(
-      Map<String, ExprType> typeMapping) {
+  public OpenSearchExprValueFactory(Map<String, MappingEntry> typeMapping) {
     this.typeMapping = typeMapping;
-  }
-
-  public OpenSearchExprValueFactory(Map<String, ExprType> typeMapping,
-                                    Map<String, MappingEntry> typeMapping2) {
-    this.typeMapping = typeMapping;
-    this.typeMapping2 = typeMapping2;
   }
 
   /**
@@ -167,7 +156,7 @@ public class OpenSearchExprValueFactory {
       return parseArray(content, field);
     } else {
       if (typeActionMap.containsKey(type)) {
-        return typeActionMap.get(type).apply(content, typeMapping2.getOrDefault(field, null));
+        return typeActionMap.get(type).apply(content, typeMapping.getOrDefault(field, null));
       } else {
         throw new IllegalStateException(
             String.format(
@@ -181,7 +170,7 @@ public class OpenSearchExprValueFactory {
    * but has empty value. For example, {"empty_field": []}.
    */
   private Optional<ExprType> type(String field) {
-    return Optional.ofNullable(typeMapping.get(field));
+    return Optional.ofNullable(typeMapping.get(field).getDataType());
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -77,6 +77,7 @@ public class OpenSearchExprValueFactory {
   /**
    * The Mapping of Field and ExprType.
    */
+  @Setter
   private Map<String, MappingEntry> typeMapping;
 
   @Getter

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/IndexMapping.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/IndexMapping.java
@@ -68,9 +68,11 @@ public class IndexMapping {
         .collect(Collectors.toMap(Map.Entry::getKey, e -> transform.apply(e.getValue())));
   }
 
+  // TODO nested, consider recursive call
   @SuppressWarnings("unchecked")
   private Map<String, MappingEntry> flat2(Map<String, Object> indexMapping) {
-    return ((Map<String, Object>)indexMapping.get("properties")).entrySet().stream()
+    return ((Map<String, Object>)indexMapping.getOrDefault("properties", emptyMap()))
+        .entrySet().stream()
         .collect(Collectors.toMap(e -> e.getKey(), e -> {
           Map<String, Object> mapping = (Map<String, Object>) e.getValue();
           return new MappingEntry((String) mapping.getOrDefault("type", "object"),

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/IndexMapping.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/IndexMapping.java
@@ -26,11 +26,14 @@ public class IndexMapping {
   /** Field mappings from field name to field type in OpenSearch date type system. */
   private final Map<String, String> fieldMappings;
 
+  public Map<String, MappingEntry> mapping2;
+
   public IndexMapping(Map<String, String> fieldMappings) {
     this.fieldMappings = fieldMappings;
   }
 
   public IndexMapping(MappingMetadata metaData) {
+    this.mapping2 = flat2(metaData.getSourceAsMap());
     this.fieldMappings = flatMappings(metaData.getSourceAsMap());
   }
 
@@ -64,6 +67,17 @@ public class IndexMapping {
     return fieldMappings.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> transform.apply(e.getValue())));
   }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, MappingEntry> flat2(Map<String, Object> indexMapping) {
+    return ((Map<String, Object>)indexMapping.get("properties")).entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey(), e -> {
+          Map<String, Object> mapping = (Map<String, Object>) e.getValue();
+          return new MappingEntry((String) mapping.getOrDefault("type", "object"),
+              (String) mapping.getOrDefault("format", null), null);
+        }));
+  }
+
 
   @SuppressWarnings("unchecked")
   private Map<String, String> flatMappings(Map<String, Object> indexMapping) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/MappingEntry.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/MappingEntry.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.opensearch.mapping;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.opensearch.common.time.DateFormatter;
+import org.opensearch.sql.data.type.ExprType;
+
+@AllArgsConstructor
+public class MappingEntry {
+
+  @Getter
+  private String fieldType;
+
+  @Getter
+  private String formats;
+
+  @Getter
+  @Setter
+  private ExprType dataType;
+
+  public MappingEntry(String fieldType) {
+    this(fieldType, null, null);
+  }
+
+  public List<String> getFormatList() {
+    if (formats == null || formats.isEmpty()) {
+      return List.of();
+    }
+    return Arrays.stream(formats.split("\\|\\|")).map(String::trim).collect(Collectors.toList());
+  }
+
+  public List<DateFormatter> getNamedFormatters() {
+    return getFormatList().stream().filter(f -> {
+          try {
+            DateTimeFormatter.ofPattern(f);
+            return false;
+          } catch (Exception e) {
+            return true;
+          }
+        })
+        .map(DateFormatter::forPattern).collect(Collectors.toList());
+  }
+
+  public List<DateTimeFormatter> getRegularFormatters() {
+    return getFormatList().stream().map(f -> {
+          try {
+            return DateTimeFormatter.ofPattern(f);
+          } catch (Exception e) {
+            return null;
+          }
+        })
+        .filter(Objects::nonNull).collect(Collectors.toList());
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/MappingEntry.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/mapping/MappingEntry.java
@@ -20,12 +20,21 @@ import org.opensearch.sql.data.type.ExprType;
 @AllArgsConstructor
 public class MappingEntry {
 
+  /**
+   * Data type stored in index mapping.
+   */
   @Getter
   private String fieldType;
 
+  /**
+   * Date formats stored in index mapping.
+   */
   @Getter
   private String formats;
 
+  /**
+   * ExprType calculated for given `fieldType`.
+   */
   @Getter
   @Setter
   private ExprType dataType;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
@@ -32,6 +32,7 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.mapping.MappingEntry;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
 
 /**
@@ -213,7 +214,7 @@ public class OpenSearchRequestBuilder {
     sourceBuilder.fetchSource(projectsSet.toArray(new String[0]), new String[0]);
   }
 
-  public void pushTypeMapping(Map<String, ExprType> typeMapping) {
+  public void pushTypeMapping(Map<String, MappingEntry> typeMapping) {
     exprValueFactory.setTypeMapping(typeMapping);
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/system/OpenSearchDescribeIndexRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/system/OpenSearchDescribeIndexRequest.java
@@ -17,9 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.tuple.Triple;
-import org.opensearch.common.collect.Tuple;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
@@ -126,7 +123,7 @@ public class OpenSearchDescribeIndexRequest implements OpenSearchSystemRequest {
   }
 
   // TODO possible collision if two indices have fields with same names
-  public Map<String, MappingEntry> getFieldTypes2() {
+  public Map<String, MappingEntry> getFieldMappings() {
     Map<String, IndexMapping> indexMappings = client.getIndexMappings(indexName.getIndexNames());
     Map<String, MappingEntry> fieldTypes = new HashMap<>();
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -19,6 +19,7 @@ import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.mapping.MappingEntry;
 import org.opensearch.sql.opensearch.planner.logical.OpenSearchLogicalIndexAgg;
 import org.opensearch.sql.opensearch.planner.logical.OpenSearchLogicalIndexScan;
 import org.opensearch.sql.opensearch.planner.logical.OpenSearchLogicalPlanOptimizerFactory;
@@ -60,6 +61,8 @@ public class OpenSearchIndex implements Table {
    */
   private Map<String, ExprType> cachedFieldTypes = null;
 
+  private Map<String, MappingEntry> cachedFieldMappings = null;
+
   /**
    * The cached max result window setting of index.
    */
@@ -87,6 +90,13 @@ public class OpenSearchIndex implements Table {
     return cachedFieldTypes;
   }
 
+  public Map<String, MappingEntry> getFieldMappings() {
+    if (cachedFieldMappings == null) {
+      cachedFieldMappings = new OpenSearchDescribeIndexRequest(client, indexName).getFieldMappings();
+    }
+    return cachedFieldMappings;
+  }
+
   /**
    * Get the max result window setting of the table.
    */
@@ -104,8 +114,7 @@ public class OpenSearchIndex implements Table {
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
     OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName,
-        getMaxResultWindow(), new OpenSearchExprValueFactory(getFieldTypes(),
-            new OpenSearchDescribeIndexRequest(client, indexName).getFieldTypes2()));
+        getMaxResultWindow(), new OpenSearchExprValueFactory(getFieldMappings()));
 
     /*
      * Visit logical plan with index scan as context so logical operators visited, such as

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -104,7 +104,8 @@ public class OpenSearchIndex implements Table {
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
     OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName,
-        getMaxResultWindow(), new OpenSearchExprValueFactory(getFieldTypes()));
+        getMaxResultWindow(), new OpenSearchExprValueFactory(getFieldTypes(),
+            new OpenSearchDescribeIndexRequest(client, indexName).getFieldTypes2()));
 
     /*
      * Visit logical plan with index scan as context so logical operators visited, such as

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
@@ -30,6 +30,7 @@ import org.opensearch.sql.expression.ExpressionNodeVisitor;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
+import org.opensearch.sql.opensearch.mapping.MappingEntry;
 import org.opensearch.sql.opensearch.response.agg.CompositeAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.MetricParser;
 import org.opensearch.sql.opensearch.response.agg.NoBucketAggregationParser;
@@ -104,14 +105,14 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
   }
 
   /**
-   * Build ElasticsearchExprValueFactory.
+   * Build mapping for OpenSearchExprValueFactory.
    */
-  public Map<String, ExprType> buildTypeMapping(
+  public Map<String, MappingEntry> buildTypeMapping(
       List<NamedAggregator> namedAggregatorList,
       List<NamedExpression> groupByList) {
-    ImmutableMap.Builder<String, ExprType> builder = new ImmutableMap.Builder<>();
-    namedAggregatorList.forEach(agg -> builder.put(agg.getName(), agg.type()));
-    groupByList.forEach(group -> builder.put(group.getNameOrAlias(), group.type()));
+    ImmutableMap.Builder<String, MappingEntry> builder = new ImmutableMap.Builder<>();
+    namedAggregatorList.forEach(agg -> builder.put(agg.getName(), new MappingEntry(null, null, agg.type())));
+    groupByList.forEach(group -> builder.put(group.getNameOrAlias(), new MappingEntry(null, null, group.type())));
     return builder.build();
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
@@ -29,6 +29,7 @@ import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.parse.ParseExpression;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.mapping.MappingEntry;
 import org.opensearch.sql.opensearch.storage.script.ScriptUtils;
 
 /**
@@ -105,10 +106,9 @@ public class ExpressionScript {
   }
 
   private OpenSearchExprValueFactory buildValueFactory(Set<ReferenceExpression> fields) {
-    Map<String, ExprType> typeEnv = fields.stream()
-        .collect(toMap(
-            ReferenceExpression::getAttr,
-            ReferenceExpression::type));
+    Map<String, MappingEntry> typeEnv = fields.stream().collect(toMap(
+        e -> e.getAttr(),
+        e -> new MappingEntry(null, null, e.type())));
     return new OpenSearchExprValueFactory(typeEnv);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -56,35 +56,37 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.data.utils.OpenSearchJsonContent;
+import org.opensearch.sql.opensearch.mapping.MappingEntry;
 
 class OpenSearchExprValueFactoryTest {
 
-  private static final Map<String, ExprType> MAPPING =
-      new ImmutableMap.Builder<String, ExprType>()
-          .put("byteV", BYTE)
-          .put("shortV", SHORT)
-          .put("intV", INTEGER)
-          .put("longV", LONG)
-          .put("floatV", FLOAT)
-          .put("doubleV", DOUBLE)
-          .put("stringV", STRING)
-          .put("dateV", DATE)
-          .put("datetimeV", DATETIME)
-          .put("timeV", TIME)
-          .put("timestampV", TIMESTAMP)
-          .put("boolV", BOOLEAN)
-          .put("structV", STRUCT)
-          .put("structV.id", INTEGER)
-          .put("structV.state", STRING)
-          .put("arrayV", ARRAY)
-          .put("arrayV.info", STRING)
-          .put("arrayV.author", STRING)
-          .put("textV", OPENSEARCH_TEXT)
-          .put("textKeywordV", OPENSEARCH_TEXT_KEYWORD)
-          .put("ipV", OPENSEARCH_IP)
-          .put("geoV", OPENSEARCH_GEO_POINT)
-          .put("binaryV", OPENSEARCH_BINARY)
+    private static final Map<String, MappingEntry> MAPPING =
+      new ImmutableMap.Builder<String, MappingEntry>()
+          .put("byteV", new MappingEntry(null, null, BYTE))
+          .put("shortV", new MappingEntry(null, null, SHORT))
+          .put("intV", new MappingEntry(null, null, INTEGER))
+          .put("longV", new MappingEntry(null, null, LONG))
+          .put("floatV", new MappingEntry(null, null, FLOAT))
+          .put("doubleV", new MappingEntry(null, null, DOUBLE))
+          .put("stringV", new MappingEntry(null, null, STRING))
+          .put("dateV", new MappingEntry(null, null, DATE))
+          .put("datetimeV", new MappingEntry(null, null, DATETIME))
+          .put("timeV", new MappingEntry(null, null, TIME))
+          .put("timestampV", new MappingEntry(null, null, TIMESTAMP))
+          .put("boolV", new MappingEntry(null, null, BOOLEAN))
+          .put("structV", new MappingEntry(null, null, STRUCT))
+          .put("structV.id", new MappingEntry(null, null, INTEGER))
+          .put("structV.state", new MappingEntry(null, null, STRING))
+          .put("arrayV", new MappingEntry(null, null, ARRAY))
+          .put("arrayV.info", new MappingEntry(null, null, STRING))
+          .put("arrayV.author", new MappingEntry(null, null, STRING))
+          .put("textV", new MappingEntry(null, null, OPENSEARCH_TEXT))
+          .put("textKeywordV", new MappingEntry(null, null, OPENSEARCH_TEXT_KEYWORD))
+          .put("ipV", new MappingEntry(null, null, OPENSEARCH_IP))
+          .put("geoV", new MappingEntry(null, null, OPENSEARCH_GEO_POINT))
+          .put("binaryV", new MappingEntry(null, null, OPENSEARCH_BINARY))
           .build();
+
   private OpenSearchExprValueFactory exprValueFactory =
       new OpenSearchExprValueFactory(MAPPING);
 
@@ -364,7 +366,8 @@ class OpenSearchExprValueFactoryTest {
   @Test
   public void constructUnsupportedTypeThrowException() {
     OpenSearchExprValueFactory exprValueFactory =
-        new OpenSearchExprValueFactory(ImmutableMap.of("type", new TestType()));
+        new OpenSearchExprValueFactory(ImmutableMap.of("type",
+            new MappingEntry(null, null, new TestType())));
     IllegalStateException exception =
         assertThrows(IllegalStateException.class, () -> exprValueFactory.construct("{\"type\":1}"));
     assertEquals("Unsupported type: TEST_TYPE for value: 1.", exception.getMessage());

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScanTest.java
@@ -41,6 +41,7 @@ import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.mapping.MappingEntry;
 import org.opensearch.sql.opensearch.request.OpenSearchQueryRequest;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.response.OpenSearchResponse;
@@ -55,7 +56,8 @@ class OpenSearchIndexScanTest {
   private Settings settings;
 
   private OpenSearchExprValueFactory exprValueFactory = new OpenSearchExprValueFactory(
-      ImmutableMap.of("name", STRING, "department", STRING));
+      Map.of("name", new MappingEntry(null, null, STRING),
+              "department", new MappingEntry(null, null, STRING)));
 
   @BeforeEach
   void setup() {


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
The fix is to collect formats from mapping and pass it to `OpenSearchExprValueFactory`.
I added `mapping2` member to `IndexMapping` and `OpenSearchExprValueFactory` which hold required data. The original mapping is not removed yet to ensure that everything works as was before.


### Test data
[date_formats.json.txt](https://github.com/Bit-Quill/opensearch-project-sql/files/10025908/date_formats.json.txt)
[date_formats_mappings.json.txt](https://github.com/Bit-Quill/opensearch-project-sql/files/10025905/date_formats_mappings.json.txt)
```sh
curl -s -XDELETE "http://localhost:9200/date-formats?pretty"
curl -s -H 'Content-Type: application/json' -XPUT "http://localhost:9200/date-formats?pretty" --data-binary @date_formats_mappings.json
curl -s -H 'Content-Type: application/json' -XPOST "http://localhost:9200/date-formats/_bulk?pretty" --data-binary @date_formats.json
```

### Test queries
```sql
select * from date-formats;
select <format> from date-formats where name = '<format>';
```
```sql
search source=date-formats;
search source=date-formats | where name='<format>' | fields <format>;
```

For example, `epoch_second` (was reported on forum)
```
opensearchsql> select epoch_second from date-formats where name = 'epoch_second';
fetched rows / total rows = 1/1
+-------------------------------+
| epoch_second                  |
|-------------------------------|
| 1984-04-12 09:07:42.000123456 |
+-------------------------------+
```

### Unsupported formats
```
weekyear
strict_weekyear
weekyear_year
strict_weekyear
year
strict_year
year_month
strict_year_month
```
(see links below)
They fall back to error: https://github.com/Bit-Quill/opensearch-project-sql/blob/f335101253b52395b3cccf161cc79b34f6dac80b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java#L258-L261

### Time interpreting issue
https://github.com/Bit-Quill/opensearch-project-sql/blob/f335101253b52395b3cccf161cc79b34f6dac80b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java#L254
goes to https://github.com/Bit-Quill/opensearch-project-sql/blob/f335101253b52395b3cccf161cc79b34f6dac80b/core/src/main/java/org/opensearch/sql/data/model/ExprTimeValue.java#L62

There is no option to access queryContext there.
This could be fixed by one of
* Returning `ExprTimeValue`
* Applying time value on top of Epoch or any other fixed date. Note - this should be consistent across the plugin.

### TBD
* What to do with `LocalTime`?
* What to do with unsupported formats?
* Can we return not `ExprTimestampValue` for date and time columns? Note: ensure that entire column has the same or similar format(s).

### TODO
* See TODO comments in code
* Fix `SQLCorrectnessIT` with query `SELECT Cancelled, AvgTicketPrice, FlightDelayMin, Carrier, timestamp FROM opensearch_dashboards_sample_data_flights`. [Test results - Class org.opensearch.sql.sql.SQLCorrectnessIT.pdf](https://github.com/Bit-Quill/opensearch-project-sql/files/10028297/Test.results.-.Class.org.opensearch.sql.sql.SQLCorrectnessIT.pdf)
Wrong data returned for `timestamp`, mapping `"format" : "yyyy-MM-dd HH:mm:ss"`

### Links
* Formats documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats
* Formats code: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/time/DateFormatters.java


### Issues Resolved
https://github.com/opensearch-project/sql/issues/794
https://forum.opensearch.org/t/sql-select-fails-on-date-fields-format-epoch-second/11521
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).