### PR TITLE
Fix the alias for the Nested function in SELECT

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/sql/common/utils/StringUtils.java
@@ -108,6 +108,18 @@ public class StringUtils {
     return String.format(Locale.ROOT, format, args);
   }
 
+  public static String getAliasWithNested(String name) {
+    String[] split = name.split("nested\\(");
+    String alias = split[0];
+
+    for (int i = 1; i < split.length ; i ++) {
+      alias = alias.concat(split[i].substring(0, split[i].indexOf(")")).
+          concat(split[i].substring(split[i].indexOf(")") + 1)));
+    }
+
+    return alias;
+  }
+
   private static boolean isQuoted(String text, String mark) {
     return !Strings.isNullOrEmpty(text) && text.startsWith(mark) && text.endsWith(mark);
   }

--- a/common/src/test/java/org/opensearch/sql/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/sql/common/utils/StringUtilsTest.java
@@ -1,0 +1,31 @@
+package org.opensearch.sql.common.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringUtilsTest {
+  @Test
+  public void test_getAliasWithNested() {
+    String name = "nested(field.subfield)";
+    assertEquals("field.subfield", StringUtils.getAliasWithNested(name));
+  }
+
+  @Test
+  public void test_nested_in_function_getAliasWithNested() {
+    String name = "sum(nested(field.subfield))";
+    assertEquals("sum(field.subfield)", StringUtils.getAliasWithNested(name));
+  }
+
+  @Test
+  public void test_multiple_nested_in_function_getAliasWithNested() {
+    String name = "concat(nested(field.subfield), nested(field.subfield))";
+    assertEquals("concat(field.subfield, field.subfield)", StringUtils.getAliasWithNested(name));
+  }
+
+  @Test
+  public void test_nested_in_function_with_arguments_getAliasWithNested() {
+    String name = "concat(nested(field.subfield), \"Add String\")";
+    assertEquals("concat(field.subfield, \"Add String\")", StringUtils.getAliasWithNested(name));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -31,7 +31,6 @@ public class NestedIT extends SQLIntegTestCase {
   @Test
   public void nested_column_name_test() {
     String fieldArg = "message.info";
-
     String query = "SELECT nested(" + fieldArg + ") FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
     verifyColumn(result, schema(fieldArg, "keyword"));
@@ -41,7 +40,6 @@ public class NestedIT extends SQLIntegTestCase {
   public void nested_alias_test() {
     String fieldArg = "message.info";
     String alias = "INFO";
-
     String query = "SELECT nested(" + fieldArg + ") AS " + alias + " FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
     verifyColumn(result, schema(fieldArg, alias, "keyword"));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 
 public class NestedIT extends SQLIntegTestCase {
   @Override
@@ -33,7 +34,7 @@ public class NestedIT extends SQLIntegTestCase {
 
     String query = "SELECT nested(" + fieldArg + ") FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
-    assertEquals(query, schema("nested(" + fieldArg + ")", fieldArg, "keyword"));
+    verifyColumn(result, schema(fieldArg, "keyword"));
   }
 
   @Test
@@ -43,6 +44,6 @@ public class NestedIT extends SQLIntegTestCase {
 
     String query = "SELECT nested(" + fieldArg + ") AS " + alias + " FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
-    assertEquals(query, schema("nested(" + fieldArg + ")", alias, "keyword"));
+    verifyColumn(result, schema(fieldArg, alias, "keyword"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -12,6 +12,7 @@ import org.opensearch.sql.legacy.SQLIntegTestCase;
 import java.io.IOException;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE;
+import static org.opensearch.sql.util.MatcherUtils.schema;
 
 public class NestedIT extends SQLIntegTestCase {
   @Override
@@ -24,5 +25,24 @@ public class NestedIT extends SQLIntegTestCase {
     String query = "SELECT nested(message.dayOfWeek) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
     assertEquals(5, result.getInt("total"));
+  }
+
+  @Test
+  public void nested_column_name_test() {
+    String fieldArg = "message.info";
+
+    String query = "SELECT nested(" + fieldArg + ") FROM " + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(query, schema("nested(" + fieldArg + ")", fieldArg, "keyword"));
+  }
+
+  @Test
+  public void nested_alias_test() {
+    String fieldArg = "message.info";
+    String alias = "INFO";
+
+    String query = "SELECT nested(" + fieldArg + ") AS " + alias + " FROM " + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(query, schema("nested(" + fieldArg + ")", alias, "keyword"));
   }
 }

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -197,6 +197,11 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
     String name = StringUtils.unquoteIdentifier(getTextInQuery(ctx.expression(), query));
     UnresolvedExpression expr = visitAstExpression(ctx.expression());
 
+    // Nested function call in SELECT should have the argument as the alias as per legacy behaviour
+    if (name.toLowerCase().contains("nested(") && !name.toLowerCase().contains("\"nested(")) {
+      name = StringUtils.getAliasWithNested(name);
+    }
+
     if (ctx.alias() == null) {
       return new Alias(name, expr);
     } else {

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -776,7 +776,7 @@ class AstBuilderTest {
         project(relation("test"),
             alias("field.subfield",
                 nested(AstDSL.qualifiedName("field", "subfield")))),
-        buildAST("SELECT concat(nested(field.subfield), nested(field.subfield)) FROM test")
+        buildAST("SELECT nested(field.subfield) FROM test")
     );
   }
 

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -29,6 +29,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.relationSubquery;
 import static org.opensearch.sql.ast.dsl.AstDSL.sort;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.values;
+import static org.opensearch.sql.ast.dsl.AstDSL.nested;
 import static org.opensearch.sql.utils.SystemIndexUtils.TABLE_INFO;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
@@ -774,8 +775,8 @@ class AstBuilderTest {
     assertEquals(
         project(relation("test"),
             alias("field.subfield",
-                qualifiedName("field.subfield"))),
-        buildAST("SELECT nested(\"field.subfield\") FROM test")
+                nested(AstDSL.qualifiedName("field", "subfield")))),
+        buildAST("SELECT concat(nested(field.subfield), nested(field.subfield)) FROM test")
     );
   }
 


### PR DESCRIPTION
### Description
To match the behaviour of legacy, the nested function should have the argument as the alias. This solution will also support matching the alias for when PartiQL syntax that will be supported in the future.

For example:
`SELECT nested(field.subfield)` will have an alias of `field.subfield`

For future PartiQL implementation:
`SELECT concat(nested(field.subfield), nested(field.subfield))` will have an alias of `concat(field.subfield, field.subfield)`
`SELECT concat(field.subfield, field.subfield)` will have an alias of `concat(field.subfield, field.subfield)`


 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).