### PR TITLE
Add Day Of Year Function To OpenSearch

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -210,6 +210,7 @@ public enum BuiltinFunctionName {
   SIMPLE_QUERY_STRING(FunctionName.of("simple_query_string")),
   MATCH_PHRASE(FunctionName.of("match_phrase")),
   MATCHPHRASE(FunctionName.of("matchphrase")),
+  MATCHPHRASEQUERY(FunctionName.of("matchphrasequery")),
   QUERY_STRING(FunctionName.of("query_string")),
   MATCH_BOOL_PREFIX(FunctionName.of("match_bool_prefix")),
   HIGHLIGHT(FunctionName.of("highlight")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -36,6 +36,7 @@ public class OpenSearchFunctions {
     // compatibility.
     repository.register(match_phrase(BuiltinFunctionName.MATCH_PHRASE));
     repository.register(match_phrase(BuiltinFunctionName.MATCHPHRASE));
+    repository.register(match_phrase(BuiltinFunctionName.MATCHPHRASEQUERY));
     repository.register(match_phrase_prefix());
   }
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2769,6 +2769,46 @@ Another example to show how to set custom values for the optional parameters::
     +----------------------+--------------------------+
 
 
+MATCHPHRASEQUERY
+------------
+
+Description
+>>>>>>>>>>>
+
+``matchphrasequery(field_expression, query_expression[, option=<option_value>]*)``
+
+The matchphrasequery function maps to the match_phrase query used in search engine, to return the documents that match a provided text with a given field.
+It is an alternate syntax for the `match_phrase`_ function. Available parameters include:
+
+- analyzer
+- slop
+- zero_terms_query
+
+For backward compatibility, matchphrase is also supported and mapped to match_phrase query.
+
+Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
+
+    os> SELECT author, title FROM books WHERE match_phrase(author, 'Alexander Milne');
+    fetched rows / total rows = 2/2
+    +----------------------+--------------------------+
+    | author               | title                    |
+    |----------------------+--------------------------|
+    | Alan Alexander Milne | The House at Pooh Corner |
+    | Alan Alexander Milne | Winnie-the-Pooh          |
+    +----------------------+--------------------------+
+
+Another example to show how to set custom values for the optional parameters::
+
+    os> SELECT author, title FROM books WHERE match_phrase(author, 'Alan Milne', slop = 2);
+    fetched rows / total rows = 2/2
+    +----------------------+--------------------------+
+    | author               | title                    |
+    |----------------------+--------------------------|
+    | Alan Alexander Milne | The House at Pooh Corner |
+    | Alan Alexander Milne | Winnie-the-Pooh          |
+    +----------------------+--------------------------+
+
+
 MATCH_BOOL_PREFIX
 -----
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhraseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhraseIT.java
@@ -37,9 +37,28 @@ public class MatchPhraseIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void test_matchphrasequery_legacy_function() throws IOException {
+    String query = "SELECT phrase FROM %s WHERE matchphrasequery(phrase, 'quick fox')";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_PHRASE));
+    verifyDataRows(result, rows("quick fox"), rows("quick fox here"));
+  }
+
+  @Test
   public void test_match_phrase_with_slop() throws IOException {
     String query = "SELECT phrase FROM %s WHERE match_phrase(phrase, 'brown fox', slop = 2)";
     JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_PHRASE));
     verifyDataRows(result, rows("brown fox"), rows("fox brown"));
+  }
+
+  @Test
+  public void test_alternate_syntax_for_match_phrase_returns_same_result() throws IOException {
+    String query1 = "SELECT phrase FROM %s WHERE matchphrase(phrase, 'quick fox')";
+    String query2 = "SELECT phrase FROM %s WHERE match_phrase(phrase, 'quick fox')";
+    String query3 = "SELECT phrase FROM %s WHERE matchphrasequery(phrase, 'quick fox')";
+    JSONObject result1 = executeJdbcRequest(String.format(query1, TEST_INDEX_PHRASE));
+    JSONObject result2 = executeJdbcRequest(String.format(query2, TEST_INDEX_PHRASE));
+    JSONObject result3 = executeJdbcRequest(String.format(query3, TEST_INDEX_PHRASE));
+    assertTrue(result1.similar(result2));
+    assertTrue(result1.similar(result3));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -61,6 +61,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.MATCH.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCH_PHRASE.getName(), new MatchPhraseQuery())
           .put(BuiltinFunctionName.MATCHPHRASE.getName(), new MatchPhraseQuery())
+          .put(BuiltinFunctionName.MATCHPHRASEQUERY.getName(), new MatchPhraseQuery())
           .put(BuiltinFunctionName.QUERY.getName(), new QueryQuery())
           .put(BuiltinFunctionName.MATCH_QUERY.getName(), new MatchQuery())
           .put(BuiltinFunctionName.MATCHQUERY.getName(), new MatchQuery())

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
@@ -28,7 +28,9 @@ import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.Matc
 public class MatchPhraseQueryTest {
 
   private final MatchPhraseQuery matchPhraseQuery = new MatchPhraseQuery();
-  private final FunctionName matchPhrase = FunctionName.of("match_phrase");
+  private final FunctionName matchPhraseName = FunctionName.of("matchphrase");
+  private final FunctionName matchPhraseWithUnderscoreName = FunctionName.of("match_phrase");
+  private final FunctionName matchPhraseQueryName = FunctionName.of("matchphrasequery");
 
   @Test
   public void test_SyntaxCheckException_when_no_arguments() {
@@ -102,9 +104,175 @@ public class MatchPhraseQueryTest {
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
 
+  @Test
+  public void test_SyntaxCheckException_when_no_arguments_match_phrase_syntax() {
+    List<Expression> arguments = List.of();
+    assertThrows(SyntaxCheckException.class,
+        () -> matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_one_argument_match_phrase_syntax() {
+    List<Expression> arguments = List.of(DSL.namedArgument("field", "test"));
+    assertThrows(SyntaxCheckException.class,
+        () -> matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseWithUnderscoreName)));
+
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_invalid_parameter_match_phrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("query", "test2"),
+        DSL.namedArgument("unsupported", "3"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_analyzer_parameter_match_phrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("analyzer", "standard")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void build_succeeds_with_two_arguments_match_phrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("query", "test2"));
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_slop_parameter_match_phrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("slop", "2")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_zero_terms_query_parameter_match_phrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("zero_terms_query", "ALL")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_zero_terms_query_parameter_lower_case_match_phrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("zero_terms_query", "all")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_no_arguments_matchphrase_syntax() {
+    List<Expression> arguments = List.of();
+    assertThrows(SyntaxCheckException.class,
+        () -> matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseQueryName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_one_argument_matchphrase_syntax() {
+    List<Expression> arguments = List.of(DSL.namedArgument("field", "test"));
+    assertThrows(SyntaxCheckException.class,
+        () -> matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseQueryName)));
+
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_invalid_parameter_matchphrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("query", "test2"),
+        DSL.namedArgument("unsupported", "3"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchPhraseQuery.build(new MatchPhraseExpression(
+            arguments, matchPhraseQueryName)));
+  }
+
+  @Test
+  public void test_analyzer_parameter_matchphrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("analyzer", "standard")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseQueryName)));
+  }
+
+  @Test
+  public void build_succeeds_with_two_arguments_matchphrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("query", "test2"));
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseQueryName)));
+  }
+
+  @Test
+  public void test_slop_parameter_matchphrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("slop", "2")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseQueryName)));
+  }
+
+  @Test
+  public void test_zero_terms_query_parameter_matchphrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("zero_terms_query", "ALL")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseQueryName)));
+  }
+
+  @Test
+  public void test_zero_terms_query_parameter_lower_case_matchphrase_syntax() {
+    List<Expression> arguments = List.of(
+        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("query", "t2"),
+        DSL.namedArgument("zero_terms_query", "all")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
+        arguments, matchPhraseQueryName)));
+  }
+
   private class MatchPhraseExpression extends FunctionExpression {
     public MatchPhraseExpression(List<Expression> arguments) {
-      super(MatchPhraseQueryTest.this.matchPhrase, arguments);
+      super(matchPhraseName, arguments);
+    }
+
+    public MatchPhraseExpression(List<Expression> arguments, FunctionName funcName) {
+      super(funcName, arguments);
     }
 
     @Override

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -295,6 +295,7 @@ INCLUDE:                            'INCLUDE';
 IN_TERMS:                           'IN_TERMS';
 MATCHPHRASE:                        'MATCHPHRASE';
 MATCH_PHRASE:                       'MATCH_PHRASE';
+MATCHPHRASEQUERY:                   'MATCHPHRASEQUERY';
 SIMPLE_QUERY_STRING:                'SIMPLE_QUERY_STRING';
 QUERY_STRING:                       'QUERY_STRING';
 MATCH_PHRASE_PREFIX:                'MATCH_PHRASE_PREFIX';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -425,7 +425,7 @@ systemFunctionName
     ;
 
 singleFieldRelevanceFunctionName
-    : MATCH | MATCH_PHRASE | MATCHPHRASE
+    : MATCH | MATCH_PHRASE | MATCHPHRASE| MATCHPHRASEQUERY
     | MATCH_BOOL_PREFIX | MATCH_PHRASE_PREFIX
     ;
 

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -391,6 +391,7 @@ class SQLSyntaxParserTest {
       "matchPhraseComplexQueries",
       "matchPhraseGeneratedQueries",
       "generateMatchPhraseQueries",
+      "matchPhraseQueryComplexQueries"
   })
   public void canParseComplexMatchPhraseArgsTest(String query) {
     assertNotNull(parser.parse(query));
@@ -417,6 +418,22 @@ class SQLSyntaxParserTest {
               + "prefix_length=34, fuzziness='auto', minimum_should_match='2<-25% 9<-3')",
       "SELECT * FROM t WHERE match_phrase(c, 3, minimum_should_match='2<-25% 9<-3')",
       "SELECT * FROM t WHERE match_phrase(c, 3, operator='AUTO')"
+    );
+  }
+
+  private static Stream<String> matchPhraseQueryComplexQueries() {
+    return Stream.of(
+        "SELECT * FROM t WHERE matchphrasequery(c, 3)",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, fuzziness=AUTO)",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, zero_terms_query=\"all\")",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, lenient=true)",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, lenient='true')",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, operator=xor)",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, cutoff_frequency=0.04)",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, cutoff_frequency=0.04, analyzer = english, "
+            + "prefix_length=34, fuzziness='auto', minimum_should_match='2<-25% 9<-3')",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, minimum_should_match='2<-25% 9<-3')",
+        "SELECT * FROM t WHERE matchphrasequery(c, 3, operator='AUTO')"
     );
   }
 

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -452,6 +452,22 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void matchPhraseQueryAllParameters() {
+    assertEquals(
+        AstDSL.function("matchphrasequery",
+            unresolvedArg("field", stringLiteral("test")),
+            unresolvedArg("query", stringLiteral("search query")),
+            unresolvedArg("slop", stringLiteral("3")),
+            unresolvedArg("analyzer", stringLiteral("standard")),
+            unresolvedArg("zero_terms_query", stringLiteral("NONE"))
+        ),
+        buildExprAst("matchphrasequery(test, 'search query', slop = 3"
+            + ", analyzer = 'standard', zero_terms_query='NONE'"
+            + ")")
+    );
+  }
+
+  @Test
   public void matchPhrasePrefixAllParameters() {
     assertEquals(
         AstDSL.function("match_phrase_prefix",


### PR DESCRIPTION
### Description
Adds the `day_of_year` function to the SQL plugin. It behaves like the `dayofyear` function which already exists in the new engine, and both are aligned with [MySQL](https://www.w3schools.com/sql/func_mysql_dayofyear.asp)
 
### Issues Resolved
#722 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).