### PR TITLE
Add position() function to PPL

### DIFF
--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -219,7 +219,7 @@ INTEGER/LONG/FLOAT/DOUBLE -> DOUBLE
 
 Example::
 
-    opensearchsql> SELECT CBRT(8), CBRT(9.261), CBRT(-27);
+    os> SELECT CBRT(8), CBRT(9.261), CBRT(-27)
     fetched rows / total rows = 1/1
     +-----------+---------------+-------------+
     | CBRT(8)   | CBRT(9.261)   | CBRT(-27)   |

--- a/docs/user/ppl/functions/math.rst
+++ b/docs/user/ppl/functions/math.rst
@@ -678,11 +678,10 @@ INTEGER/LONG/FLOAT/DOUBLE -> DOUBLE
 
 Example::
 
-    opensearchsql> source=location | eval `CBRT(8)` = CBRT(8), `CBRT(9.261)` = CBRT(9.261), `CBRT(-27)` = CBRT(-27) | fields `CBRT(8)`, `CBRT(9.261)`, `CBRT(-27)`;
-    fetched rows / total rows = 2/2
+    os> source=people | eval `CBRT(8)` = CBRT(8), `CBRT(9.261)` = CBRT(9.261), `CBRT(-27)` = CBRT(-27) | fields `CBRT(8)`, `CBRT(9.261)`, `CBRT(-27)`
+    fetched rows / total rows = 1/1
     +-----------+---------------+-------------+
     | CBRT(8)   | CBRT(9.261)   | CBRT(-27)   |
     |-----------+---------------+-------------|
-    | 2.0       | 2.1           | -3.0        |
     | 2.0       | 2.1           | -3.0        |
     +-----------+---------------+-------------+

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -150,6 +150,32 @@ Example::
     +---------------------+---------------------+
 
 
+POSITION
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: The syntax POSITION(substr IN str) returns the position of the first occurrence of substring substr in string str. Returns 0 if substr is not in str. Returns NULL if any argument is NULL.
+
+Argument type: STRING, STRING, INTEGER
+
+Return type integer:
+
+(STRING IN STRING) -> INTEGER
+
+Example::
+
+    opensearchsql> source=location | eval `POSITION('world' IN 'helloworld')` = POSITION('world' IN 'helloworld'), `POSITION('invalid' IN 'helloworld')`= POSITION('invalid' IN 'helloworld')  | fields `POSITION('world' IN 'helloworld')`, `POSITION('invalid' IN 'helloworld')`;
+    fetched rows / total rows = 2/2
+    +-------------------------------------+---------------------------------------+
+    | POSITION('world' IN 'helloworld')   | POSITION('invalid' IN 'helloworld')   |
+    |-------------------------------------+---------------------------------------|
+    | 6                                   | 0                                     |
+    | 6                                   | 0                                     |
+    +-------------------------------------+---------------------------------------+
+
+
 RIGHT
 -----
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -166,7 +166,7 @@ Return type integer:
 
 Example::
 
-    opensearchsql> source=location | eval `POSITION('world' IN 'helloworld')` = POSITION('world' IN 'helloworld'), `POSITION('invalid' IN 'helloworld')`= POSITION('invalid' IN 'helloworld')  | fields `POSITION('world' IN 'helloworld')`, `POSITION('invalid' IN 'helloworld')`;
+    os> source=location | eval `POSITION('world' IN 'helloworld')` = POSITION('world' IN 'helloworld'), `POSITION('invalid' IN 'helloworld')`= POSITION('invalid' IN 'helloworld')  | fields `POSITION('world' IN 'helloworld')`, `POSITION('invalid' IN 'helloworld')`;
     fetched rows / total rows = 2/2
     +-------------------------------------+---------------------------------------+
     | POSITION('world' IN 'helloworld')   | POSITION('invalid' IN 'helloworld')   |

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -166,12 +166,11 @@ Return type integer:
 
 Example::
 
-    os> source=location | eval `POSITION('world' IN 'helloworld')` = POSITION('world' IN 'helloworld'), `POSITION('invalid' IN 'helloworld')`= POSITION('invalid' IN 'helloworld')  | fields `POSITION('world' IN 'helloworld')`, `POSITION('invalid' IN 'helloworld')`;
-    fetched rows / total rows = 2/2
+    os> source=people | eval `POSITION('world' IN 'helloworld')` = POSITION('world' IN 'helloworld'), `POSITION('invalid' IN 'helloworld')`= POSITION('invalid' IN 'helloworld')  | fields `POSITION('world' IN 'helloworld')`, `POSITION('invalid' IN 'helloworld')`
+    fetched rows / total rows = 1/1
     +-------------------------------------+---------------------------------------+
     | POSITION('world' IN 'helloworld')   | POSITION('invalid' IN 'helloworld')   |
     |-------------------------------------+---------------------------------------|
-    | 6                                   | 0                                     |
     | 6                                   | 0                                     |
     +-------------------------------------+---------------------------------------+
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -158,7 +158,7 @@ Description
 
 Usage: The syntax POSITION(substr IN str) returns the position of the first occurrence of substring substr in string str. Returns 0 if substr is not in str. Returns NULL if any argument is NULL.
 
-Argument type: STRING, STRING, INTEGER
+Argument type: STRING
 
 Return type integer:
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -158,7 +158,7 @@ Description
 
 Usage: The syntax POSITION(substr IN str) returns the position of the first occurrence of substring substr in string str. Returns 0 if substr is not in str. Returns NULL if any argument is NULL.
 
-Argument type: STRING
+Argument type: STRING, STRING
 
 Return type integer:
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -156,7 +156,7 @@ POSITION
 Description
 >>>>>>>>>>>
 
-Usage: The syntax POSITION(substr IN str) returns the position of the first occurrence of substring substr in string str. Returns 0 if substr is not in str. Returns NULL if any argument is NULL.
+Usage: The syntax `POSITION(substr IN str)` returns the position of the first occurrence of substring `substr` in string `str`. Returns `0` if `substr` is not in `str`. Returns `NULL` if any argument is `NULL`.
 
 Argument type: STRING, STRING
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PositionFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PositionFunctionIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+public class PositionFunctionIT extends PPLIntegTestCase {
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.CALCS);
+  }
+
+  @Test
+  public void test_position_function() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS
+        + " | eval f=position('ON', str1) | fields f";
+
+    var result = executeQuery(query);
+
+    assertEquals(17, result.getInt("total"));
+    verifyDataRows(result,
+            rows(7), rows(7),
+            rows(2), rows(0),
+            rows(0), rows(0),
+            rows(0), rows(0),
+            rows(0), rows(0),
+            rows(0), rows(0),
+            rows(0), rows(0),
+            rows(0), rows(0),
+            rows(0));
+  }
+
+  @Test
+  public void test_position_function_with_fields_only() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS
+            + " | eval f=position(str3 IN str2) | where str2 IN ('one', 'two', 'three')| fields f";
+
+    var result = executeQuery(query);
+
+    assertEquals(3, result.getInt("total"));
+    verifyDataRows(result, rows(3), rows(0), rows(4));
+  }
+
+  @Test
+  public void test_position_function_with_string_literals() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS
+            + " | eval f=position('world' IN 'hello world') | where str2='one' | fields f";
+
+    var result = executeQuery(query);
+
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows(7));
+  }
+
+  @Test
+  public void test_position_function_with_nulls() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS
+            + " | eval f=position('ee' IN str2) | where isnull(str2) | fields str2,f";
+
+    var result = executeQuery(query);
+
+    assertEquals(4, result.getInt("total"));
+    verifyDataRows(result,
+            rows(null, null),
+            rows(null, null),
+            rows(null, null),
+            rows(null, null));
+  }
+
+  @Test
+  public void test_position_function_with_function_as_arg() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS
+            + " | eval f=position(upper(str3) IN str1) | where like(str1, 'BINDING SUPPLIES') | fields f";
+
+    var result = executeQuery(query);
+
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows(15));
+  }
+
+  @Test
+  public void test_position_function_with_function_in_where_clause() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS
+            + " | where position(str3 IN str2)=1 | fields str2";
+
+    var result = executeQuery(query);
+
+    assertEquals(2, result.getInt("total"));
+    verifyDataRows(result, rows("eight"), rows("eleven"));
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -215,6 +215,7 @@ LOG10:                              'LOG10';
 LOG2:                               'LOG2';
 MOD:                                'MOD';
 PI:                                 'PI';
+POSITION:                           'POSITION';
 POW:                                'POW';
 POWER:                              'POWER';
 RAND:                               'RAND';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -258,6 +258,7 @@ valueExpression
     | LT_PRTHS left=valueExpression binaryOperator
     right=valueExpression RT_PRTHS                                  #parentheticBinaryArithmetic
     | primaryExpression                                             #valueExpressionDefault
+    | positionFunction                                              #positionFunctionCall
     ;
 
 primaryExpression
@@ -265,6 +266,10 @@ primaryExpression
     | dataTypeFunctionCall
     | fieldExpression
     | literalValue
+    ;
+
+positionFunction
+    : positionFunctionName LT_PRTHS functionArg IN functionArg RT_PRTHS
     ;
 
 booleanExpression
@@ -362,6 +367,7 @@ evalFunctionName
     | textFunctionBase
     | conditionFunctionBase
     | systemFunctionBase
+    | positionFunctionName
     ;
 
 functionArgs
@@ -484,6 +490,10 @@ textFunctionBase
     | RIGHT | LEFT | ASCII | LOCATE | REPLACE
     ;
 
+positionFunctionName
+    : POSITION
+    ;
+
 /** operators */
 comparisonOperator
     : EQUAL | NOT_EQUAL | LESS | NOT_LESS | GREATER | NOT_GREATER | REGEXP
@@ -603,4 +613,5 @@ keywordsCanBeId
     | dateAndTimeFunctionBase
     | textFunctionBase
     | mathematicalFunctionBase
+    | positionFunctionName
     ;

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -9,6 +9,7 @@ package org.opensearch.sql.ppl.parser;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.POSITION;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BinaryArithmeticContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BooleanFunctionCallContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BooleanLiteralContext;
@@ -69,7 +70,6 @@ import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
-import org.opensearch.sql.ast.expression.PositionFunction;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.expression.Span;
@@ -294,8 +294,10 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitPositionFunction(
           OpenSearchPPLParser.PositionFunctionContext ctx) {
-    return new PositionFunction(visitFunctionArg(ctx.functionArg(0)),
-            visitFunctionArg(ctx.functionArg(1)));
+    return new Function(
+            POSITION.getName().getFunctionName(),
+            Arrays.asList(visitFunctionArg(ctx.functionArg(0)),
+                    visitFunctionArg(ctx.functionArg(1))));
   }
 
   /**

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -69,6 +69,7 @@ import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
+import org.opensearch.sql.ast.expression.PositionFunction;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.expression.Span;
@@ -288,6 +289,13 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     } else {
       return visitIdentifiers(Arrays.asList(ctx));
     }
+  }
+
+  @Override
+  public UnresolvedExpression visitPositionFunction(
+          OpenSearchPPLParser.PositionFunctionContext ctx) {
+    return new PositionFunction(visitFunctionArg(ctx.functionArg(0)),
+            visitFunctionArg(ctx.functionArg(1)));
   }
 
   /**

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -35,6 +35,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.longLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.not;
 import static org.opensearch.sql.ast.dsl.AstDSL.nullLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.or;
+import static org.opensearch.sql.ast.dsl.AstDSL.position;
 import static org.opensearch.sql.ast.dsl.AstDSL.projectWithArg;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
@@ -177,6 +178,18 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             let(
                 field("f"),
                 function("PI")
+            )
+        ));
+  }
+
+  @Test
+  public void testPositionFunctionExpr() {
+    assertEqual("source=t | eval f=position(fieldA IN fieldB)",
+        eval(
+            relation("t"),
+            let(
+                field("f"),
+                position(field("fieldA"), field("fieldB"))
             )
         ));
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -35,7 +35,6 @@ import static org.opensearch.sql.ast.dsl.AstDSL.longLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.not;
 import static org.opensearch.sql.ast.dsl.AstDSL.nullLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.or;
-import static org.opensearch.sql.ast.dsl.AstDSL.position;
 import static org.opensearch.sql.ast.dsl.AstDSL.projectWithArg;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
@@ -184,12 +183,13 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
 
   @Test
   public void testPositionFunctionExpr() {
-    assertEqual("source=t | eval f=position(fieldA IN fieldB)",
+    assertEqual("source=t | eval f=position('substr' IN 'str')",
         eval(
             relation("t"),
             let(
                 field("f"),
-                position(field("fieldA"), field("fieldB"))
+                function("position",
+                        stringLiteral("substr"), stringLiteral("str"))
             )
         ));
   }


### PR DESCRIPTION
Signed-off-by: Margarit Hakobyan <margarith@bitquilltech.com>

### Description
Usage: The syntax POSITION(substr IN str) returns the position of the first occurrence of substring substr in string str. Returns 0 if substr is not in str. Returns NULL if any argument is NULL.

Argument type: STRING, STRING

Return type integer:

(STRING IN STRING) -> INTEGER

Example::

    opensearchsql> source=location | eval `POSITION('world' IN 'helloworld')` = POSITION('world' IN 'helloworld'), `POSITION('invalid' IN 'helloworld')`= POSITION('invalid' IN 'helloworld')  | fields `POSITION('world' IN 'helloworld')`, `POSITION('invalid' IN 'helloworld')`;
    fetched rows / total rows = 2/2
    +-------------------------------------+---------------------------------------+
    | POSITION('world' IN 'helloworld')   | POSITION('invalid' IN 'helloworld')   |
    |-------------------------------------+---------------------------------------|
    | 6                                   | 0                                     |
    | 6                                   | 0                                     |
    +-------------------------------------+---------------------------------------+

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).