### PR TITLE
[WIP] Added new exception for nested fields to force it to fallback to legacy

### DIFF
--- a/core/src/main/java/org/opensearch/sql/exception/UnsupportedV2NestedException.java
+++ b/core/src/main/java/org/opensearch/sql/exception/UnsupportedV2NestedException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.exception;
+
+/**
+ * Exception thrown to fall back to legacy when nested fields are queried.
+ */
+public class UnsupportedV2NestedException extends QueryEngineException {
+  public UnsupportedV2NestedException(String message) {
+    super(message);
+  }
+}
+
+
+

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedFallbackIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedFallbackIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.sql;
+import org.json.JSONObject;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+import java.io.IOException;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+
+public class NestedFallbackIT extends SQLIntegTestCase{
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.NESTED);
+  }
+
+  @Test
+  public void nested_function_and_without_nested_function_test() {
+    String query = "SELECT nested(message.info), message.info FROM " + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    verifyColumn(result, schema("message.info", "keyword"),
+        schema("message.info", "keyword"));
+    verifyDataRows(result, rows("a", "a"),
+        rows("b", "b"),
+        rows("c", "c"),
+        rows("c", "c"),
+        rows("a", "a"),
+        rows("zz", "zz"));
+  }
+
+  @Ignore("Legacy has a bug that returns nulls for array values. " +
+      "This will be fixed in the new engine. https://github.com/opensearch-project/sql/issues/1218")
+  @Test
+  public void without_nested_function_test() {
+    String query = "SELECT message.info FROM " + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    verifyColumn(result, schema("message.info", "keyword"));
+    verifyDataRows(result, rows("a"),
+        rows("b"),
+        rows("c"),
+        rows("c"),
+        rows("a"),
+        rows("zz"));
+  }
+}

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -24,6 +24,7 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.common.utils.QueryContext;
+import org.opensearch.sql.exception.UnsupportedV2NestedException;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.legacy.metrics.MetricName;
 import org.opensearch.sql.legacy.metrics.Metrics;
@@ -126,7 +127,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
 
       @Override
       public void onFailure(Exception e) {
-        if (e instanceof SyntaxCheckException) {
+        if (e instanceof SyntaxCheckException || e instanceof UnsupportedV2NestedException) {
           fallBackHandler.accept(channel, e);
         } else {
           next.onFailure(e);


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guian.gumpac@improving.com>

### Description
A new exception was made for nested fields that is thrown when the field is of type `(ExprCoreTye)ARRAY`. There is one old unit test and one old integration tests that are failing and to be investigated.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1277
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).