### PR TITLE
Text and Keyword aggregation integration tests 

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -57,6 +57,7 @@ import static org.opensearch.sql.legacy.TestUtils.getPeople2IndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getPhraseIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 import static org.opensearch.sql.legacy.TestUtils.getStringIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDataTextKeywordIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getWeblogsIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestUtils.loadDataByRestClient;
@@ -584,7 +585,11 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     CALCS(TestsConstants.TEST_INDEX_CALCS,
         "calcs",
         getMappingFile("calcs_index_mappings.json"),
-        "src/test/resources/calcs.json"),;
+        "src/test/resources/calcs.json"),
+    TEXTKEYWORD(TestsConstants.TEST_INDEX_TEXTKEYWORD,
+        "textkeyword",
+          getMappingFile("text_keyword_index_mapping.json"),
+        "src/test/resources/text_keyword_index.json");
 
     private final String name;
     private final String type;

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -243,6 +243,11 @@ public class TestUtils {
     return getMappingFile(mappingFile);
   }
 
+  public static String getDataTextKeywordIndexMapping() {
+    String mappingFile = "text_keyword_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
   public static void loadBulk(Client client, String jsonPath, String defaultIndex)
       throws Exception {
     System.out.println(String.format("Loading file %s into opensearch cluster", jsonPath));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -53,6 +53,7 @@ public class TestsConstants {
   public final static String TEST_INDEX_BEER = TEST_INDEX + "_beer";
   public final static String TEST_INDEX_NULL_MISSING = TEST_INDEX + "_null_missing";
   public final static String TEST_INDEX_CALCS = TEST_INDEX + "_calcs";
+  public final static String TEST_INDEX_TEXTKEYWORD = TEST_INDEX + "_textkeyword";
 
   public final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   public final static String TS_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";

--- a/integ-test/src/test/java/org/opensearch/sql/sql/TextTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/TextTypeIT.java
@@ -1,0 +1,60 @@
+  /*
+   * Copyright OpenSearch Contributors
+   * SPDX-License-Identifier: Apache-2.0
+   */
+
+package org.opensearch.sql.sql;
+
+  import org.junit.Test;
+  import org.opensearch.sql.legacy.SQLIntegTestCase;
+  import java.io.IOException;
+
+
+  import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_TEXTKEYWORD;
+  import static org.opensearch.sql.util.MatcherUtils.schema;
+  import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+  public class TextTypeIT extends SQLIntegTestCase {
+
+
+    @Override
+    public void init() throws Exception {
+      super.init();
+      loadIndex(Index.TEXTKEYWORD);
+    }
+
+    @Test
+    public void textKeywordTest() throws IOException {
+      var result = executeJdbcRequest(String.format("select typeText from %s", TEST_INDEX_TEXTKEYWORD));
+      verifySchema(result,
+          schema("typeText", null, "text"));
+    }
+
+    @Test
+    public void aggregateOnText() throws IOException {
+      var result = executeJdbcRequest(String.format("select sum(int0) from %s GROUP BY typeText", TEST_INDEX_TEXTKEYWORD));
+      verifySchema(result,
+          schema("sum(int0)", null, "integer"));
+    }
+
+    @Test
+    public void aggregateOnKeyword() throws IOException {
+      var result = executeJdbcRequest(String.format("select sum(int0) from %s GROUP BY typeKeyword", TEST_INDEX_TEXTKEYWORD));
+      verifySchema(result,
+          schema("sum(int0)", null, "integer"));
+    }
+
+    @Test
+    public void aggregateOnTextFieldData() throws IOException {
+      var result = executeJdbcRequest(String.format("select sum(int0) from %s GROUP BY typeTextFieldData", TEST_INDEX_TEXTKEYWORD));
+      verifySchema(result,
+          schema("sum(int0)", null, "integer"));
+    }
+
+    @Test
+    public void aggregateOnKeywordFieldData() throws IOException {
+      var result = executeJdbcRequest(String.format("select sum(int0) from %s GROUP BY typeKeywordFieldNoFieldData", TEST_INDEX_TEXTKEYWORD));
+      verifySchema(result,
+          schema("sum(int0)", null, "integer"));
+    }
+  }

--- a/integ-test/src/test/resources/indexDefinitions/text_keyword_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/text_keyword_index_mapping.json
@@ -1,0 +1,33 @@
+{
+  "mappings" : {
+    "properties" : {
+      "typeKeyword" : {
+        "type" : "keyword"
+      },
+      "typeText" : {
+        "type" : "text"
+      },
+      "typeKeywordFieldNoFieldData" : {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }      },
+      "typeTextFieldData" : {
+        "type": "text",
+        "fielddata": true,
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "int0" : {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/integ-test/src/test/resources/text_keyword_index.json
+++ b/integ-test/src/test/resources/text_keyword_index.json
@@ -1,0 +1,16 @@
+{"index": {}}
+{"typeKeyword": "key00", "typeText": "text00", "typeKeywordFieldData": "keyFD00", "typeTextFieldData":  "textFD00", "int0": 0}
+{"index": {}}
+{"typeKeyword": "key01", "typeText": "text01", "typeKeywordFieldData": "keyFD01", "typeTextFieldData":  "textFD01", "int0": 1}
+{"index": {}}
+{"typeKeyword": "key02", "typeText": "text02", "typeKeywordFieldData": "keyFD02", "typeTextFieldData":  "textFD02", "int0": 2}
+{"index": {}}
+{"typeKeyword": "key03", "typeText": "text03", "typeKeywordFieldData": "keyFD03", "typeTextFieldData":  "textFD03", "int0": 3}
+{"index": {}}
+{"typeKeyword": "key04", "typeText": "text04", "typeKeywordFieldData": "keyFD04", "typeTextFieldData":  "textFD04", "int0": 4}
+{"index": {}}
+{"typeKeyword": "key05", "typeText": "text05", "typeKeywordFieldData": "keyFD05", "typeTextFieldData":  "textFD05", "int0": 5}
+{"index": {}}
+{"typeKeyword": "key06", "typeText": "text06", "typeKeywordFieldData": "keyFD06", "typeTextFieldData":  "textFD06", "int0": 6}
+{"index": {}}
+{"typeKeyword": "key07", "typeText": "text07", "typeKeywordFieldData": "keyFD07", "typeTextFieldData":  "textFD07", "int0": 7}


### PR DESCRIPTION
Signed-off-by: MitchellGale-BitQuill <mitchellg@bitquilltech.com>

### Description
Adds integration tests for:
type keyword:
```
      "typeKeyword" : {
        "type" : "keyword"
      }
```

type text:
```
      "typeText" : {
        "type" : "text"
      }
```

type keyword with field data false:
```      
"typeKeywordFieldNoFieldData" : {
        "type": "text",
        "fields": {
          "keyword": {
            "type": "keyword",
            "ignore_above": 256
          }
        }      
}
```

type keyword and field data true:
   ```
   "typeTextFieldData" : {
        "type": "text",
        "fielddata": true,
        "fields": {
          "keyword": {
            "type": "keyword",
            "ignore_above": 256
          }
        }
```

#### Integration test failure:
Only `aggregateOnText` fails
```
REPRODUCE WITH: ./gradlew ':integ-test:integTest' --tests "org.opensearch.sql.sql.TextTypeIT.aggregateOnText" -Dtests.seed=A48DC4566936223B -Dtests.security.manager=false -Dtests.locale=zh-Hans-CN -Dtests.timezone=Europe/San_Marino -Druntime.java=13

org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:62239], URI [/_plugins/_sql?format=jdbc], status line [HTTP/1.1 503 Service Unavailable]
{
  "error": {
    "reason": "Error occurred in OpenSearch engine: all shards failed",
    "details": "Shard[0]: java.lang.IllegalArgumentException: Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [typeText] in order to load field data by uninverting the inverted index. Note that this can use significant memory.\n\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "SearchPhaseExecutionException"
  },
  "status": 400
}
java.lang.RuntimeException: org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:62239], URI [/_plugins/_sql?format=jdbc], status line [HTTP/1.1 503 Service Unavailable]
{
  "error": {
    "reason": "Error occurred in OpenSearch engine: all shards failed",
    "details": "Shard[0]: java.lang.IllegalArgumentException: Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [typeText] in order to load field data by uninverting the inverted index. Note that this can use significant memory.\n\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "SearchPhaseExecutionException"
  },
  "status": 400
}
	at __randomizedtesting.SeedInfo.seed([A48DC4566936223B:93D9AB68DC690E72]:0)
	at org.opensearch.sql.legacy.SQLIntegTestCase.executeQuery(SQLIntegTestCase.java:239)
	at org.opensearch.sql.legacy.SQLIntegTestCase.executeJdbcRequest(SQLIntegTestCase.java:244)
	at org.opensearch.sql.sql.TextTypeIT.aggregateOnText(TextTypeIT.java:35)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1750)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:938)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:974)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:988)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:44)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:817)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:468)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:947)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:832)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:883)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:894)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at java.base/java.lang.Thread.run(Thread.java:830)
Caused by: org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:62239], URI [/_plugins/_sql?format=jdbc], status line [HTTP/1.1 503 Service Unavailable]
{
  "error": {
    "reason": "Error occurred in OpenSearch engine: all shards failed",
    "details": "Shard[0]: java.lang.IllegalArgumentException: Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [typeText] in order to load field data by uninverting the inverted index. Note that this can use significant memory.\n\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "SearchPhaseExecutionException"
  },
  "status": 400
}
	at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:375)
	at app//org.opensearch.client.RestClient.performRequest(RestClient.java:345)
	at app//org.opensearch.client.RestClient.performRequest(RestClient.java:351)
	at app//org.opensearch.client.RestClient.performRequest(RestClient.java:320)
	at app//org.opensearch.sql.legacy.SQLIntegTestCase.executeQuery(SQLIntegTestCase.java:233)
	... 42 more
	Suppressed: org.opensearch.client.ResponseException: method [POST], host [http://[::1]:62238], URI [/_plugins/_sql?format=jdbc], status line [HTTP/1.1 503 Service Unavailable]
{
  "error": {
    "reason": "Error occurred in OpenSearch engine: all shards failed",
    "details": "Shard[0]: java.lang.IllegalArgumentException: Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [typeText] in order to load field data by uninverting the inverted index. Note that this can use significant memory.\n\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "SearchPhaseExecutionException"
  },
  "status": 400
}
		at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:375)
		at app//org.opensearch.client.RestClient.performRequest(RestClient.java:345)
		... 44 more
```
 
### Issues Resolved
Part of investigation for [#1038](https://github.com/opensearch-project/sql/issues/1038)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).