### PR TITLE
Add Support For `TIME` Type in "*_OF_YEAR" Functions

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -400,8 +400,9 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.TO_DAYS, expressions);
   }
 
-  public static FunctionExpression week(Expression... expressions) {
-    return compile(FunctionProperties.None, BuiltinFunctionName.WEEK, expressions);
+  public static FunctionExpression week(
+      FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.WEEK, expressions);
   }
 
   public static FunctionExpression week_of_year(

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -334,8 +334,9 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYOFYEAR, expressions);
   }
 
-  public static FunctionExpression day_of_year(Expression... expressions) {
-    return compile(FunctionProperties.None, BuiltinFunctionName.DAY_OF_YEAR, expressions);
+  public static FunctionExpression day_of_year(
+      FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.DAY_OF_YEAR, expressions);
   }
 
   public static FunctionExpression from_days(Expression... expressions) {
@@ -358,8 +359,9 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.MONTH, expressions);
   }
 
-  public static FunctionExpression month_of_year(Expression... expressions) {
-    return compile(FunctionProperties.None, BuiltinFunctionName.MONTH_OF_YEAR, expressions);
+  public static FunctionExpression month_of_year(
+      FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.MONTH_OF_YEAR, expressions);
   }
 
   public static FunctionExpression monthname(Expression... expressions) {
@@ -402,8 +404,9 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.WEEK, expressions);
   }
 
-  public static FunctionExpression week_of_year(Expression... expressions) {
-    return compile(FunctionProperties.None, BuiltinFunctionName.WEEK_OF_YEAR, expressions);
+  public static FunctionExpression week_of_year(
+      FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.WEEK_OF_YEAR, expressions);
   }
 
   public static FunctionExpression year(Expression... expressions) {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -1153,7 +1153,7 @@ public class DateTimeFunction {
    * @param mode ExprValue of Integer type.
    */
   private ExprValue exprWeek(ExprValue expr, ExprValue mode) {
-    switch ((ExprCoreType)expr.type()){
+    switch ((ExprCoreType)expr.type()) {
       case TIME:
         return new ExprIntegerValue(
             CalendarLookup.getWeekNumber(mode.integerValue(),

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -1155,12 +1155,12 @@ public class DateTimeFunction {
   /**
    * Week for date implementation for ExprValue.
    *
-   * @param expr ExprValue of Date/Datetime/Time/Timestamp/String type.
+   * @param date ExprValue of Date/Datetime/Timestamp/String type.
    * @param mode ExprValue of Integer type.
    */
-  private ExprValue exprWeek(ExprValue expr, ExprValue mode) {
-      return new ExprIntegerValue(
-          CalendarLookup.getWeekNumber(mode.integerValue(), expr.dateValue()));
+  private ExprValue exprWeek(ExprValue date, ExprValue mode) {
+    return new ExprIntegerValue(
+        CalendarLookup.getWeekNumber(mode.integerValue(), date.dateValue()));
   }
 
   private ExprValue unixTimeStamp(Clock clock) {
@@ -1240,11 +1240,11 @@ public class DateTimeFunction {
    * Week for date implementation for ExprValue.
    * When mode is not specified default value mode 0 is used for default_week_format.
    *
-   * @param expr ExprValue of Date/Datetime/Time/Timestamp/String type.
+   * @param date ExprValue of Date/Datetime/Timestamp/String type.
    * @return ExprValue.
    */
-  private ExprValue exprWeekWithoutMode(ExprValue expr) {
-    return exprWeek(expr, new ExprIntegerValue(0));
+  private ExprValue exprWeekWithoutMode(ExprValue date) {
+    return exprWeek(date, new ExprIntegerValue(0));
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -620,9 +620,10 @@ public class DateTimeFunction {
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, TIMESTAMP),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, STRING),
-        implWithProperties((functionProperties, time, modeArg) -> DateTimeFunction.weekOfYearToday(
-            modeArg,
-            functionProperties.getQueryStartClock()), INTEGER, TIME, INTEGER),
+        implWithProperties(nullMissingHandlingWithProperties((functionProperties, time, modeArg)
+            -> DateTimeFunction.weekOfYearToday(
+                modeArg,
+            functionProperties.getQueryStartClock())), INTEGER, TIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATE, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATETIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, TIMESTAMP, INTEGER),
@@ -664,12 +665,12 @@ public class DateTimeFunction {
   }
 
   private ExprValue dayOfYearToday(Clock clock) {
-    return new ExprIntegerValue((formatNow(clock).getDayOfYear()));
+    return new ExprIntegerValue(LocalDateTime.now(clock).getDayOfYear());
   }
 
   private ExprValue weekOfYearToday(ExprValue mode, Clock clock) {
     return new ExprIntegerValue(
-        CalendarLookup.getWeekNumber(mode.integerValue(), formatNow(clock).toLocalDate()));
+        CalendarLookup.getWeekNumber(mode.integerValue(), LocalDateTime.now(clock).toLocalDate()));
   }
 
   /**
@@ -1268,7 +1269,7 @@ public class DateTimeFunction {
   }
 
   private ExprValue monthOfYearToday(Clock clock) {
-    return new ExprIntegerValue((formatNow(clock).getMonthValue()));
+    return new ExprIntegerValue(LocalDateTime.now(clock).getMonthValue());
   }
 
   private LocalDateTime formatNow(Clock clock) {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -20,6 +20,7 @@ import static org.opensearch.sql.expression.function.FunctionDSL.define;
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.implWithProperties;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
+import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandlingWithProperties;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_FORMATTER_LONG_YEAR;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_FORMATTER_SHORT_YEAR;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_LONG_YEAR;
@@ -371,8 +372,9 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver dayOfYear(BuiltinFunctionName dayOfYear) {
     return define(dayOfYear.getName(),
-        implWithProperties((functionProperties, arg) -> DateTimeFunction.dayOfYearToday(
-            functionProperties.getQueryStartClock()), INTEGER, TIME),
+        implWithProperties(nullMissingHandlingWithProperties((functionProperties, arg)
+            -> DateTimeFunction.dayOfYearToday(
+            functionProperties.getQueryStartClock())), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, TIMESTAMP),
@@ -446,8 +448,9 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver month(BuiltinFunctionName month) {
     return define(month.getName(),
-        implWithProperties((functionProperties, arg) -> DateTimeFunction.monthOfYearToday(
-            functionProperties.getQueryStartClock()), INTEGER, TIME),
+        implWithProperties(nullMissingHandlingWithProperties((functionProperties, arg)
+            -> DateTimeFunction.monthOfYearToday(
+            functionProperties.getQueryStartClock())), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprMonth), INTEGER, TIMESTAMP),
@@ -609,9 +612,10 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver week(BuiltinFunctionName week) {
     return define(week.getName(),
-        implWithProperties((functionProperties, arg) -> DateTimeFunction.weekOfYearToday(
+        implWithProperties(nullMissingHandlingWithProperties((functionProperties, arg)
+            -> DateTimeFunction.weekOfYearToday(
             DEFAULT_WEEK_OF_YEAR_MODE,
-            functionProperties.getQueryStartClock()), INTEGER, TIME),
+            functionProperties.getQueryStartClock())), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, TIMESTAMP),

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -606,15 +606,17 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver week(BuiltinFunctionName week) {
     return define(week.getName(),
+        implWithProperties((functionProperties, arg) -> DateTimeFunction.weekOfYearToday(new ExprIntegerValue(0),
+            functionProperties.getQueryStartClock()), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, TIMESTAMP),
-        impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, STRING),
+        implWithProperties((functionProperties, arg1, arg2) -> DateTimeFunction.weekOfYearToday(arg2,
+            functionProperties.getQueryStartClock()), INTEGER, TIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATE, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATETIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, TIMESTAMP, INTEGER),
-        impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, TIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, STRING, INTEGER)
     );
   }
@@ -654,6 +656,10 @@ public class DateTimeFunction {
 
   private ExprValue dayOfYearToday(Clock clock) {
     return new ExprIntegerValue((formatNow(clock).getDayOfYear()));
+  }
+
+  private ExprValue weekOfYearToday(ExprValue mode, Clock clock) {
+    return new ExprIntegerValue(CalendarLookup.getWeekNumber(mode.integerValue(), formatNow(clock).toLocalDate()));
   }
 
   /**
@@ -1153,15 +1159,8 @@ public class DateTimeFunction {
    * @param mode ExprValue of Integer type.
    */
   private ExprValue exprWeek(ExprValue expr, ExprValue mode) {
-    switch ((ExprCoreType)expr.type()) {
-      case TIME:
-        return new ExprIntegerValue(
-            CalendarLookup.getWeekNumber(mode.integerValue(),
-                formatNow(Clock.systemDefaultZone()).toLocalDate()));
-      default:
-        return new ExprIntegerValue(
-            CalendarLookup.getWeekNumber(mode.integerValue(), expr.dateValue()));
-    }
+      return new ExprIntegerValue(
+          CalendarLookup.getWeekNumber(mode.integerValue(), expr.dateValue()));
   }
 
   private ExprValue unixTimeStamp(Clock clock) {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -82,6 +82,9 @@ public class DateTimeFunction {
   // 32536771199.999999, or equivalent '3001-01-18 23:59:59.999999' UTC
   private static final Double MYSQL_MAX_TIMESTAMP = 32536771200d;
 
+  // Mode used for week/week_of_year function by default when no argument is provided
+  private static final ExprIntegerValue DEFAULT_WEEK_OF_YEAR_MODE = new ExprIntegerValue(0);
+
   /**
    * Register Date and Time Functions.
    *
@@ -607,14 +610,14 @@ public class DateTimeFunction {
   private DefaultFunctionResolver week(BuiltinFunctionName week) {
     return define(week.getName(),
         implWithProperties((functionProperties, arg) -> DateTimeFunction.weekOfYearToday(
-            new ExprIntegerValue(0),
+            DEFAULT_WEEK_OF_YEAR_MODE,
             functionProperties.getQueryStartClock()), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, TIMESTAMP),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, STRING),
-        implWithProperties((functionProperties, arg1, arg2) -> DateTimeFunction.weekOfYearToday(
-            arg2,
+        implWithProperties((functionProperties, time, modeArg) -> DateTimeFunction.weekOfYearToday(
+            modeArg,
             functionProperties.getQueryStartClock()), INTEGER, TIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATE, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATETIME, INTEGER),

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -371,6 +371,7 @@ public class DateTimeFunction {
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, TIMESTAMP),
+        impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, STRING)
     );
   }

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -606,13 +606,15 @@ public class DateTimeFunction {
    */
   private DefaultFunctionResolver week(BuiltinFunctionName week) {
     return define(week.getName(),
-        implWithProperties((functionProperties, arg) -> DateTimeFunction.weekOfYearToday(new ExprIntegerValue(0),
+        implWithProperties((functionProperties, arg) -> DateTimeFunction.weekOfYearToday(
+            new ExprIntegerValue(0),
             functionProperties.getQueryStartClock()), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, TIMESTAMP),
         impl(nullMissingHandling(DateTimeFunction::exprWeekWithoutMode), INTEGER, STRING),
-        implWithProperties((functionProperties, arg1, arg2) -> DateTimeFunction.weekOfYearToday(arg2,
+        implWithProperties((functionProperties, arg1, arg2) -> DateTimeFunction.weekOfYearToday(
+            arg2,
             functionProperties.getQueryStartClock()), INTEGER, TIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATE, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATETIME, INTEGER),
@@ -659,7 +661,8 @@ public class DateTimeFunction {
   }
 
   private ExprValue weekOfYearToday(ExprValue mode, Clock clock) {
-    return new ExprIntegerValue(CalendarLookup.getWeekNumber(mode.integerValue(), formatNow(clock).toLocalDate()));
+    return new ExprIntegerValue(
+        CalendarLookup.getWeekNumber(mode.integerValue(), formatNow(clock).toLocalDate()));
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -148,7 +148,7 @@ public class FunctionDSL {
    * @return Binary Function Implementation.
    */
   public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
-  implWithProperties(
+      implWithProperties(
       SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue> function,
       ExprType returnType,
       ExprType args1Type,

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -138,10 +138,10 @@ public class FunctionDSL {
   }
 
   /**
-   * Implementation of a function that takes two argument, returns a value, and
+   * Implementation of a function that takes two arguments, returns a value, and
    * requires FunctionProperties to complete.
    *
-   * @param function {@link ExprValue} based binary function.
+   * @param function   {@link ExprValue} based Binary function.
    * @param returnType return type.
    * @param args1Type first argument type.
    * @param args2Type second argument type.
@@ -227,31 +227,8 @@ public class FunctionDSL {
       ExprType args1Type,
       ExprType args2Type) {
 
-    return functionName -> {
-      FunctionSignature functionSignature =
-          new FunctionSignature(functionName, Arrays.asList(args1Type, args2Type));
-      FunctionBuilder functionBuilder =
-          (functionProperties, arguments) -> new FunctionExpression(functionName, arguments) {
-            @Override
-            public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
-              ExprValue arg1 = arguments.get(0).valueOf(valueEnv);
-              ExprValue arg2 = arguments.get(1).valueOf(valueEnv);
-              return function.apply(arg1, arg2);
-            }
-
-            @Override
-            public ExprType type() {
-              return returnType;
-            }
-
-            @Override
-            public String toString() {
-              return String.format("%s(%s, %s)", functionName, arguments.get(0).toString(),
-                  arguments.get(1).toString());
-            }
-          };
-      return Pair.of(functionSignature, functionBuilder);
-    };
+    return implWithProperties((fp, arg1, arg2) ->
+        function.apply(arg1, arg2), returnType, args1Type, args2Type);
   }
 
   /**
@@ -360,6 +337,24 @@ public class FunctionDSL {
         return ExprValueUtils.nullValue();
       } else {
         return implementation.apply(functionProperties, v1);
+      }
+    };
+  }
+
+  /**
+   * Wrapper for the ExprValue function that takes 2 arguments and is aware of FunctionProperties,
+   * with default NULL and MISSING handling.
+   */
+  public static SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue>
+        nullMissingHandlingWithProperties(
+      SerializableTriFunction<FunctionProperties, ExprValue, ExprValue,ExprValue> implementation) {
+    return (functionProperties, v1, v2) -> {
+      if (v1.isMissing() || v2.isMissing()) {
+        return ExprValueUtils.missingValue();
+      } else if (v1.isNull() || v2.isNull()) {
+        return ExprValueUtils.nullValue();
+      } else {
+        return implementation.apply(functionProperties, v1, v2);
       }
     };
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -138,6 +138,52 @@ public class FunctionDSL {
   }
 
   /**
+   * Implementation of a function that takes two argument, returns a value, and
+   * requires FunctionProperties to complete.
+   *
+   * @param function {@link ExprValue} based binary function.
+   * @param returnType return type.
+   * @param args1Type first argument type.
+   * @param args2Type second argument type.
+   * @return Binary Function Implementation.
+   */
+  public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+  implWithProperties(
+      SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue> function,
+      ExprType returnType,
+      ExprType args1Type,
+      ExprType args2Type) {
+
+    return functionName -> {
+      FunctionSignature functionSignature =
+          new FunctionSignature(functionName, Arrays.asList(args1Type, args2Type));
+      FunctionBuilder functionBuilder =
+          (functionProperties, arguments) -> new FunctionExpression(functionName, arguments) {
+            @Override
+            public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+              ExprValue arg1 = arguments.get(0).valueOf(valueEnv);
+              ExprValue arg2 = arguments.get(1).valueOf(valueEnv);
+              return function.apply(functionProperties, arg1, arg2);
+            }
+
+            @Override
+            public ExprType type() {
+              return returnType;
+            }
+
+            @Override
+            public String toString() {
+              return String.format("%s(%s)", functionName,
+                  arguments.stream()
+                      .map(Object::toString)
+                      .collect(Collectors.joining(", ")));
+            }
+          };
+      return Pair.of(functionSignature, functionBuilder);
+    };
+  }
+
+  /**
    * No Arg Function Implementation.
    *
    * @param function   {@link ExprValue} based unary function.

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -492,23 +492,21 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void testDayOfYearWithTimeType() {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
-    FunctionExpression expression = DSL.day_of_year(
-        functionProperties,
-        DSL.literal(new ExprTimeValue("12:23:34")));
 
-    assertEquals(INTEGER, eval(expression).type());
-    assertEquals(LocalDate.now(
-            functionProperties.getQueryStartClock()).getDayOfYear(),
-        eval(expression).integerValue());
-    assertEquals("day_of_year(TIME '12:23:34')", expression.toString());
+    validateStringFormat(
+        DSL.day_of_year(functionProperties, DSL.literal(new ExprTimeValue("12:23:34"))),
+        "day_of_year(TIME '12:23:34')",
+        LocalDate.now(functionProperties.getQueryStartClock()).getDayOfYear());
   }
 
   public void dayOfYearWithUnderscoresQuery(String date, int dayOfYear) {
     FunctionExpression expression = DSL.day_of_year(
         functionProperties,
         DSL.literal(new ExprDateValue(date)));
-    assertEquals(INTEGER, expression.type());
-    assertEquals(integerValue(dayOfYear), eval(expression));
+    assertAll(
+        () -> assertEquals(INTEGER, expression.type()),
+        () -> assertEquals(integerValue(dayOfYear), eval(expression))
+    );
   }
 
   @Test
@@ -589,19 +587,26 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void invalidDayOfYearArgument() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.day_of_year(
-        functionProperties,
-        nullRef)));
-    assertEquals(missingValue(), eval(DSL.day_of_year(
-        functionProperties,
-        missingRef)));
 
-    //29th of Feb non-leapyear
-    assertThrows(SemanticCheckException.class, () ->  invalidDayOfYearQuery("2019-02-29"));
-    //13th month
-    assertThrows(SemanticCheckException.class, () ->  invalidDayOfYearQuery("2019-13-15"));
-    //incorrect format for type
-    assertThrows(SemanticCheckException.class, () ->  invalidDayOfYearQuery("asdfasdfasdf"));
+    assertAll(
+        () -> assertEquals(nullValue(), eval(DSL.day_of_year(functionProperties, nullRef))),
+        () -> assertEquals(missingValue(), eval(DSL.day_of_year(functionProperties, missingRef))),
+
+        //29th of Feb non-leapyear
+        () -> assertThrows(
+            SemanticCheckException.class,
+            () ->  invalidDayOfYearQuery("2019-02-29")),
+
+        //13th month
+        () -> assertThrows(
+            SemanticCheckException.class,
+            () ->  invalidDayOfYearQuery("2019-13-15")),
+        
+        //incorrect format for type
+        () -> assertThrows(
+            SemanticCheckException.class,
+            () ->  invalidDayOfYearQuery("asdfasdfasdf"))
+    );
   }
   
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -766,7 +766,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     eval(expression);
   }
 
-  @Test void monthOfYearInvalidDates() {
+  @Test
+  public void monthOfYearInvalidDates() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
     assertEquals(nullValue(), eval(DSL.month_of_year(
@@ -1036,7 +1037,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals("timestamp(TIMESTAMP '2020-08-17 01:01:01')", expr.toString());
   }
 
-  private void testWeek(String date, int mode, int expectedResult) {
+  private void weekQuery(String date, int mode, int expectedResult) {
     FunctionExpression expression = DSL
         .week(functionProperties, DSL.literal(new ExprDateValue(date)), DSL.literal(mode));
     assertEquals(INTEGER, expression.type());
@@ -1089,36 +1090,36 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals("week(\"2019-01-05 00:01:00\")", expression.toString());
     assertEquals(integerValue(0), eval(expression));
 
-    testWeek("2019-01-05", 0, 0);
-    testWeek("2019-01-05", 1, 1);
-    testWeek("2019-01-05", 2, 52);
-    testWeek("2019-01-05", 3, 1);
-    testWeek("2019-01-05", 4, 1);
-    testWeek("2019-01-05", 5, 0);
-    testWeek("2019-01-05", 6, 1);
-    testWeek("2019-01-05", 7, 53);
+    weekQuery("2019-01-05", 0, 0);
+    weekQuery("2019-01-05", 1, 1);
+    weekQuery("2019-01-05", 2, 52);
+    weekQuery("2019-01-05", 3, 1);
+    weekQuery("2019-01-05", 4, 1);
+    weekQuery("2019-01-05", 5, 0);
+    weekQuery("2019-01-05", 6, 1);
+    weekQuery("2019-01-05", 7, 53);
 
-    testWeek("2019-01-06", 0, 1);
-    testWeek("2019-01-06", 1, 1);
-    testWeek("2019-01-06", 2, 1);
-    testWeek("2019-01-06", 3, 1);
-    testWeek("2019-01-06", 4, 2);
-    testWeek("2019-01-06", 5, 0);
-    testWeek("2019-01-06", 6, 2);
-    testWeek("2019-01-06", 7, 53);
+    weekQuery("2019-01-06", 0, 1);
+    weekQuery("2019-01-06", 1, 1);
+    weekQuery("2019-01-06", 2, 1);
+    weekQuery("2019-01-06", 3, 1);
+    weekQuery("2019-01-06", 4, 2);
+    weekQuery("2019-01-06", 5, 0);
+    weekQuery("2019-01-06", 6, 2);
+    weekQuery("2019-01-06", 7, 53);
 
-    testWeek("2019-01-07", 0, 1);
-    testWeek("2019-01-07", 1, 2);
-    testWeek("2019-01-07", 2, 1);
-    testWeek("2019-01-07", 3, 2);
-    testWeek("2019-01-07", 4, 2);
-    testWeek("2019-01-07", 5, 1);
-    testWeek("2019-01-07", 6, 2);
-    testWeek("2019-01-07", 7, 1);
+    weekQuery("2019-01-07", 0, 1);
+    weekQuery("2019-01-07", 1, 2);
+    weekQuery("2019-01-07", 2, 1);
+    weekQuery("2019-01-07", 3, 2);
+    weekQuery("2019-01-07", 4, 2);
+    weekQuery("2019-01-07", 5, 1);
+    weekQuery("2019-01-07", 6, 2);
+    weekQuery("2019-01-07", 7, 1);
 
-    testWeek("2000-01-01", 0, 0);
-    testWeek("2000-01-01", 2, 52);
-    testWeek("1999-12-31", 0, 52);
+    weekQuery("2000-01-01", 0, 0);
+    weekQuery("2000-01-01", 2, 52);
+    weekQuery("1999-12-31", 0, 52);
   }
 
   @Test
@@ -1162,7 +1163,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         exception.getMessage());
   }
 
-  private void testWeekOfYear(String date, int mode, int expectedResult) {
+  private void weekOfYearQuery(String date, int mode, int expectedResult) {
     FunctionExpression expression = DSL
         .week_of_year(
             functionProperties,
@@ -1206,11 +1207,11 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         nullRef, missingRef)));
 
     //test invalid month
-    assertThrows(SemanticCheckException.class, () -> testWeekOfYear("2019-13-05 01:02:03", 0, 0));
+    assertThrows(SemanticCheckException.class, () -> weekOfYearQuery("2019-13-05 01:02:03", 0, 0));
     //test invalid day
-    assertThrows(SemanticCheckException.class, () -> testWeekOfYear("2019-01-50 01:02:03", 0, 0));
+    assertThrows(SemanticCheckException.class, () -> weekOfYearQuery("2019-01-50 01:02:03", 0, 0));
     //test invalid leap year
-    assertThrows(SemanticCheckException.class, () -> testWeekOfYear("2019-02-29 01:02:03", 0, 0));
+    assertThrows(SemanticCheckException.class, () -> weekOfYearQuery("2019-02-29 01:02:03", 0, 0));
   }
 
   @Test
@@ -1247,36 +1248,36 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
     //Test the behavior of different modes passed into the 'week_of_year' function
-    testWeekOfYear("2019-01-05", 0, 0);
-    testWeekOfYear("2019-01-05", 1, 1);
-    testWeekOfYear("2019-01-05", 2, 52);
-    testWeekOfYear("2019-01-05", 3, 1);
-    testWeekOfYear("2019-01-05", 4, 1);
-    testWeekOfYear("2019-01-05", 5, 0);
-    testWeekOfYear("2019-01-05", 6, 1);
-    testWeekOfYear("2019-01-05", 7, 53);
+    weekOfYearQuery("2019-01-05", 0, 0);
+    weekOfYearQuery("2019-01-05", 1, 1);
+    weekOfYearQuery("2019-01-05", 2, 52);
+    weekOfYearQuery("2019-01-05", 3, 1);
+    weekOfYearQuery("2019-01-05", 4, 1);
+    weekOfYearQuery("2019-01-05", 5, 0);
+    weekOfYearQuery("2019-01-05", 6, 1);
+    weekOfYearQuery("2019-01-05", 7, 53);
 
-    testWeekOfYear("2019-01-06", 0, 1);
-    testWeekOfYear("2019-01-06", 1, 1);
-    testWeekOfYear("2019-01-06", 2, 1);
-    testWeekOfYear("2019-01-06", 3, 1);
-    testWeekOfYear("2019-01-06", 4, 2);
-    testWeekOfYear("2019-01-06", 5, 0);
-    testWeekOfYear("2019-01-06", 6, 2);
-    testWeekOfYear("2019-01-06", 7, 53);
+    weekOfYearQuery("2019-01-06", 0, 1);
+    weekOfYearQuery("2019-01-06", 1, 1);
+    weekOfYearQuery("2019-01-06", 2, 1);
+    weekOfYearQuery("2019-01-06", 3, 1);
+    weekOfYearQuery("2019-01-06", 4, 2);
+    weekOfYearQuery("2019-01-06", 5, 0);
+    weekOfYearQuery("2019-01-06", 6, 2);
+    weekOfYearQuery("2019-01-06", 7, 53);
 
-    testWeekOfYear("2019-01-07", 0, 1);
-    testWeekOfYear("2019-01-07", 1, 2);
-    testWeekOfYear("2019-01-07", 2, 1);
-    testWeekOfYear("2019-01-07", 3, 2);
-    testWeekOfYear("2019-01-07", 4, 2);
-    testWeekOfYear("2019-01-07", 5, 1);
-    testWeekOfYear("2019-01-07", 6, 2);
-    testWeekOfYear("2019-01-07", 7, 1);
+    weekOfYearQuery("2019-01-07", 0, 1);
+    weekOfYearQuery("2019-01-07", 1, 2);
+    weekOfYearQuery("2019-01-07", 2, 1);
+    weekOfYearQuery("2019-01-07", 3, 2);
+    weekOfYearQuery("2019-01-07", 4, 2);
+    weekOfYearQuery("2019-01-07", 5, 1);
+    weekOfYearQuery("2019-01-07", 6, 2);
+    weekOfYearQuery("2019-01-07", 7, 1);
 
-    testWeekOfYear("2000-01-01", 0, 0);
-    testWeekOfYear("2000-01-01", 2, 52);
-    testWeekOfYear("1999-12-31", 0, 52);
+    weekOfYearQuery("2000-01-01", 0, 0);
+    weekOfYearQuery("2000-01-01", 2, 52);
+    weekOfYearQuery("1999-12-31", 0, 52);
 
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -1038,7 +1038,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
   private void testWeek(String date, int mode, int expectedResult) {
     FunctionExpression expression = DSL
-        .week(DSL.literal(new ExprDateValue(date)), DSL.literal(mode));
+        .week(functionProperties, DSL.literal(new ExprDateValue(date)), DSL.literal(mode));
     assertEquals(INTEGER, expression.type());
     assertEquals(String.format("week(DATE '%s', %d)", date, mode), expression.toString());
     assertEquals(integerValue(expectedResult), eval(expression));
@@ -1047,8 +1047,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   private void testNullMissingWeek(ExprCoreType date) {
     when(nullRef.type()).thenReturn(date);
     when(missingRef.type()).thenReturn(date);
-    assertEquals(nullValue(), eval(DSL.week(nullRef)));
-    assertEquals(missingValue(), eval(DSL.week(missingRef)));
+    assertEquals(nullValue(), eval(DSL.week(functionProperties, nullRef)));
+    assertEquals(missingValue(), eval(DSL.week(functionProperties, missingRef)));
   }
 
   @Test
@@ -1060,25 +1060,31 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     when(nullRef.type()).thenReturn(INTEGER);
     when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(nullValue(), eval(DSL.week(DSL.literal("2019-01-05"), nullRef)));
-    assertEquals(missingValue(), eval(DSL.week(DSL.literal("2019-01-05"), missingRef)));
+    assertEquals(nullValue(), eval(DSL.week(
+        functionProperties,
+        DSL.literal("2019-01-05"), nullRef)));
+    assertEquals(missingValue(), eval(DSL.week(
+        functionProperties,
+        DSL.literal("2019-01-05"), missingRef)));
 
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(missingValue(), eval(DSL.week(nullRef, missingRef)));
+    assertEquals(missingValue(), eval(DSL.week(
+        functionProperties,
+        nullRef, missingRef)));
 
     FunctionExpression expression = DSL
-        .week(DSL.literal(new ExprTimestampValue("2019-01-05 01:02:03")));
+        .week(functionProperties, DSL.literal(new ExprTimestampValue("2019-01-05 01:02:03")));
     assertEquals(INTEGER, expression.type());
     assertEquals("week(TIMESTAMP '2019-01-05 01:02:03')", expression.toString());
     assertEquals(integerValue(0), eval(expression));
 
-    expression = DSL.week(DSL.literal("2019-01-05"));
+    expression = DSL.week(functionProperties, DSL.literal("2019-01-05"));
     assertEquals(INTEGER, expression.type());
     assertEquals("week(\"2019-01-05\")", expression.toString());
     assertEquals(integerValue(0), eval(expression));
 
-    expression = DSL.week(DSL.literal("2019-01-05 00:01:00"));
+    expression = DSL.week(functionProperties, DSL.literal("2019-01-05 00:01:00"));
     assertEquals(INTEGER, expression.type());
     assertEquals("week(\"2019-01-05 00:01:00\")", expression.toString());
     assertEquals(integerValue(0), eval(expression));
@@ -1119,10 +1125,18 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void testWeekOfYearWithTimeType() {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
-    FunctionExpression expression = DSL.week_of_year(
+
+    FunctionExpression expression = DSL
+        .week(functionProperties, DSL.literal(new ExprTimeValue("12:23:34")), DSL.literal(0));
+    assertEquals(INTEGER, eval(expression).type());
+    assertEquals(LocalDate.now(
+            functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR),
+        eval(expression).integerValue());
+    assertEquals("week(TIME '12:23:34', 0)", expression.toString());
+
+    expression = DSL.week_of_year(
         functionProperties,
         DSL.literal(new ExprTimeValue("12:23:34")));
-
     assertEquals(INTEGER, eval(expression).type());
     assertEquals(LocalDate.now(
             functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR),
@@ -1135,14 +1149,14 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     testNullMissingWeek(DATE);
 
     FunctionExpression expression1 = DSL
-        .week(DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(8));
+        .week(functionProperties, DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(8));
     SemanticCheckException exception =
         assertThrows(SemanticCheckException.class, () -> eval(expression1));
     assertEquals("mode:8 is invalid, please use mode value between 0-7",
         exception.getMessage());
 
     FunctionExpression expression2 = DSL
-        .week(DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(-1));
+        .week(functionProperties, DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(-1));
     exception = assertThrows(SemanticCheckException.class, () -> eval(expression2));
     assertEquals("mode:-1 is invalid, please use mode value between 0-7",
         exception.getMessage());

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
-
 import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -820,6 +819,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
             8)
     );
   }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("getTestDataForMonthOfYear")
   public void monthOfYear(LiteralExpression arg, String expectedString, int expectedResult) {
@@ -1153,7 +1153,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   }
 
   @Test
-  public void testNullMissingWeek(){
+  public void testNullMissingWeek() {
     nullMissingWeekQuery(DATE);
     nullMissingWeekQuery(DATETIME);
     nullMissingWeekQuery(TIMESTAMP);
@@ -1276,7 +1276,10 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     assertAll(
         () -> validateStringFormat(
-            DSL.week(functionProperties, DSL.literal(new ExprTimeValue("12:23:34")), DSL.literal(0)),
+            DSL.week(
+                functionProperties,
+                DSL.literal(new ExprTimeValue("12:23:34")),
+                DSL.literal(0)),
             "week(TIME '12:23:34', 0)",
             LocalDate.now(functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR)),
 

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -497,7 +497,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals("day_of_year(TIME '12:23:34')", expression.toString());
   }
 
-  public void testDayOfYearWithUnderscores(String date, int dayOfYear) {
+  public void dayOfYearWithUnderscoresQuery(String date, int dayOfYear) {
     FunctionExpression expression = DSL.day_of_year(
         functionProperties,
         DSL.literal(new ExprDateValue(date)));
@@ -521,13 +521,13 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         DSL.literal("2020-08-07 01:02:03"));
 
     assertAll(
-        () -> testDayOfYearWithUnderscores("2020-08-07", 220),
+        () -> dayOfYearWithUnderscoresQuery("2020-08-07", 220),
         () -> assertEquals("day_of_year(DATE '2020-08-07')", expression1.toString()),
 
-        () -> testDayOfYearWithUnderscores("2020-08-07", 220),
+        () -> dayOfYearWithUnderscoresQuery("2020-08-07", 220),
         () ->     assertEquals("day_of_year(\"2020-08-07\")", expression2.toString()),
 
-        () -> testDayOfYearWithUnderscores("2020-08-07 01:02:03", 220),
+        () -> dayOfYearWithUnderscoresQuery("2020-08-07 01:02:03", 220),
         () ->     assertEquals("day_of_year(\"2020-08-07 01:02:03\")", expression3.toString())
     );
   }
@@ -539,11 +539,11 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     assertAll(
         //31st of December during non leap year (should be 365)
-        () -> testDayOfYearWithUnderscores("2019-12-31", 365),
+        () -> dayOfYearWithUnderscoresQuery("2019-12-31", 365),
         //Year 1200
-        () -> testDayOfYearWithUnderscores("1200-02-28", 59),
+        () -> dayOfYearWithUnderscoresQuery("1200-02-28", 59),
         //Year 4000
-        () -> testDayOfYearWithUnderscores("4000-02-28", 59)
+        () -> dayOfYearWithUnderscoresQuery("4000-02-28", 59)
     );
   }
 
@@ -554,25 +554,25 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     assertAll(
         //28th of Feb
-        () -> testDayOfYearWithUnderscores("2020-02-28", 59),
+        () -> dayOfYearWithUnderscoresQuery("2020-02-28", 59),
 
         //29th of Feb during leap year
-        () -> testDayOfYearWithUnderscores("2020-02-29 23:59:59", 60),
-        () -> testDayOfYearWithUnderscores("2020-02-29", 60),
+        () -> dayOfYearWithUnderscoresQuery("2020-02-29 23:59:59", 60),
+        () -> dayOfYearWithUnderscoresQuery("2020-02-29", 60),
 
         //1st of March during leap year
-        () -> testDayOfYearWithUnderscores("2020-03-01 00:00:00", 61),
-        () -> testDayOfYearWithUnderscores("2020-03-01", 61),
+        () -> dayOfYearWithUnderscoresQuery("2020-03-01 00:00:00", 61),
+        () -> dayOfYearWithUnderscoresQuery("2020-03-01", 61),
 
         //1st of March during non leap year
-        () -> testDayOfYearWithUnderscores("2019-03-01", 60),
+        () -> dayOfYearWithUnderscoresQuery("2019-03-01", 60),
 
         //31st of December during  leap year (should be 366)
-        () -> testDayOfYearWithUnderscores("2020-12-31", 366)
+        () -> dayOfYearWithUnderscoresQuery("2020-12-31", 366)
     );
   }
 
-  public void testInvalidDayOfYear(String date) {
+  public void invalidDayOfYearQuery(String date) {
     FunctionExpression expression = DSL.day_of_year(
         functionProperties,
         DSL.literal(new ExprDateValue(date)));
@@ -591,11 +591,11 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         missingRef)));
 
     //29th of Feb non-leapyear
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDayOfYear("2019-02-29"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDayOfYearQuery("2019-02-29"));
     //13th month
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDayOfYear("2019-13-15"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDayOfYearQuery("2019-13-15"));
     //incorrect format for type
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDayOfYear("asdfasdfasdf"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDayOfYearQuery("asdfasdfasdf"));
   }
   
   @Test
@@ -759,7 +759,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals("month_of_year(TIME '12:23:34')", expression.toString());
   }
 
-  public void testInvalidDates(String date) throws SemanticCheckException {
+  public void invalidDatesQuery(String date) throws SemanticCheckException {
     FunctionExpression expression = DSL.month_of_year(
         functionProperties,
         DSL.literal(new ExprDateValue(date)));
@@ -776,10 +776,10 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         functionProperties,
         missingRef)));
 
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDates("2019-01-50"));
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDates("2019-02-29"));
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDates("2019-02-31"));
-    assertThrows(SemanticCheckException.class, () ->  testInvalidDates("2019-13-05"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-01-50"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-02-29"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-02-31"));
+    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-13-05"));
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.expression.datetime;
 
+import static java.time.temporal.ChronoField.ALIGNED_WEEK_OF_YEAR;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -481,8 +482,25 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(integerValue(220), eval(expression));
   }
 
+  @Test
+  public void testDayOfYearWithTimeType() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+    FunctionExpression expression = DSL.day_of_year(
+        functionProperties,
+        DSL.literal(new ExprTimeValue("12:23:34")));
+
+    assertEquals(INTEGER, eval(expression).type());
+    assertEquals(LocalDate.now(
+            functionProperties.getQueryStartClock()).getDayOfYear(),
+        eval(expression).integerValue());
+    assertEquals("day_of_year(TIME '12:23:34')", expression.toString());
+  }
+
   public void testDayOfYearWithUnderscores(String date, int dayOfYear) {
-    FunctionExpression expression = DSL.day_of_year(DSL.literal(new ExprDateValue(date)));
+    FunctionExpression expression = DSL.day_of_year(
+        functionProperties,
+        DSL.literal(new ExprDateValue(date)));
     assertEquals(INTEGER, expression.type());
     assertEquals(integerValue(dayOfYear), eval(expression));
   }
@@ -492,9 +510,15 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
-    FunctionExpression expression1 = DSL.day_of_year(DSL.literal(new ExprDateValue("2020-08-07")));
-    FunctionExpression expression2 = DSL.day_of_year(DSL.literal("2020-08-07"));
-    FunctionExpression expression3 = DSL.day_of_year(DSL.literal("2020-08-07 01:02:03"));
+    FunctionExpression expression1 = DSL.day_of_year(
+        functionProperties,
+        DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression2 = DSL.day_of_year(
+        functionProperties,
+        DSL.literal("2020-08-07"));
+    FunctionExpression expression3 = DSL.day_of_year(
+        functionProperties,
+        DSL.literal("2020-08-07 01:02:03"));
 
     assertAll(
         () -> testDayOfYearWithUnderscores("2020-08-07", 220),
@@ -549,7 +573,9 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   }
 
   public void testInvalidDayOfYear(String date) {
-    FunctionExpression expression = DSL.day_of_year(DSL.literal(new ExprDateValue(date)));
+    FunctionExpression expression = DSL.day_of_year(
+        functionProperties,
+        DSL.literal(new ExprDateValue(date)));
     eval(expression);
   }
 
@@ -557,8 +583,12 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void invalidDayOfYearArgument() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.day_of_year(nullRef)));
-    assertEquals(missingValue(), eval(DSL.day_of_year(missingRef)));
+    assertEquals(nullValue(), eval(DSL.day_of_year(
+        functionProperties,
+        nullRef)));
+    assertEquals(missingValue(), eval(DSL.day_of_year(
+        functionProperties,
+        missingRef)));
 
     //29th of Feb non-leapyear
     assertThrows(SemanticCheckException.class, () ->  testInvalidDayOfYear("2019-02-29"));
@@ -714,16 +744,37 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(integerValue(8), eval(expression));
   }
 
+  @Test
+  public void testMonthOfYearWithTimeType() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+    FunctionExpression expression = DSL.month_of_year(
+        functionProperties,
+        DSL.literal(new ExprTimeValue("12:23:34")));
+
+    assertEquals(INTEGER, eval(expression).type());
+    assertEquals(LocalDate.now(
+            functionProperties.getQueryStartClock()).getMonthValue(),
+        eval(expression).integerValue());
+    assertEquals("month_of_year(TIME '12:23:34')", expression.toString());
+  }
+
   public void testInvalidDates(String date) throws SemanticCheckException {
-    FunctionExpression expression = DSL.month_of_year(DSL.literal(new ExprDateValue(date)));
+    FunctionExpression expression = DSL.month_of_year(
+        functionProperties,
+        DSL.literal(new ExprDateValue(date)));
     eval(expression);
   }
 
   @Test void monthOfYearInvalidDates() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.month_of_year(nullRef)));
-    assertEquals(missingValue(), eval(DSL.month_of_year(missingRef)));
+    assertEquals(nullValue(), eval(DSL.month_of_year(
+        functionProperties,
+        nullRef)));
+    assertEquals(missingValue(), eval(DSL.month_of_year(
+        functionProperties,
+        missingRef)));
 
     assertThrows(SemanticCheckException.class, () ->  testInvalidDates("2019-01-50"));
     assertThrows(SemanticCheckException.class, () ->  testInvalidDates("2019-02-29"));
@@ -736,17 +787,23 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
-    FunctionExpression expression = DSL.month_of_year(DSL.literal(new ExprDateValue("2020-08-07")));
+    FunctionExpression expression = DSL.month_of_year(
+        functionProperties,
+        DSL.literal(new ExprDateValue("2020-08-07")));
     assertEquals(INTEGER, expression.type());
     assertEquals("month_of_year(DATE '2020-08-07')", expression.toString());
     assertEquals(integerValue(8), eval(expression));
 
-    expression = DSL.month_of_year(DSL.literal("2020-08-07"));
+    expression = DSL.month_of_year(
+        functionProperties,
+        DSL.literal("2020-08-07"));
     assertEquals(INTEGER, expression.type());
     assertEquals("month_of_year(\"2020-08-07\")", expression.toString());
     assertEquals(integerValue(8), eval(expression));
 
-    expression = DSL.month_of_year(DSL.literal("2020-08-07 01:02:03"));
+    expression = DSL.month_of_year(
+        functionProperties,
+        DSL.literal("2020-08-07 01:02:03"));
     assertEquals(INTEGER, expression.type());
     assertEquals("month_of_year(\"2020-08-07 01:02:03\")", expression.toString());
     assertEquals(integerValue(8), eval(expression));
@@ -1059,6 +1116,21 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   }
 
   @Test
+  public void testWeekOfYearWithTimeType() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+    FunctionExpression expression = DSL.week_of_year(
+        functionProperties,
+        DSL.literal(new ExprTimeValue("12:23:34")));
+
+    assertEquals(INTEGER, eval(expression).type());
+    assertEquals(LocalDate.now(
+            functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR),
+        eval(expression).integerValue());
+    assertEquals("week_of_year(TIME '12:23:34')", expression.toString());
+  }
+
+  @Test
   public void modeInUnsupportedFormat() {
     testNullMissingWeek(DATE);
 
@@ -1078,7 +1150,9 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
   private void testWeekOfYear(String date, int mode, int expectedResult) {
     FunctionExpression expression = DSL
-        .week_of_year(DSL.literal(new ExprDateValue(date)), DSL.literal(mode));
+        .week_of_year(
+            functionProperties,
+            DSL.literal(new ExprDateValue(date)), DSL.literal(mode));
     assertEquals(INTEGER, expression.type());
     assertEquals(String.format("week_of_year(DATE '%s', %d)", date, mode), expression.toString());
     assertEquals(integerValue(expectedResult), eval(expression));
@@ -1087,8 +1161,12 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   private void testNullMissingWeekOfYear(ExprCoreType date) {
     when(nullRef.type()).thenReturn(date);
     when(missingRef.type()).thenReturn(date);
-    assertEquals(nullValue(), eval(DSL.week_of_year(nullRef)));
-    assertEquals(missingValue(), eval(DSL.week_of_year(missingRef)));
+    assertEquals(nullValue(), eval(DSL.week_of_year(
+        functionProperties,
+        nullRef)));
+    assertEquals(missingValue(), eval(DSL.week_of_year(
+        functionProperties,
+        missingRef)));
   }
 
   @Test
@@ -1100,12 +1178,18 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     when(nullRef.type()).thenReturn(INTEGER);
     when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(nullValue(), eval(DSL.week_of_year(DSL.literal("2019-01-05"), nullRef)));
-    assertEquals(missingValue(), eval(DSL.week_of_year(DSL.literal("2019-01-05"), missingRef)));
+    assertEquals(nullValue(), eval(DSL.week_of_year(
+        functionProperties,
+        DSL.literal("2019-01-05"), nullRef)));
+    assertEquals(missingValue(), eval(DSL.week_of_year(
+        functionProperties,
+        DSL.literal("2019-01-05"), missingRef)));
 
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(missingValue(), eval(DSL.week_of_year(nullRef, missingRef)));
+    assertEquals(missingValue(), eval(DSL.week_of_year(
+        functionProperties,
+        nullRef, missingRef)));
 
     //test invalid month
     assertThrows(SemanticCheckException.class, () -> testWeekOfYear("2019-13-05 01:02:03", 0, 0));
@@ -1121,17 +1205,23 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
 
     FunctionExpression expression = DSL
-        .week_of_year(DSL.literal(new ExprTimestampValue("2019-01-05 01:02:03")));
+        .week_of_year(
+            functionProperties,
+            DSL.literal(new ExprTimestampValue("2019-01-05 01:02:03")));
     assertEquals(INTEGER, expression.type());
     assertEquals("week_of_year(TIMESTAMP '2019-01-05 01:02:03')", expression.toString());
     assertEquals(integerValue(0), eval(expression));
 
-    expression = DSL.week_of_year(DSL.literal("2019-01-05"));
+    expression = DSL.week_of_year(
+        functionProperties,
+        DSL.literal("2019-01-05"));
     assertEquals(INTEGER, expression.type());
     assertEquals("week_of_year(\"2019-01-05\")", expression.toString());
     assertEquals(integerValue(0), eval(expression));
 
-    expression = DSL.week_of_year(DSL.literal("2019-01-05 00:01:00"));
+    expression = DSL.week_of_year(
+        functionProperties,
+        DSL.literal("2019-01-05 00:01:00"));
     assertEquals(INTEGER, expression.type());
     assertEquals("week_of_year(\"2019-01-05 00:01:00\")", expression.toString());
     assertEquals(integerValue(0), eval(expression));
@@ -1181,14 +1271,18 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     testNullMissingWeekOfYear(DATE);
 
     FunctionExpression expression1 = DSL
-        .week_of_year(DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(8));
+        .week_of_year(
+            functionProperties,
+            DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(8));
     SemanticCheckException exception =
         assertThrows(SemanticCheckException.class, () -> eval(expression1));
     assertEquals("mode:8 is invalid, please use mode value between 0-7",
         exception.getMessage());
 
     FunctionExpression expression2 = DSL
-        .week_of_year(DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(-1));
+        .week_of_year(
+            functionProperties,
+            DSL.literal(new ExprDateValue("2019-01-05")), DSL.literal(-1));
     exception = assertThrows(SemanticCheckException.class, () -> eval(expression2));
     assertEquals("mode:-1 is invalid, please use mode value between 0-7",
         exception.getMessage());

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -754,15 +754,11 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void testMonthOfYearWithTimeType() {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
     lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
-    FunctionExpression expression = DSL.month_of_year(
-        functionProperties,
-        DSL.literal(new ExprTimeValue("12:23:34")));
 
-    assertEquals(INTEGER, eval(expression).type());
-    assertEquals(LocalDate.now(
-            functionProperties.getQueryStartClock()).getMonthValue(),
-        eval(expression).integerValue());
-    assertEquals("month_of_year(TIME '12:23:34')", expression.toString());
+    validateStringFormat(
+        DSL.month_of_year(functionProperties, DSL.literal(new ExprTimeValue("12:23:34"))),
+        "month_of_year(TIME '12:23:34')",
+        LocalDate.now(functionProperties.getQueryStartClock()).getMonthValue());
   }
 
   public void invalidDatesQuery(String date) throws SemanticCheckException {
@@ -776,17 +772,22 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void monthOfYearInvalidDates() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
-    assertEquals(nullValue(), eval(DSL.month_of_year(
-        functionProperties,
-        nullRef)));
-    assertEquals(missingValue(), eval(DSL.month_of_year(
-        functionProperties,
-        missingRef)));
 
-    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-01-50"));
-    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-02-29"));
-    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-02-31"));
-    assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-13-05"));
+    assertAll(
+        () -> assertEquals(nullValue(), eval(DSL.month_of_year(
+            functionProperties,
+            nullRef))),
+        () -> assertEquals(missingValue(), eval(DSL.month_of_year(
+            functionProperties,
+            missingRef))),
+        () -> assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-01-50")),
+        () -> assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-02-29")),
+        () -> assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-02-31")),
+        () -> assertThrows(SemanticCheckException.class, () ->  invalidDatesQuery("2019-13-05"))
+    );
+
+
+
   }
 
   @Test
@@ -1250,11 +1251,17 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     assertAll(
         //test invalid month
-        () -> assertThrows(SemanticCheckException.class, () -> weekOfYearQuery("2019-13-05 01:02:03", 0, 0)),
+        () -> assertThrows(
+            SemanticCheckException.class,
+            () -> weekOfYearQuery("2019-13-05 01:02:03", 0, 0)),
         //test invalid day
-        () -> assertThrows(SemanticCheckException.class, () -> weekOfYearQuery("2019-01-50 01:02:03", 0, 0)),
+        () -> assertThrows(
+            SemanticCheckException.class,
+            () -> weekOfYearQuery("2019-01-50 01:02:03", 0, 0)),
         //test invalid leap year
-        () -> assertThrows(SemanticCheckException.class, () -> weekOfYearQuery("2019-02-29 01:02:03", 0, 0))
+        () -> assertThrows(
+            SemanticCheckException.class,
+            () -> weekOfYearQuery("2019-02-29 01:02:03", 0, 0))
     );
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -488,6 +488,47 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(integerValue(220), eval(expression));
   }
 
+  private static Stream<Arguments> getTestDataForDayOfYear() {
+    return Stream.of(
+        Arguments.of(DSL.literal(
+            new ExprDateValue("2020-08-07")),
+            "day_of_year(DATE '2020-08-07')",
+            220),
+        Arguments.of(DSL.literal(
+                new ExprDatetimeValue("2020-08-07 12:23:34")),
+            "day_of_year(DATETIME '2020-08-07 12:23:34')",
+            220),
+        Arguments.of(DSL.literal(
+                new ExprTimestampValue("2020-08-07 12:23:34")),
+            "day_of_year(TIMESTAMP '2020-08-07 12:23:34')",
+            220),
+        Arguments.of(DSL.literal(
+            "2020-08-07"),
+            "day_of_year(\"2020-08-07\")",
+            220),
+        Arguments.of(DSL.literal(
+            "2020-08-07 01:02:03"),
+            "day_of_year(\"2020-08-07 01:02:03\")",
+            220)
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getTestDataForDayOfYear")
+  public void dayOfYearWithUnderscores(
+      LiteralExpression arg,
+      String expectedString,
+      int expectedResult) {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+
+    validateStringFormat(
+        DSL.day_of_year(functionProperties, arg),
+        expectedString,
+        expectedResult
+    );
+  }
+
   @Test
   public void testDayOfYearWithTimeType() {
     lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
@@ -601,7 +642,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         () -> assertThrows(
             SemanticCheckException.class,
             () ->  invalidDayOfYearQuery("2019-13-15")),
-        
+
         //incorrect format for type
         () -> assertThrows(
             SemanticCheckException.class,
@@ -753,6 +794,43 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals(INTEGER, expression.type());
     assertEquals("month(\"2020-08-07 01:02:03\")", expression.toString());
     assertEquals(integerValue(8), eval(expression));
+  }
+
+  private static Stream<Arguments> getTestDataForMonthOfYear() {
+    return Stream.of(
+        Arguments.of(
+            DSL.literal(new ExprDateValue("2020-08-07")),
+            "month_of_year(DATE '2020-08-07')",
+            8),
+        Arguments.of(
+            DSL.literal(new ExprDatetimeValue("2020-08-07 12:23:34")),
+            "month_of_year(DATETIME '2020-08-07 12:23:34')",
+            8),
+        Arguments.of(
+            DSL.literal(new ExprTimestampValue("2020-08-07 12:23:34")),
+            "month_of_year(TIMESTAMP '2020-08-07 12:23:34')",
+            8),
+        Arguments.of(
+            DSL.literal("2020-08-07"),
+            "month_of_year(\"2020-08-07\")",
+            8),
+        Arguments.of(
+            DSL.literal("2020-08-07 01:02:03"),
+            "month_of_year(\"2020-08-07 01:02:03\")",
+            8)
+    );
+  }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getTestDataForMonthOfYear")
+  public void monthOfYear(LiteralExpression arg, String expectedString, int expectedResult) {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+
+    validateStringFormat(
+        DSL.month_of_year(functionProperties, arg),
+        expectedString,
+        expectedResult
+    );
   }
 
   @Test
@@ -1155,6 +1233,12 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
   private static Stream<Arguments> getTestDataForWeekFormats() {
     return Stream.of(
+        Arguments.of(DSL.literal(new ExprDateValue("2019-01-05")),
+            "DATE '2019-01-05'",
+            0),
+        Arguments.of(DSL.literal(new ExprDatetimeValue("2019-01-05 01:02:03")),
+            "DATETIME '2019-01-05 01:02:03'",
+            0),
         Arguments.of(DSL.literal(new ExprTimestampValue("2019-01-05 01:02:03")),
             "TIMESTAMP '2019-01-05 01:02:03'",
             0),
@@ -1169,7 +1253,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     );
   }
 
-  @ParameterizedTest(name = "{1}{2}")
+  @ParameterizedTest(name = "{0}")
   @MethodSource("getTestDataForWeekFormats")
   public void testWeekFormats(
       LiteralExpression arg,

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
@@ -52,6 +52,8 @@ public class FunctionDSLTestBase {
   static final SerializableFunction<ExprValue, ExprValue> oneArg = v -> ANY;
   static final SerializableBiFunction<FunctionProperties, ExprValue, ExprValue>
       oneArgWithProperties = (functionProperties, v) -> ANY;
+  static final SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue>
+      twoArgWithProperties = (functionProperties, v1, v2) -> ANY;
 
   static final SerializableBiFunction<ExprValue, ExprValue, ExprValue>
       twoArgs = (v1, v2) -> ANY;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+
+class FunctionDSLimplWithPropertiesTwoArgTest extends FunctionDSLimplTestBase {
+
+  @Override
+  SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      getImplementationGenerator() {
+    SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue> functionBody
+        = (fp, arg1, arg2) -> ANY;
+    return FunctionDSL.implWithProperties(functionBody, ANY_TYPE, ANY_TYPE, ANY_TYPE);
+  }
+
+  @Override
+  List<Expression> getSampleArguments() {
+    return List.of(DSL.literal(ANY), DSL.literal(ANY));
+  }
+
+  @Override
+  String getExpected_toString() {
+    return "sample(ANY, ANY)";
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+
+import java.util.List;
+
+class FunctionDSLimplWithPropertiesTwoArgsTest extends FunctionDSLimplTestBase {
+
+  @Override
+  SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      getImplementationGenerator() {
+    SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue> functionBody
+        = (fp, arg1, arg2) -> ANY;
+    return FunctionDSL.implWithProperties(functionBody, ANY_TYPE, ANY_TYPE, ANY_TYPE);
+  }
+
+  @Override
+  List<Expression> getSampleArguments() {
+    return List.of(DSL.literal(ANY), DSL.literal(ANY));
+  }
+
+  @Override
+  String getExpected_toString() {
+    return "sample(ANY, ANY)";
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgsTest.java
@@ -6,12 +6,11 @@
 package org.opensearch.sql.expression.function;
 
 
+import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
-
-import java.util.List;
 
 class FunctionDSLimplWithPropertiesTwoArgsTest extends FunctionDSLimplTestBase {
 

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLnullMissingHandlingTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLnullMissingHandlingTest.java
@@ -48,6 +48,41 @@ class FunctionDSLnullMissingHandlingTest extends FunctionDSLTestBase {
   }
 
   @Test
+  void nullMissingHandling_twoArgs_FunctionProperties_nullValue_firstArg() {
+    assertEquals(NULL,
+        nullMissingHandlingWithProperties(twoArgWithProperties)
+            .apply(functionProperties, NULL, ANY));
+  }
+
+  @Test
+  void nullMissingHandling_twoArgs_FunctionProperties_nullValue_secondArg() {
+    assertEquals(NULL,
+        nullMissingHandlingWithProperties(twoArgWithProperties)
+            .apply(functionProperties, ANY, NULL));
+  }
+
+  @Test
+  void nullMissingHandling_twoArgs_FunctionProperties_missingValue_firstArg() {
+    assertEquals(MISSING,
+        nullMissingHandlingWithProperties(twoArgWithProperties)
+            .apply(functionProperties, MISSING, ANY));
+  }
+
+  @Test
+  void nullMissingHandling_twoArgs_FunctionProperties_missingValue_secondArg() {
+    assertEquals(MISSING,
+        nullMissingHandlingWithProperties(twoArgWithProperties)
+            .apply(functionProperties, ANY, MISSING));
+  }
+
+  @Test
+  void nullMissingHandling_twoArgs_FunctionProperties_apply() {
+    assertEquals(ANY,
+        nullMissingHandlingWithProperties(twoArgWithProperties)
+            .apply(functionProperties, ANY, ANY));
+  }
+
+  @Test
   void nullMissingHandling_twoArgs_firstArg_nullValue() {
     assertEquals(NULL, nullMissingHandling(twoArgs).apply(NULL, ANY));
   }

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1457,9 +1457,10 @@ Description
 >>>>>>>>>>>
 
 Usage:  dayofyear(date) returns the day of the year for date, in the range 1 to 366.
+If an argument of type `TIME` is given, the function will use the current date to calculate an output.
 The function `day_of_year`_ is also provided as an alias.
 
-Argument type: STRING/DATE/DATETIME/TIMESTAMP
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
 
 Return type: INTEGER
 
@@ -1496,9 +1497,10 @@ DAY_OF_YEAR
 Description
 >>>>>>>>>>>
 
+If an argument of type `TIME` is given, the function will use the current date to calculate an output.
 This function is an alias to the `dayofyear`_ function
 
-Argument type: STRING/DATE/DATETIME/TIMESTAMP
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
 
 Return type: INTEGER
 
@@ -1770,9 +1772,10 @@ Description
 >>>>>>>>>>>
 
 Usage: month(date) returns the month for date, in the range 1 to 12 for January to December. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
-The function month_of_year is also provided as an alias
+If an argument of type `TIME` is given, the function will use the current date to calculate an output.
+The function month_of_year is also provided as an alias.
 
-Argument type: STRING/DATE/DATETIME/TIMESTAMP
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
 
 Return type: INTEGER
 
@@ -2194,6 +2197,7 @@ Description
 >>>>>>>>>>>
 
 Usage: week(date[, mode]) returns the week number for date. If the mode argument is omitted, the default mode 0 is used.
+If an argument of type `TIME` is given, the function will use the current date to calculate an output.
 The function `week_of_year` is also provided as an alias.
 
 .. list-table:: The following table describes how the mode argument works.
@@ -2237,7 +2241,7 @@ The function `week_of_year` is also provided as an alias.
      - 1-53
      - with a Monday in this year
 
-Argument type: DATE/DATETIME/TIMESTAMP/STRING
+Argument type: DATE/DATETIME/TIME/TIMESTAMP/STRING
 
 Return type: INTEGER
 
@@ -2258,8 +2262,9 @@ Description
 >>>>>>>>>>>
 
 The week_of_year function is a synonym for the `week`_ function.
+If an argument of type `TIME` is given, the function will use the current date to calculate an output.
 
-Argument type: DATE/DATETIME/TIMESTAMP/STRING
+Argument type: DATE/DATETIME/TIME/TIMESTAMP/STRING
 
 Return type: INTEGER
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1457,7 +1457,7 @@ Description
 >>>>>>>>>>>
 
 Usage:  dayofyear(date) returns the day of the year for date, in the range 1 to 366.
-If an argument of type `TIME` is given, the function will use the current date to calculate an output.
+If an argument of type `TIME` is given, the function will use the current date.
 The function `day_of_year`_ is also provided as an alias.
 
 Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
@@ -1497,7 +1497,7 @@ DAY_OF_YEAR
 Description
 >>>>>>>>>>>
 
-If an argument of type `TIME` is given, the function will use the current date to calculate an output.
+If an argument of type `TIME` is given, the function will use the current date.
 This function is an alias to the `dayofyear`_ function
 
 Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
@@ -1772,8 +1772,8 @@ Description
 >>>>>>>>>>>
 
 Usage: month(date) returns the month for date, in the range 1 to 12 for January to December. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
-If an argument of type `TIME` is given, the function will use the current date to calculate an output.
-The function month_of_year is also provided as an alias.
+If an argument of type `TIME` is given, the function will use the current date.
+The function `month_of_year`_ is also provided as an alias.
 
 Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
 
@@ -2197,7 +2197,7 @@ Description
 >>>>>>>>>>>
 
 Usage: week(date[, mode]) returns the week number for date. If the mode argument is omitted, the default mode 0 is used.
-If an argument of type `TIME` is given, the function will use the current date to calculate an output.
+If an argument of type `TIME` is given, the function will use the current date.
 The function `week_of_year` is also provided as an alias.
 
 .. list-table:: The following table describes how the mode argument works.
@@ -2262,7 +2262,7 @@ Description
 >>>>>>>>>>>
 
 The week_of_year function is a synonym for the `week`_ function.
-If an argument of type `TIME` is given, the function will use the current date to calculate an output.
+If an argument of type `TIME` is given, the function will use the current date.
 
 Argument type: DATE/DATETIME/TIME/TIMESTAMP/STRING
 

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -244,14 +244,11 @@ datetimeConstantLiteral
     : CURRENT_DATE
     | CURRENT_TIME
     | CURRENT_TIMESTAMP
-    | DAY_OF_YEAR
     | LOCALTIME
     | LOCALTIMESTAMP
-    | MONTH_OF_YEAR
     | UTC_TIMESTAMP
     | UTC_DATE
     | UTC_TIME
-    | WEEK_OF_YEAR
     ;
 
 intervalLiteral
@@ -428,6 +425,9 @@ dateTimeFunctionName
     | DAYOFMONTH
     | DAYOFWEEK
     | DAYOFYEAR
+    | DAY_OF_MONTH
+    | DAY_OF_WEEK
+    | DAY_OF_YEAR
     | FROM_DAYS
     | FROM_UNIXTIME
     | HOUR

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -425,8 +425,6 @@ dateTimeFunctionName
     | DAYOFMONTH
     | DAYOFWEEK
     | DAYOFYEAR
-    | DAY_OF_MONTH
-    | DAY_OF_WEEK
     | DAY_OF_YEAR
     | FROM_DAYS
     | FROM_UNIXTIME
@@ -437,6 +435,7 @@ dateTimeFunctionName
     | MINUTE
     | MONTH
     | MONTHNAME
+    | MONTH_OF_YEAR
     | NOW
     | PERIOD_ADD
     | PERIOD_DIFF
@@ -450,6 +449,7 @@ dateTimeFunctionName
     | TO_DAYS
     | UNIX_TIMESTAMP
     | WEEK
+    | WEEK_OF_YEAR
     | YEAR
     ;
 


### PR DESCRIPTION
### Description
Adds support for the `TIME` type in the functions `day_of_year`, `week_of_year`, and `month_of_year`. Uses the current local date to calculate the output of the function.

Examples (Assuming the current date is `2022-12-28`): 
```
opensearchsql> SELECT day_of_year(time('12:23:34'));
fetched rows / total rows = 1/1
+---------------------------------+
| day_of_year(time('12:23:34'))   |
|---------------------------------|
| 362                             |
+---------------------------------+

opensearchsql> SELECT week_of_year(time('12:23:34'));
fetched rows / total rows = 1/1
+----------------------------------+
| week_of_year(time('12:23:34'))   |
|----------------------------------|
| 52                               |
+----------------------------------+

opensearchsql> SELECT month_of_year(time('12:23:34'));
fetched rows / total rows = 1/1
+-----------------------------------+
| month_of_year(time('12:23:34'))   |
|-----------------------------------|
| 12                                |
+-----------------------------------+
 
```
### Issues Resolved
`[#722](https://github.com/opensearch-project/sql/issues/722)`

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).