### PR TITLE
Add Day_Of_Month Function As An Alias Of DayOfMonth

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -322,8 +322,8 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYNAME, expressions);
   }
 
-  public static FunctionExpression dayofmonth(Expression... expressions) {
-    return compile(FunctionProperties.None, BuiltinFunctionName.DAYOFMONTH, expressions);
+  public static FunctionExpression dayofmonth(FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties , BuiltinFunctionName.DAYOFMONTH, expressions);
   }
 
   public static FunctionExpression dayofweek(Expression... expressions) {
@@ -334,8 +334,8 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYOFYEAR, expressions);
   }
 
-  public static FunctionExpression day_of_month(Expression... expressions) {
-    return compile(FunctionProperties.None, BuiltinFunctionName.DAY_OF_MONTH, expressions);
+  public static FunctionExpression day_of_month(FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.DAY_OF_MONTH, expressions);
   }
 
   public static FunctionExpression day_of_year(Expression... expressions) {

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -322,8 +322,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYNAME, expressions);
   }
 
-  public static FunctionExpression dayofmonth(FunctionProperties functionProperties, Expression... expressions) {
-    return compile(functionProperties , BuiltinFunctionName.DAYOFMONTH, expressions);
+  public static FunctionExpression dayofmonth(
+      FunctionProperties functionProperties,
+      Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.DAYOFMONTH, expressions);
   }
 
   public static FunctionExpression dayofweek(Expression... expressions) {
@@ -334,7 +336,9 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYOFYEAR, expressions);
   }
 
-  public static FunctionExpression day_of_month(FunctionProperties functionProperties, Expression... expressions) {
+  public static FunctionExpression day_of_month(
+      FunctionProperties functionProperties,
+      Expression... expressions) {
     return compile(functionProperties, BuiltinFunctionName.DAY_OF_MONTH, expressions);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -334,6 +334,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYOFYEAR, expressions);
   }
 
+  public static FunctionExpression day_of_month(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.DAY_OF_MONTH, expressions);
+  }
+
   public static FunctionExpression day_of_year(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAY_OF_YEAR, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -21,6 +21,7 @@ import static org.opensearch.sql.expression.function.FunctionDSL.define;
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.implWithProperties;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
+import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandlingWithProperties;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_FORMATTER_LONG_YEAR;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_FORMATTER_SHORT_YEAR;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_LONG_YEAR;
@@ -339,8 +340,8 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver dayOfMonth(BuiltinFunctionName name) {
     return define(name.getName(),
-        implWithProperties((functionProperties, arg) -> DateTimeFunction.dayOfMonthToday(
-            functionProperties.getQueryStartClock()), INTEGER, TIME),
+        implWithProperties(nullMissingHandlingWithProperties((functionProperties, arg) -> DateTimeFunction.dayOfMonthToday(
+            functionProperties.getQueryStartClock())), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING),
@@ -619,7 +620,7 @@ public class DateTimeFunction {
   }
 
   private ExprValue dayOfMonthToday(Clock clock) {
-    return new ExprIntegerValue(formatNow(clock).getDayOfMonth());
+    return new ExprIntegerValue(LocalDateTime.now(clock).getDayOfMonth());
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -339,8 +339,8 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver dayOfMonth(BuiltinFunctionName name) {
     return define(name.getName(),
-        implWithProperties((functionProperties, arg)
-            -> DateTimeFunction.dayOfMonthToday(functionProperties.getQueryStartClock()), INTEGER, TIME),
+        implWithProperties((functionProperties, arg) -> DateTimeFunction.dayOfMonthToday(
+            functionProperties.getQueryStartClock()), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING),
@@ -768,11 +768,11 @@ public class DateTimeFunction {
   /**
    * Day of Month implementation for ExprValue.
    *
-   * @param exprValue ExprValue of Date/Datetime/String/Time/Timestamp type.
+   * @param date ExprValue of Date/Datetime/String/Time/Timestamp type.
    * @return ExprValue.
    */
-  private ExprValue exprDayOfMonth(ExprValue exprValue) {
-    return new ExprIntegerValue(exprValue.dateValue().getDayOfMonth());
+  private ExprValue exprDayOfMonth(ExprValue date) {
+    return new ExprIntegerValue(date.dateValue().getDayOfMonth());
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.expression.datetime;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static org.opensearch.sql.data.type.ExprCoreType.DATE;
 import static org.opensearch.sql.data.type.ExprCoreType.DATETIME;
@@ -340,8 +341,9 @@ public class DateTimeFunction {
     return define(name.getName(),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATETIME),
-        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, TIMESTAMP),
-        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING)
+        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING),
+        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, TIME),
+        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, TIMESTAMP)
     );
   }
 
@@ -761,11 +763,16 @@ public class DateTimeFunction {
   /**
    * Day of Month implementation for ExprValue.
    *
-   * @param date ExprValue of Date/String type.
+   * @param exprValue ExprValue of Date/Datetime/String/Time/Timestamp type.
    * @return ExprValue.
    */
-  private ExprValue exprDayOfMonth(ExprValue date) {
-    return new ExprIntegerValue(date.dateValue().getDayOfMonth());
+  private ExprValue exprDayOfMonth(ExprValue exprValue) {
+    switch ((ExprCoreType) exprValue.type()) {
+      case TIME:
+        return new ExprIntegerValue(formatNow(Clock.systemDefaultZone()).getDayOfMonth());
+      default:
+        return new ExprIntegerValue(exprValue.dateValue().getDayOfMonth());
+    }
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -57,7 +57,6 @@ import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
-import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.DefaultFunctionResolver;
@@ -100,7 +99,8 @@ public class DateTimeFunction {
     repository.register(date_sub());
     repository.register(day());
     repository.register(dayName());
-    repository.register(dayOfMonth());
+    repository.register(dayOfMonth(BuiltinFunctionName.DAYOFMONTH));
+    repository.register(dayOfMonth(BuiltinFunctionName.DAY_OF_MONTH));
     repository.register(dayOfWeek());
     repository.register(dayOfYear(BuiltinFunctionName.DAYOFYEAR));
     repository.register(dayOfYear(BuiltinFunctionName.DAY_OF_YEAR));
@@ -336,8 +336,8 @@ public class DateTimeFunction {
   /**
    * DAYOFMONTH(STRING/DATE/DATETIME/TIMESTAMP). return the day of the month (1-31).
    */
-  private DefaultFunctionResolver dayOfMonth() {
-    return define(BuiltinFunctionName.DAYOFMONTH.getName(),
+  private DefaultFunctionResolver dayOfMonth(BuiltinFunctionName name) {
+    return define(name.getName(),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, TIMESTAMP),

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -339,10 +339,11 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver dayOfMonth(BuiltinFunctionName name) {
     return define(name.getName(),
+        implWithProperties((functionProperties, arg)
+            -> DateTimeFunction.dayOfMonthToday(functionProperties.getQueryStartClock()), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING),
-        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, TIMESTAMP)
     );
   }
@@ -617,6 +618,10 @@ public class DateTimeFunction {
     );
   }
 
+  private ExprValue dayOfMonthToday(Clock clock) {
+    return new ExprIntegerValue(formatNow(clock).getDayOfMonth());
+  }
+
   /**
    * ADDDATE function implementation for ExprValue.
    *
@@ -767,12 +772,7 @@ public class DateTimeFunction {
    * @return ExprValue.
    */
   private ExprValue exprDayOfMonth(ExprValue exprValue) {
-    switch ((ExprCoreType) exprValue.type()) {
-      case TIME:
-        return new ExprIntegerValue(formatNow(Clock.systemDefaultZone()).getDayOfMonth());
-      default:
-        return new ExprIntegerValue(exprValue.dateValue().getDayOfMonth());
-    }
+    return new ExprIntegerValue(exprValue.dateValue().getDayOfMonth());
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -340,8 +340,9 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver dayOfMonth(BuiltinFunctionName name) {
     return define(name.getName(),
-        implWithProperties(nullMissingHandlingWithProperties((functionProperties, arg) -> DateTimeFunction.dayOfMonthToday(
-            functionProperties.getQueryStartClock())), INTEGER, TIME),
+        implWithProperties(nullMissingHandlingWithProperties(
+            (functionProperties, arg) -> DateTimeFunction.dayOfMonthToday(
+                functionProperties.getQueryStartClock())), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -67,6 +67,7 @@ public enum BuiltinFunctionName {
   DAY(FunctionName.of("day")),
   DAYNAME(FunctionName.of("dayname")),
   DAYOFMONTH(FunctionName.of("dayofmonth")),
+  DAY_OF_MONTH(FunctionName.of("day_of_month")),
   DAYOFWEEK(FunctionName.of("dayofweek")),
   DAYOFYEAR(FunctionName.of("dayofyear")),
   DAY_OF_YEAR(FunctionName.of("day_of_year")),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -416,15 +416,15 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void dayOfMonth() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.dayofmonth(nullRef)));
-    assertEquals(missingValue(), eval(DSL.dayofmonth(missingRef)));
+    assertEquals(nullValue(), eval(DSL.dayofmonth(functionProperties, nullRef)));
+    assertEquals(missingValue(), eval(DSL.dayofmonth(functionProperties, missingRef)));
 
-    FunctionExpression expression = DSL.dayofmonth(DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression = DSL.dayofmonth(functionProperties, DSL.literal(new ExprDateValue("2020-08-07")));
     assertEquals(INTEGER, expression.type());
     assertEquals("dayofmonth(DATE '2020-08-07')", expression.toString());
     assertEquals(integerValue(7), eval(expression));
 
-    expression = DSL.dayofmonth(DSL.literal("2020-07-08"));
+    expression = DSL.dayofmonth(functionProperties, DSL.literal("2020-07-08"));
     assertEquals(INTEGER, expression.type());
     assertEquals("dayofmonth(\"2020-07-08\")", expression.toString());
     assertEquals(integerValue(8), eval(expression));
@@ -441,8 +441,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
 
-    FunctionExpression expression1 = DSL.dayofmonth(DSL.literal(new ExprDateValue("2020-08-07")));
-    FunctionExpression expression2 = DSL.dayofmonth(DSL.literal("2020-07-08"));
+    FunctionExpression expression1 = DSL.dayofmonth(functionProperties, DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression2 = DSL.dayofmonth(functionProperties, DSL.literal("2020-07-08"));
 
     assertAll(
         () -> testDayOfMonthWithUnderscores(expression1, 7),
@@ -454,8 +454,19 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     );
   }
 
+  @Test
+  public void testDayOfMonthWithTimeType() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+    FunctionExpression expression = DSL.day_of_month(functionProperties, DSL.literal(new ExprTimeValue("12:23:34")));
+
+    assertEquals(INTEGER, eval(expression).type());
+    assertEquals(LocalDate.now(functionProperties.getQueryStartClock()).getDayOfMonth(), eval(expression).integerValue());
+    assertEquals("day_of_month(TIME '12:23:34')", expression.toString());
+  }
+
   private void testInvalidDayOfMonth(String date) {
-    FunctionExpression expression = DSL.day_of_month(DSL.literal(new ExprDateValue(date)));
+    FunctionExpression expression = DSL.day_of_month(functionProperties, DSL.literal(new ExprDateValue(date)));
     eval(expression);
   }
 
@@ -465,7 +476,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
     //Feb. 29 of a leap year
-    testDayOfMonthWithUnderscores(DSL.day_of_month(DSL.literal("2020-02-29")), 29);
+    testDayOfMonthWithUnderscores(DSL.day_of_month(functionProperties, DSL.literal("2020-02-29")), 29);
 
     //Feb. 29 of a non-leap year
     assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-29"));
@@ -475,8 +486,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void dayOfMonthWithUnderscoresInvalidArguments() {
     lenient().when(nullRef.type()).thenReturn(DATE);
     lenient().when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.day_of_month(nullRef)));
-    assertEquals(missingValue(), eval(DSL.day_of_month(missingRef)));
+    assertEquals(nullValue(), eval(DSL.day_of_month(functionProperties, nullRef)));
+    assertEquals(missingValue(), eval(DSL.day_of_month(functionProperties, missingRef)));
 
     //40th day of the month
     assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-40"));

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -493,17 +493,25 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void dayOfMonthWithUnderscoresInvalidArguments() {
     lenient().when(nullRef.type()).thenReturn(DATE);
     lenient().when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.day_of_month(functionProperties, nullRef)));
-    assertEquals(missingValue(), eval(DSL.day_of_month(functionProperties, missingRef)));
 
-    //40th day of the month
-    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-40"));
+    assertAll(
+        () -> assertEquals(nullValue(), eval(DSL.day_of_month(functionProperties, nullRef))),
+        () -> assertEquals(
+            missingValue(), eval(DSL.day_of_month(functionProperties, missingRef))),
 
-    //13th month of the year
-    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-13-40"));
+        //40th day of the month
+        () -> assertThrows(
+            SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-40")),
+        //13th month of the year
+        () -> assertThrows(
+            SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-13-40")),
+        //incorrect format
+        () -> assertThrows(
+            SemanticCheckException.class, () -> testInvalidDayOfMonth("asdfasdfasdf"))
+        );
 
-    //incorrect format
-    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("asdfasdfasdf"));
+
+
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -430,6 +430,64 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(integerValue(8), eval(expression));
   }
 
+  public void testDayOfMonthWithUnderscores(FunctionExpression dateExpression, int dayOfMonth) {
+    assertEquals(INTEGER, dateExpression.type());
+    assertEquals(integerValue(dayOfMonth), eval(dateExpression));
+  }
+
+  @Test
+  public void dayOfMonthWithUnderscores() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+
+
+    FunctionExpression expression1 = DSL.dayofmonth(DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression2 = DSL.dayofmonth(DSL.literal("2020-07-08"));
+
+    assertAll(
+        () -> testDayOfMonthWithUnderscores(expression1, 7),
+        () -> assertEquals("dayofmonth(DATE '2020-08-07')", expression1.toString()),
+
+        () -> testDayOfMonthWithUnderscores(expression2, 8),
+        () -> assertEquals("dayofmonth(\"2020-07-08\")", expression2.toString())
+
+    );
+  }
+
+  public void testInvalidDayOfMonth(String date) {
+    FunctionExpression expression = DSL.day_of_month(DSL.literal(new ExprDateValue(date)));
+    eval(expression);
+  }
+
+  @Test
+  public void dayOfMonthWithUnderscoresLeapYear() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+
+    //Feb. 29 of a leap year
+    testDayOfMonthWithUnderscores(DSL.day_of_month(DSL.literal("2020-02-29")), 29);
+
+    //Feb. 29 of a non-leap year
+    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-29"));
+  }
+
+  @Test
+  public void dayOfMonthWithUnderscoresInvalidArguments() {
+    lenient().when(nullRef.type()).thenReturn(DATE);
+    lenient().when(missingRef.type()).thenReturn(DATE);
+    assertEquals(nullValue(), eval(DSL.day_of_month(nullRef)));
+    assertEquals(missingValue(), eval(DSL.day_of_month(missingRef)));
+
+    //40th day of the month
+    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-40"));
+
+    //13th month of the year
+    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-13-40"));
+
+    //incorrect format
+    assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("asdfasdfasdf"));
+  }
+
   @Test
   public void dayOfWeek() {
     when(nullRef.type()).thenReturn(DATE);

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -508,10 +508,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         //incorrect format
         () -> assertThrows(
             SemanticCheckException.class, () -> testInvalidDayOfMonth("asdfasdfasdf"))
-        );
-
-
-
+    );
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -430,7 +430,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(integerValue(8), eval(expression));
   }
 
-  public void testDayOfMonthWithUnderscores(FunctionExpression dateExpression, int dayOfMonth) {
+  private void testDayOfMonthWithUnderscores(FunctionExpression dateExpression, int dayOfMonth) {
     assertEquals(INTEGER, dateExpression.type());
     assertEquals(integerValue(dayOfMonth), eval(dateExpression));
   }
@@ -454,7 +454,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     );
   }
 
-  public void testInvalidDayOfMonth(String date) {
+  private void testInvalidDayOfMonth(String date) {
     FunctionExpression expression = DSL.day_of_month(DSL.literal(new ExprDateValue(date)));
     eval(expression);
   }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -419,7 +419,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(nullValue(), eval(DSL.dayofmonth(functionProperties, nullRef)));
     assertEquals(missingValue(), eval(DSL.dayofmonth(functionProperties, missingRef)));
 
-    FunctionExpression expression = DSL.dayofmonth(functionProperties, DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression = DSL.dayofmonth(
+        functionProperties, DSL.literal(new ExprDateValue("2020-08-07")));
     assertEquals(INTEGER, expression.type());
     assertEquals("dayofmonth(DATE '2020-08-07')", expression.toString());
     assertEquals(integerValue(7), eval(expression));
@@ -441,7 +442,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
 
-    FunctionExpression expression1 = DSL.dayofmonth(functionProperties, DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression1 = DSL.dayofmonth(
+        functionProperties, DSL.literal(new ExprDateValue("2020-08-07")));
     FunctionExpression expression2 = DSL.dayofmonth(functionProperties, DSL.literal("2020-07-08"));
 
     assertAll(
@@ -458,15 +460,19 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void testDayOfMonthWithTimeType() {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
-    FunctionExpression expression = DSL.day_of_month(functionProperties, DSL.literal(new ExprTimeValue("12:23:34")));
+    FunctionExpression expression = DSL.day_of_month(
+        functionProperties, DSL.literal(new ExprTimeValue("12:23:34")));
 
     assertEquals(INTEGER, eval(expression).type());
-    assertEquals(LocalDate.now(functionProperties.getQueryStartClock()).getDayOfMonth(), eval(expression).integerValue());
+    assertEquals(
+        LocalDate.now(functionProperties.getQueryStartClock()).getDayOfMonth(),
+        eval(expression).integerValue());
     assertEquals("day_of_month(TIME '12:23:34')", expression.toString());
   }
 
   private void testInvalidDayOfMonth(String date) {
-    FunctionExpression expression = DSL.day_of_month(functionProperties, DSL.literal(new ExprDateValue(date)));
+    FunctionExpression expression = DSL.day_of_month(
+        functionProperties, DSL.literal(new ExprDateValue(date)));
     eval(expression);
   }
 
@@ -476,7 +482,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
     //Feb. 29 of a leap year
-    testDayOfMonthWithUnderscores(DSL.day_of_month(functionProperties, DSL.literal("2020-02-29")), 29);
+    testDayOfMonthWithUnderscores(DSL.day_of_month(
+        functionProperties, DSL.literal("2020-02-29")), 29);
 
     //Feb. 29 of a non-leap year
     assertThrows(SemanticCheckException.class, () -> testInvalidDayOfMonth("2021-02-29"));

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1359,7 +1359,7 @@ DAY
 Description
 >>>>>>>>>>>
 
-Usage: day(date) extracts the day of the month for date, in the range 1 to 31. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+Usage: day(date) extracts the day of the month for date, in the range 1 to 31.
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
@@ -1407,7 +1407,7 @@ DAYOFMONTH
 Description
 >>>>>>>>>>>
 
-Usage: dayofmonth(date) extracts the day of the month for date, in the range 1 to 31. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+Usage: dayofmonth(date) extracts the day of the month for date, in the range 1 to 31.
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
@@ -1431,7 +1431,7 @@ DAY_OF_MONTH
 Description
 >>>>>>>>>>>
 
-Usage: day_of_month(date) extracts the day of the month for date, in the range 1 to 31. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+Usage: day_of_month(date) extracts the day of the month for date, in the range 1 to 31.
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
@@ -1448,31 +1448,6 @@ Example::
     |------------------------------|
     | 26                           |
     +------------------------------+
-
-    os> SELECT DAY_OF_MONTH(DATE('2020-08-26'))
-    fetched rows / total rows = 1/1
-    +------------------------------------+
-    | DAY_OF_MONTH(DATE('2020-08-26'))   |
-    |------------------------------------|
-    | 26                                 |
-    +------------------------------------+
-
-    os> SELECT DAY_OF_MONTH(TIMESTAMP('2020-08-26 00:00:00'))
-    fetched rows / total rows = 1/1
-    +--------------------------------------------------+
-    | DAY_OF_MONTH(TIMESTAMP('2020-08-26 00:00:00'))   |
-    |--------------------------------------------------|
-    | 26                                               |
-    +--------------------------------------------------+
-
-    os> SELECT DAY_OF_MONTH(DATETIME('2020-08-26 00:00:00'))
-    fetched rows / total rows = 1/1
-    +-------------------------------------------------+
-    | DAY_OF_MONTH(DATETIME('2020-08-26 00:00:00'))   |
-    |-------------------------------------------------|
-    | 26                                              |
-    +-------------------------------------------------+
-
 
 DAYOFWEEK
 ---------

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1365,7 +1365,7 @@ Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
 Return type: INTEGER
 
-Synonyms: DAYOFMONTH
+Synonyms: `DAYOFMONTH`_, `DAY_OF_MONTH`_
 
 Example::
 
@@ -1413,7 +1413,7 @@ Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
 Return type: INTEGER
 
-Synonyms: DAY
+Synonyms: `DAY`_, `DAY_OF_MONTH`_
 
 Example::
 
@@ -1424,6 +1424,54 @@ Example::
     |----------------------------------|
     | 26                               |
     +----------------------------------+
+
+DAY_OF_MONTH
+----------
+
+Description
+>>>>>>>>>>>
+
+Usage: day_of_month(date) extracts the day of the month for date, in the range 1 to 31. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Synonyms: `DAY`_, `DAYOFMONTH`_
+
+Example::
+
+    os> SELECT DAY_OF_MONTH('2020-08-26')
+    fetched rows / total rows = 1/1
+    +------------------------------+
+    | DAY_OF_MONTH('2020-08-26')   |
+    |------------------------------|
+    | 26                           |
+    +------------------------------+
+
+    os> SELECT DAY_OF_MONTH(DATE('2020-08-26'))
+    fetched rows / total rows = 1/1
+    +------------------------------------+
+    | DAY_OF_MONTH(DATE('2020-08-26'))   |
+    |------------------------------------|
+    | 26                                 |
+    +------------------------------------+
+
+    os> SELECT DAY_OF_MONTH(TIMESTAMP('2020-08-26 00:00:00'))
+    fetched rows / total rows = 1/1
+    +--------------------------------------------------+
+    | DAY_OF_MONTH(TIMESTAMP('2020-08-26 00:00:00'))   |
+    |--------------------------------------------------|
+    | 26                                               |
+    +--------------------------------------------------+
+
+    os> SELECT DAY_OF_MONTH(DATETIME('2020-08-26 00:00:00'))
+    fetched rows / total rows = 1/1
+    +-------------------------------------------------+
+    | DAY_OF_MONTH(DATETIME('2020-08-26 00:00:00'))   |
+    |-------------------------------------------------|
+    | 26                                              |
+    +-------------------------------------------------+
 
 
 DAYOFWEEK

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1426,14 +1426,14 @@ Example::
     +----------------------------------+
 
 DAY_OF_MONTH
-----------
+------------
 
 Description
 >>>>>>>>>>>
 
 Usage: day_of_month(date) extracts the day of the month for date, in the range 1 to 31.
 
-Argument type: STRING/DATE/DATETIME/TIMESTAMP
+Argument type: STRING/DATE/TIME/DATETIME/TIMESTAMP
 
 Return type: INTEGER
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1361,7 +1361,7 @@ Description
 
 Usage: day(date) extracts the day of the month for date, in the range 1 to 31.
 
-Argument type: STRING/DATE/DATETIME/TIMESTAMP
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
 
 Return type: INTEGER
 
@@ -1409,7 +1409,7 @@ Description
 
 Usage: dayofmonth(date) extracts the day of the month for date, in the range 1 to 31.
 
-Argument type: STRING/DATE/DATETIME/TIMESTAMP
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
 
 Return type: INTEGER
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -207,6 +207,48 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testDayOfMonthWithUnderscores() throws IOException {
+    JSONObject result = executeQuery("select day_of_month(date('2020-09-16'))");
+    verifySchema(result, schema("day_of_month(date('2020-09-16'))", null, "integer"));
+    verifyDataRows(result, rows(16));
+
+    result = executeQuery("select day_of_month('2020-09-16')");
+    verifySchema(result, schema("day_of_month('2020-09-16')", null, "integer"));
+    verifyDataRows(result, rows(16));
+  }
+
+  @Test
+  public void testDayOfMonthAliasesReturnTheSameResults() throws IOException {
+    JSONObject result1 = executeQuery("SELECT dayofmonth(date('2022-11-22'))");
+    JSONObject result2 = executeQuery("SELECT day_of_month(date('2022-11-22'))");
+    verifyDataRows(result1, rows(22));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT dayofmonth(CAST(date0 AS date)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT day_of_month(CAST(date0 AS date)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT dayofmonth(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT day_of_month(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT dayofmonth(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT day_of_month(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT dayofmonth(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT day_of_month(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+  }
+  @Test
   public void testDayOfWeek() throws IOException {
     JSONObject result = executeQuery("select dayofweek(date('2020-09-16'))");
     verifySchema(result, schema("dayofweek(date('2020-09-16'))", null, "integer"));

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -244,7 +244,6 @@ datetimeConstantLiteral
     : CURRENT_DATE
     | CURRENT_TIME
     | CURRENT_TIMESTAMP
-    | DAY_OF_MONTH
     | DAY_OF_YEAR
     | LOCALTIME
     | LOCALTIMESTAMP
@@ -427,6 +426,7 @@ dateTimeFunctionName
     | DAY
     | DAYNAME
     | DAYOFMONTH
+    | DAY_OF_MONTH
     | DAYOFWEEK
     | DAYOFYEAR
     | FROM_DAYS

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -244,6 +244,7 @@ datetimeConstantLiteral
     : CURRENT_DATE
     | CURRENT_TIME
     | CURRENT_TIMESTAMP
+    | DAY_OF_MONTH
     | DAY_OF_YEAR
     | LOCALTIME
     | LOCALTIMESTAMP

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -198,6 +198,12 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_dayofmonth_functions() {
+    assertNotNull(parser.parse("SELECT dayofmonth('2022-11-18')"));
+    assertNotNull(parser.parse("SELECT day_of_month('2022-11-18')"));
+  }
+
+  @Test
   public void can_parse_dayofyear_functions() {
     assertNotNull(parser.parse("SELECT dayofyear('2022-11-18')"));
     assertNotNull(parser.parse("SELECT day_of_year('2022-11-18')"));


### PR DESCRIPTION
### Description
Adds support for the `day_of_month` function as an alias for the `dayofmonth` function which currently exists in opensearch

### Issues Resolved
[#722](https://github.com/opensearch-project/sql/issues/722)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).