### PR TITLE
`concat()` support multiple string arguments

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -182,6 +182,9 @@ public class BuiltinFunctionRepository {
     if (isCastFunction(functionName) || sourceTypes.equals(targetTypes)) {
       return funcBuilder;
     }
+    if (functionName.equals(BuiltinFunctionName.CONCAT.getName())) {
+      return castArguments(sourceTypes, sourceTypes, funcBuilder);
+    }
     return castArguments(sourceTypes,
         targetTypes, funcBuilder);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -182,6 +182,10 @@ public class BuiltinFunctionRepository {
     if (isCastFunction(functionName) || sourceTypes.equals(targetTypes)) {
       return funcBuilder;
     }
+    // For functions with variable number of args (ex: concat())
+    // targetTypes will always be empty (as the function signature is not fixed),
+    // and failure will occur.
+    // So, in this case sourceTypes are passed instead of targetTypes to address that.
     if (functionResolverMap.get(functionName) instanceof VarargsFunctionResolver) {
       return castArguments(sourceTypes, sourceTypes, funcBuilder);
     }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -182,7 +182,7 @@ public class BuiltinFunctionRepository {
     if (isCastFunction(functionName) || sourceTypes.equals(targetTypes)) {
       return funcBuilder;
     }
-    if (functionName.equals(BuiltinFunctionName.CONCAT.getName())) {
+    if (functionResolverMap.get(functionName) instanceof VarargsFunctionResolver) {
       return castArguments(sourceTypes, sourceTypes, funcBuilder);
     }
     return castArguments(sourceTypes,

--- a/core/src/main/java/org/opensearch/sql/expression/function/DefaultFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/DefaultFunctionResolver.java
@@ -51,7 +51,7 @@ public class DefaultFunctionResolver implements FunctionResolver {
     }
     Map.Entry<Integer, FunctionSignature> bestMatchEntry = functionMatchQueue.peek();
     if (FunctionSignature.NOT_MATCH.equals(bestMatchEntry.getKey())
-    && !unresolvedSignature.getFunctionName().equals(BuiltinFunctionName.CONCAT.getName())) {
+            && !isConcatFunction(unresolvedSignature)) {
       throw new ExpressionEvaluationException(
           String.format("%s function expected %s, but get %s", functionName,
               formatFunctions(functionBundle.keySet()),
@@ -66,5 +66,10 @@ public class DefaultFunctionResolver implements FunctionResolver {
   private String formatFunctions(Set<FunctionSignature> functionSignatures) {
     return functionSignatures.stream().map(FunctionSignature::formatTypes)
         .collect(Collectors.joining(",", "{", "}"));
+  }
+
+  private boolean isConcatFunction(FunctionSignature signature) {
+    return signature.getFunctionName().equals(BuiltinFunctionName.CONCAT.getName())
+            && signature.getParamTypeList().size() > 1;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/DefaultFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/DefaultFunctionResolver.java
@@ -50,7 +50,8 @@ public class DefaultFunctionResolver implements FunctionResolver {
               functionSignature));
     }
     Map.Entry<Integer, FunctionSignature> bestMatchEntry = functionMatchQueue.peek();
-    if (FunctionSignature.NOT_MATCH.equals(bestMatchEntry.getKey())) {
+    if (FunctionSignature.NOT_MATCH.equals(bestMatchEntry.getKey())
+    && !unresolvedSignature.getFunctionName().equals(BuiltinFunctionName.CONCAT.getName())) {
       throw new ExpressionEvaluationException(
           String.format("%s function expected %s, but get %s", functionName,
               formatFunctions(functionBundle.keySet()),

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -379,13 +379,13 @@ public class FunctionDSL {
    */
   public SerializableVarargsFunction<ExprValue, ExprValue> nullMissingHandling(
           SerializableVarargsFunction<ExprValue, ExprValue> function, boolean withVarargs) {
-    return (strings) -> {
-      if (Arrays.stream(strings).anyMatch(ExprValue::isMissing)) {
+    return (args) -> {
+      if (Arrays.stream(args).anyMatch(ExprValue::isMissing)) {
         return ExprValueUtils.missingValue();
-      } else if (Arrays.stream(strings).anyMatch(ExprValue::isNull)) {
+      } else if (Arrays.stream(args).anyMatch(ExprValue::isNull)) {
         return ExprValueUtils.nullValue();
       } else {
-        return function.apply(strings);
+        return function.apply(args);
       }
     };
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -249,6 +249,7 @@ public class FunctionDSL {
 
   /**
    * Varargs Function Implementation.
+   * This implementation considers 1...n args of the same type.
    *
    * @param function   {@link ExprValue} based varargs function.
    * @param returnType return type.

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -42,6 +42,19 @@ public class FunctionDSL {
   }
 
   /**
+   * Define varargs function with implementation.
+   *
+   * @param functionName function name.
+   * @param functions    a list of function implementation.
+   * @return VarargsFunctionResolver.
+   */
+  public static VarargsFunctionResolver defineVarargsFunction(FunctionName functionName,
+               SerializableFunction<FunctionName, Pair<FunctionSignature,
+                FunctionBuilder>>... functions) {
+    return defineVarargsFunction(functionName, List.of(functions));
+  }
+
+  /**
    * Define overloaded function with implementation.
    *
    * @param functionName function name.
@@ -54,6 +67,25 @@ public class FunctionDSL {
     DefaultFunctionResolverBuilder builder = DefaultFunctionResolver.builder();
     builder.functionName(functionName);
     for (Function<FunctionName, Pair<FunctionSignature, FunctionBuilder>> func : functions) {
+      Pair<FunctionSignature, FunctionBuilder> functionBuilder = func.apply(functionName);
+      builder.functionBundle(functionBuilder.getKey(), functionBuilder.getValue());
+    }
+    return builder.build();
+  }
+
+  /**
+   * Define varargs function with implementation.
+   *
+   * @param functionName function name.
+   * @param functions    a list of function implementation.
+   * @return VarargsFunctionResolver.
+   */
+  public static VarargsFunctionResolver defineVarargsFunction(FunctionName functionName, List<
+      SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>> functions) {
+
+    VarargsFunctionResolver.VarargsFunctionResolverBuilder builder = VarargsFunctionResolver.builder();
+    builder.functionName(functionName);
+    for (SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>> func : functions) {
       Pair<FunctionSignature, FunctionBuilder> functionBuilder = func.apply(functionName);
       builder.functionBundle(functionBuilder.getKey(), functionBuilder.getValue());
     }

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -380,7 +380,7 @@ public class FunctionDSL {
   public SerializableVarargsFunction<ExprValue, ExprValue> nullMissingHandling(
           SerializableVarargsFunction<ExprValue, ExprValue> function, boolean withVarargs) {
     return (strings) -> {
-      if (strings.length == 0) {
+      if (Arrays.stream(strings).anyMatch(ExprValue::isMissing)) {
         return ExprValueUtils.missingValue();
       } else if (Arrays.stream(strings).anyMatch(ExprValue::isNull)) {
         return ExprValueUtils.nullValue();

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -42,19 +42,6 @@ public class FunctionDSL {
   }
 
   /**
-   * Define varargs function with implementation.
-   *
-   * @param functionName function name.
-   * @param functions    a list of function implementation.
-   * @return VarargsFunctionResolver.
-   */
-  public static VarargsFunctionResolver defineVarargsFunction(FunctionName functionName,
-               SerializableFunction<FunctionName, Pair<FunctionSignature,
-                FunctionBuilder>>... functions) {
-    return defineVarargsFunction(functionName, List.of(functions));
-  }
-
-  /**
    * Define overloaded function with implementation.
    *
    * @param functionName function name.
@@ -80,18 +67,32 @@ public class FunctionDSL {
    * @param functions    a list of function implementation.
    * @return VarargsFunctionResolver.
    */
-  public static VarargsFunctionResolver defineVarargsFunction(FunctionName functionName, List<
-      SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>> functions) {
+  public static VarargsFunctionResolver defineVarargsFunction(FunctionName functionName,
+          SerializableFunction<FunctionName,
+                  Pair<FunctionSignature, FunctionBuilder>>... functions) {
+    return defineVarargsFunction(functionName, List.of(functions));
+  }
 
-    VarargsFunctionResolver.VarargsFunctionResolverBuilder builder = VarargsFunctionResolver.builder();
+  /**
+   * Define varargs function with implementation.
+   *
+   * @param functionName function name.
+   * @param functions    a list of function implementation.
+   * @return VarargsFunctionResolver.
+   */
+  public static VarargsFunctionResolver defineVarargsFunction(FunctionName functionName, List<
+          SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>> functions) {
+
+    VarargsFunctionResolver.VarargsFunctionResolverBuilder builder =
+            VarargsFunctionResolver.builder();
     builder.functionName(functionName);
-    for (SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>> func : functions) {
+    for (SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>> func
+            : functions) {
       Pair<FunctionSignature, FunctionBuilder> functionBuilder = func.apply(functionName);
       builder.functionBundle(functionBuilder.getKey(), functionBuilder.getValue());
     }
     return builder.build();
   }
-
 
   /**
    * Implementation of no args function that uses FunctionProperties.

--- a/core/src/main/java/org/opensearch/sql/expression/function/SerializableVarargsFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/SerializableVarargsFunction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.function;
+
+import java.io.Serializable;
+
+/**
+ * Serializable Varargs Function.
+ */
+public interface SerializableVarargsFunction<T, R> extends Serializable {
+  /**
+   * Applies this function to the given arguments.
+   *
+   * @param t the function argument
+   * @return the function result
+   */
+  R apply(T... t);
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/VarargsFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/VarargsFunctionResolver.java
@@ -25,7 +25,7 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
  */
 @Builder
 @RequiredArgsConstructor
-public class DefaultFunctionResolver implements FunctionResolver {
+public class VarargsFunctionResolver implements FunctionResolver {
   @Getter
   private final FunctionName functionName;
   @Singular("functionBundle")
@@ -42,20 +42,20 @@ public class DefaultFunctionResolver implements FunctionResolver {
   @Override
   public Pair<FunctionSignature, FunctionBuilder> resolve(FunctionSignature unresolvedSignature) {
     PriorityQueue<Map.Entry<Integer, FunctionSignature>> functionMatchQueue = new PriorityQueue<>(
-        Map.Entry.comparingByKey());
+            Map.Entry.comparingByKey());
 
     for (FunctionSignature functionSignature : functionBundle.keySet()) {
       functionMatchQueue.add(
-          new AbstractMap.SimpleEntry<>(unresolvedSignature.match(functionSignature),
-              functionSignature));
+              new AbstractMap.SimpleEntry<>(unresolvedSignature.match(functionSignature),
+                      functionSignature));
     }
     Map.Entry<Integer, FunctionSignature> bestMatchEntry = functionMatchQueue.peek();
-    if (FunctionSignature.NOT_MATCH.equals(bestMatchEntry.getKey())) {
+    if (unresolvedSignature.getParamTypeList().size() < 2) {
       throw new ExpressionEvaluationException(
-          String.format("%s function expected %s, but get %s", functionName,
-              formatFunctions(functionBundle.keySet()),
-              unresolvedSignature.formatTypes()
-          ));
+              String.format("%s function expected %s, but get %s", functionName,
+                      formatFunctions(functionBundle.keySet()),
+                      unresolvedSignature.formatTypes()
+              ));
     } else {
       FunctionSignature resolvedSignature = bestMatchEntry.getValue();
       return Pair.of(resolvedSignature, functionBundle.get(resolvedSignature));
@@ -64,6 +64,6 @@ public class DefaultFunctionResolver implements FunctionResolver {
 
   private String formatFunctions(Set<FunctionSignature> functionSignatures) {
     return functionSignatures.stream().map(FunctionSignature::formatTypes)
-        .collect(Collectors.joining(",", "{", "}"));
+            .collect(Collectors.joining(",", "{", "}"));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/VarargsFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/VarargsFunctionResolver.java
@@ -50,7 +50,7 @@ public class VarargsFunctionResolver implements FunctionResolver {
                       functionSignature));
     }
     Map.Entry<Integer, FunctionSignature> bestMatchEntry = functionMatchQueue.peek();
-    if (unresolvedSignature.getParamTypeList().size() < 2) {
+    if (unresolvedSignature.getParamTypeList().isEmpty()) {
       throw new ExpressionEvaluationException(
               String.format("%s function expected %s, but get %s", functionName,
                       formatFunctions(functionBundle.keySet()),

--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -13,6 +13,8 @@ import static org.opensearch.sql.expression.function.FunctionDSL.defineVarargsFu
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprStringValue;
@@ -24,10 +26,6 @@ import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.SerializableBiFunction;
 import org.opensearch.sql.expression.function.SerializableTriFunction;
 import org.opensearch.sql.expression.function.VarargsFunctionResolver;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 
 /**
  * The definition of text functions.

--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -9,6 +9,7 @@ package org.opensearch.sql.expression.text;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.expression.function.FunctionDSL.define;
+import static org.opensearch.sql.expression.function.FunctionDSL.defineVarargsFunction;
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
 
@@ -22,6 +23,7 @@ import org.opensearch.sql.expression.function.DefaultFunctionResolver;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.SerializableBiFunction;
 import org.opensearch.sql.expression.function.SerializableTriFunction;
+import org.opensearch.sql.expression.function.VarargsFunctionResolver;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -150,8 +152,8 @@ public class TextFunction {
    * Supports following signatures:
    * (STRING, STRING) -> STRING
    */
-  private DefaultFunctionResolver concat() {
-    return define(BuiltinFunctionName.CONCAT.getName(),
+  private VarargsFunctionResolver concat() {
+    return defineVarargsFunction(BuiltinFunctionName.CONCAT.getName(),
         impl(nullMissingHandling(strings ->
             new ExprStringValue(Arrays.stream(strings)
                     .map(ExprValue::stringValue)

--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -144,11 +144,9 @@ public class TextFunction {
   }
 
   /**
-   * TODO: https://github.com/opendistro-for-elasticsearch/sql/issues/710
-   *  Extend to accept variable argument amounts.
    * Concatenates a list of Strings.
    * Supports following signatures:
-   * (STRING, STRING) -> STRING
+   * (STRING, STRING, ...., STRING) -> STRING
    */
   private VarargsFunctionResolver concat() {
     return defineVarargsFunction(BuiltinFunctionName.CONCAT.getName(),

--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -23,6 +23,9 @@ import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.SerializableBiFunction;
 import org.opensearch.sql.expression.function.SerializableTriFunction;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 
 /**
  * The definition of text functions.
@@ -149,8 +152,10 @@ public class TextFunction {
    */
   private DefaultFunctionResolver concat() {
     return define(BuiltinFunctionName.CONCAT.getName(),
-        impl(nullMissingHandling((str1, str2) ->
-            new ExprStringValue(str1.stringValue() + str2.stringValue())), STRING, STRING, STRING));
+        impl(nullMissingHandling(strings ->
+            new ExprStringValue(Arrays.stream(strings)
+                    .map(ExprValue::stringValue)
+                    .collect(Collectors.joining())), true), STRING, STRING, true));
   }
 
   /**

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
@@ -59,6 +59,8 @@ public class FunctionDSLTestBase {
       twoArgs = (v1, v2) -> ANY;
   static final SerializableTriFunction<ExprValue, ExprValue, ExprValue, ExprValue>
       threeArgs = (v1, v2, v3) -> ANY;
+  static final SerializableVarargsFunction<ExprValue, ExprValue>
+      varrgs = (v1) -> ANY;
   @Mock
   FunctionProperties mockProperties;
 }

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplVarargsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplVarargsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import static org.opensearch.sql.expression.function.FunctionDSL.impl;
+
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+
+class FunctionDSLimplVarargsTest extends FunctionDSLimplTestBase {
+
+  @Override
+  SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      getImplementationGenerator() {
+    return impl(varrgs, ANY_TYPE, ANY_TYPE, true);
+  }
+
+  @Override
+  List<Expression> getSampleArguments() {
+    return List.of(DSL.literal(ANY));
+  }
+
+  @Override
+  String getExpected_toString() {
+    return "sample(ANY)";
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/VarargsFunctionResolverTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/VarargsFunctionResolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.type.WideningTypeRule;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class VarargsFunctionResolverTest {
+  @Mock
+  private FunctionSignature exactlyMatchFS;
+  @Mock
+  private FunctionSignature bestMatchFS;
+  @Mock
+  private FunctionSignature leastMatchFS;
+  @Mock
+  private FunctionSignature notMatchFS;
+  @Mock
+  private FunctionSignature functionSignature;
+  @Mock
+  private FunctionBuilder exactlyMatchBuilder;
+  @Mock
+  private FunctionBuilder bestMatchBuilder;
+  @Mock
+  private FunctionBuilder leastMatchBuilder;
+  @Mock
+  private FunctionBuilder notMatchBuilder;
+
+  private FunctionName functionName = FunctionName.of("test_function");
+
+  @Test
+  void resolve_function_signature_exactly_match() {
+    when(functionSignature.match(exactlyMatchFS)).thenReturn(WideningTypeRule.TYPE_EQUAL);
+    when(functionSignature.getParamTypeList()).thenReturn(ImmutableList.of(STRING, STRING, STRING));
+    VarargsFunctionResolver resolver = new VarargsFunctionResolver(functionName,
+        ImmutableMap.of(exactlyMatchFS, exactlyMatchBuilder));
+
+    assertEquals(exactlyMatchBuilder, resolver.resolve(functionSignature).getValue());
+  }
+
+  @Test
+  void resolve_function_signature_best_match() {
+    when(functionSignature.match(bestMatchFS)).thenReturn(1);
+    when(functionSignature.match(leastMatchFS)).thenReturn(2);
+    when(functionSignature.getParamTypeList()).thenReturn(ImmutableList.of(STRING, STRING, STRING));
+    VarargsFunctionResolver resolver = new VarargsFunctionResolver(functionName,
+        ImmutableMap.of(bestMatchFS, bestMatchBuilder, leastMatchFS, leastMatchBuilder));
+
+    assertEquals(bestMatchBuilder, resolver.resolve(functionSignature).getValue());
+  }
+
+  @Test
+  void resolve_function_not_match() {
+    when(functionSignature.match(notMatchFS)).thenReturn(WideningTypeRule.IMPOSSIBLE_WIDENING);
+    // accepts 2 or more arguments, but passing one
+    when(functionSignature.getParamTypeList()).thenReturn(ImmutableList.of(STRING));
+    VarargsFunctionResolver resolver = new VarargsFunctionResolver(functionName,
+        ImmutableMap.of(notMatchFS, notMatchBuilder));
+
+    assertThrows(ExpressionEvaluationException.class, () -> resolver.resolve(functionSignature));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/VarargsFunctionResolverTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/VarargsFunctionResolverTest.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -70,8 +71,8 @@ class VarargsFunctionResolverTest {
   @Test
   void resolve_function_not_match() {
     when(functionSignature.match(notMatchFS)).thenReturn(WideningTypeRule.IMPOSSIBLE_WIDENING);
-    // accepts 2 or more arguments, but passing one
-    when(functionSignature.getParamTypeList()).thenReturn(ImmutableList.of(STRING));
+    // accepts 1 or more arguments
+    when(functionSignature.getParamTypeList()).thenReturn(Collections.emptyList());
     VarargsFunctionResolver resolver = new VarargsFunctionResolver(functionName,
         ImmutableMap.of(notMatchFS, notMatchBuilder));
 

--- a/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
@@ -72,6 +72,9 @@ public class TextFunctionTest extends ExpressionTestBase {
   private static List<List<String>> CONCAT_STRING_LISTS = ImmutableList.of(
       ImmutableList.of("hello", "world"),
       ImmutableList.of("123", "5325"));
+  private static List<List<String>> CONCAT_STRING_LISTS_WITH_MANY_STRINGS = ImmutableList.of(
+      ImmutableList.of("he", "llo", "wo", "rld", "!"),
+      ImmutableList.of("0", "123", "53", "25", "7"));
 
   interface SubstrSubstring {
     FunctionExpression getFunction(SubstringInfo strInfo);
@@ -228,6 +231,7 @@ public class TextFunctionTest extends ExpressionTestBase {
   @Test
   void concat() {
     CONCAT_STRING_LISTS.forEach(this::testConcatString);
+    CONCAT_STRING_LISTS_WITH_MANY_STRINGS.forEach(this::testConcatMultipleString);
 
     when(nullRef.type()).thenReturn(STRING);
     when(missingRef.type()).thenReturn(STRING);
@@ -442,6 +446,22 @@ public class TextFunctionTest extends ExpressionTestBase {
 
     FunctionExpression expression = DSL.concat_ws(
         DSL.literal(delim), DSL.literal(strings.get(0)), DSL.literal(strings.get(1)));
+    assertEquals(STRING, expression.type());
+    assertEquals(expected, eval(expression).stringValue());
+  }
+
+  void testConcatMultipleString(List<String> strings) {
+    String expected = null;
+    if (strings.stream().noneMatch(Objects::isNull)) {
+      expected = String.join("", strings);
+    }
+
+    FunctionExpression expression = DSL.concat(
+            DSL.literal(strings.get(0)),
+            DSL.literal(strings.get(1)),
+            DSL.literal(strings.get(2)),
+            DSL.literal(strings.get(3)),
+            DSL.literal(strings.get(4)));
     assertEquals(STRING, expression.type());
     assertEquals(expected, eval(expression).stringValue());
   }

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2622,13 +2622,13 @@ Return type: STRING
 
 Example::
 
-    os> SELECT CONCAT('hello', 'world')
+    os> SELECT CONCAT('hello', 'world'), CONCAT('hello ', 'whole ', 'world', '!');
     fetched rows / total rows = 1/1
-    +----------------------------+
-    | CONCAT('hello', 'world')   |
-    |----------------------------|
-    | helloworld                 |
-    +----------------------------+
+    +----------------------------+--------------------------------------------+
+    | CONCAT('hello', 'world')   | CONCAT('hello ', 'whole ', 'world', '!')   |
+    |----------------------------+--------------------------------------------|
+    | helloworld                 | hello whole world!                         |
+    +----------------------------+--------------------------------------------+
 
 
 CONCAT_WS

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2614,9 +2614,9 @@ CONCAT
 Description
 >>>>>>>>>>>
 
-Usage: CONCAT(str1, str2) returns str1 and str strings concatenated together.
+Usage: CONCAT(str1, str2, ...., str_n) adds two or more strings together.
 
-Argument type: STRING, STRING
+Argument type: STRING, STRING, ...., STRING
 
 Return type: STRING
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -22,13 +22,13 @@ Return type: STRING
 
 Example::
 
-    os> source=people | eval `CONCAT('hello', 'world')` = CONCAT('hello', 'world') | fields `CONCAT('hello', 'world')`
+    os> source=people | eval `CONCAT('hello', 'world')` = CONCAT('hello', 'world'), `CONCAT('hello ', 'whole ', 'world', '!')` = CONCAT('hello ', 'whole ', 'world', '!') | fields `CONCAT('hello', 'world')`, `CONCAT('hello ', 'whole ', 'world', '!')`
     fetched rows / total rows = 1/1
-    +----------------------------+
-    | CONCAT('hello', 'world')   |
-    |----------------------------|
-    | helloworld                 |
-    +----------------------------+
+    +----------------------------+--------------------------------------------+
+    | CONCAT('hello', 'world')   | CONCAT('hello ', 'whole ', 'world', '!')   |
+    |----------------------------+--------------------------------------------|
+    | helloworld                 | hello whole world!                         |
+    +----------------------------+--------------------------------------------+
 
 
 CONCAT_WS

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -14,9 +14,9 @@ CONCAT
 Description
 >>>>>>>>>>>
 
-Usage: CONCAT(str1, str2) returns str1 and str strings concatenated together.
+Usage: CONCAT(str1, str2, ...., str_n) adds two or more strings together.
 
-Argument type: STRING, STRING
+Argument type: STRING, STRING, ...., STRING
 
 Return type: STRING
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/TextFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/TextFunctionIT.java
@@ -99,8 +99,8 @@ public class TextFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testConcat() throws IOException {
-    verifyQuery("concat", "", ", 'there'",
-        "hellothere", "worldthere", "helloworldthere");
+    verifyQuery("concat", "", ", 'there', 'all', '!'",
+        "hellothereall!", "worldthereall!", "helloworldthereall!");
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/TextFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/TextFunctionIT.java
@@ -108,6 +108,7 @@ public class TextFunctionIT extends SQLIntegTestCase {
 
   @Test
   public void testConcat() throws IOException {
+    verifyQuery("concat('hello', 'whole', 'world', '!', '!')", "keyword", "hellowholeworld!!");
     verifyQuery("concat('hello', 'world')", "keyword", "helloworld");
     verifyQuery("concat('', 'hello')", "keyword", "hello");
   }

--- a/integ-test/src/test/resources/correctness/expressions/text_functions.txt
+++ b/integ-test/src/test/resources/correctness/expressions/text_functions.txt
@@ -12,3 +12,5 @@ LOCATE('world', 'hello') as column
 LOCATE('world', 'helloworld', 7) as column
 REPLACE('helloworld', 'world', 'opensearch') as column
 REPLACE('hello', 'world', 'opensearch') as column
+CONCAT('hello', 'world') as column
+CONCAT('hello ', 'whole ', 'world', '!') as column


### PR DESCRIPTION
Signed-off-by: Margarit Hakobyan <margarit.hakobyan@improving.com>

### Description
These changes enable `concat()` string function to accept more than two arguments.
Usage: CONCAT(str1, str2, ...., str_n) adds two or more strings together.

Argument type: STRING, STRING, ...., STRING

Return type: STRING

Example::

    os> source=people | eval `CONCAT('hello', 'world')` = CONCAT('hello', 'world'), `CONCAT('hello ', 'whole ', 'world', '!')` = CONCAT('hello ', 'whole ', 'world', '!') | fields `CONCAT('hello', 'world')`, `CONCAT('hello ', 'whole ', 'world', '!')`
    fetched rows / total rows = 1/1
    +----------------------------+--------------------------------------------+
    | CONCAT('hello', 'world')   | CONCAT('hello ', 'whole ', 'world', '!')   |
    |----------------------------+--------------------------------------------|
    | helloworld                 | hello whole world!                         |
    +----------------------------+--------------------------------------------+
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).