### PR TITLE
Modify workflow to show deprecation progress against integration tests

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -36,13 +36,16 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.entry.java }}
 
+      - name: Install xmlstarlet
+        run: |
+          sudo apt-get update
+          sudo apt-get install xmlstarlet
+
       - name: Build with Gradle
         run: ./gradlew --continue integ-test:integTest
 
       - name: Delete failure text in XML files
-        uses: Mudlet/xmlstarlet-action@master
-        with:
-          args: ed --inplace -d '//text()' integ-test/build/test-results/integTest/*.xml
+        run: xmlstarlet ed --inplace -d '//text()' integ-test/build/test-results/integTest/*.xml
         if: always()
 
       - name: Test Summary

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -24,68 +24,111 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { os: ubuntu-latest, java: 11 }
-          - { os: windows-latest, java: 11, os_build_args: -x doctest -x integTest -x jacocoTestReport -PbuildPlatform=windows }
-          - { os: macos-latest, java: 11, os_build_args: -x doctest -x integTest -x jacocoTestReport  }
-          - { os: ubuntu-latest, java: 17 }
-          - { os: windows-latest, java: 17, os_build_args: -x doctest -x integTest -x jacocoTestReport  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 17, os_build_args: -x doctest -x integTest -x jacocoTestReport  }
+          - { os: ubuntu-latest, java: 11, os_build_args: -x doctest -x jacocoTestReport  }
     runs-on: ${{ matrix.entry.os }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.entry.java }}
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.entry.java }}
 
-    - name: Build with Gradle
-      run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
+      - name: Build with Gradle
+        run: ./gradlew --continue integ-test:integTest
 
-    - name: PiTest with Gradle
-      run: |
-        ./gradlew :core:pitest
-        ./gradlew :opensearch:pitest
-     
+      - name: Copy test result file
+        run: |
+          mkdir test-folder
+          mkdir test-folder/legacy
+          mkdir test-folder/sql1
+          mkdir test-folder/sql2
+          mkdir test-folder/ppl
+          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.legacy.*.xml test-folder/legacy
+          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.sql.[A-M]*.xml test-folder/sql1
+          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.sql.[N-Z]*.xml test-folder/sql2
+          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.ppl.*.xml test-folder/ppl
+        if: always()
 
-    - name: Run backward compatibility tests
-      if: ${{ matrix.entry.os == 'ubuntu-latest' }}
-      run: ./scripts/bwctest.sh
+      - name: Legacy Test Summary
+        uses: test-summary/action@v2
+        with:
+          output: legacy-test-summary.md
+          paths: test-folder/legacy/*.xml
+        if: always()
 
-    - name: Create Artifact Path
-      run: |
-        mkdir -p opensearch-sql-builds
-        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
+      - name: Upload legacy test summary
+        uses: actions/upload-artifact@v3
+        with:
+          name: legacy-test-summary
+          path: legacy-test-summary.md
+        if: always()
 
-    # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
-    - name: Upload SQL Coverage Report
-      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
-      uses: codecov/codecov-action@v3
-      with:
-        flags: sql-engine
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: SQL Test Summary 1
+        uses: test-summary/action@v2
+        with:
+          output: sql-test-summary1.md
+          paths: test-folder/sql1/*.xml
+        if: always()
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: opensearch-sql-${{ matrix.entry.os }}
-        path: opensearch-sql-builds
+      - name: Upload SQL test summary 1
+        uses: actions/upload-artifact@v3
+        with:
+          name: sql-test-summary1
+          path: sql-test-summary1.md
+        if: always()
 
-    - name: Upload test reports
-      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
-      uses: actions/upload-artifact@v2
-      continue-on-error: true
-      with:
-        name: test-reports
-        path: |
-          sql/build/reports/**
-          ppl/build/reports/**
-          core/build/reports/**
-          common/build/reports/**
-          opensearch/build/reports/**
-          integ-test/build/reports/**
-          protocol/build/reports/**
-          legacy/build/reports/**
-          plugin/build/reports/**
+      - name: SQL Test Summary 2
+        uses: test-summary/action@v2
+        with:
+          output: sql-test-summary2.md
+          paths: test-folder/sql2/*.xml
+        if: always()
+
+      - name: Upload SQL test summary 2
+        uses: actions/upload-artifact@v3
+        with:
+          name: sql-test-summary2
+          path: sql-test-summary2.md
+        if: always()
+
+      - name: PPL Test Summary
+        uses: test-summary/action@v2
+        with:
+          output: ppl-test-summary.md
+          paths: test-folder/ppl/*.xml
+        if: always()
+
+      - name: Upload PPL test summary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ppl-test-summary
+          path: ppl-test-summary.md
+        if: always()
+
+      - name: Compile Results
+        run: |
+          touch test-summary.md
+          echo -e "### Legacy Test Results\n" > test-summary.md
+          head -c 150 legacy-test-summary.md | sed 's/>.*//' >> test-summary.md
+          echo -e "> \n\n### SQL.[A-M] Test Results\n" >> test-summary.md
+          head -c 150 sql-test-summary1.md | sed 's/>.*//' >> test-summary.md
+          echo -e "> \n\n### SQL.[N-Z] Test Results\n" >> test-summary.md
+          head -c 150 sql-test-summary2.md | sed 's/>.*//' >> test-summary.md
+          echo -e "> \n\n### PPL Test Results\n" >> test-summary.md
+          head -c 150 ppl-test-summary.md | sed 's/>.*//' >> test-summary.md
+          echo -e ">" >> test-summary.md
+        if: always()
+
+      - name: Upload Compiled Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-summary
+          path: test-summary.md
+        if: always()
+
+      - name: Show Compiled Results
+        run: cat test-summary.md >> $GITHUB_STEP_SUMMARY
+        if: always()

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -113,13 +113,21 @@ jobs:
           touch test-summary.md
           echo -e "### Legacy Test Results\n" > test-summary.md
           head -c 150 legacy-test-summary.md | sed 's/>.*//' >> test-summary.md
-          echo -e "> \n\n### SQL.[A-M] Test Results\n" >> test-summary.md
+          echo -e "><details>" >> test-summary.md
+          sed '1,2d' legacy-test-summary.md >> test-summary.md
+          echo -e "</details> \n\n### SQL.[A-M] Test Results\n" >> test-summary.md
           head -c 150 sql-test-summary1.md | sed 's/>.*//' >> test-summary.md
-          echo -e "> \n\n### SQL.[N-Z] Test Results\n" >> test-summary.md
+          echo -e "><details>" >> test-summary.md
+          sed '1,2d' sql-test-summary1.md >> test-summary.md
+          echo -e "</details> \n\n### SQL.[N-Z] Test Results\n" >> test-summary.md
           head -c 150 sql-test-summary2.md | sed 's/>.*//' >> test-summary.md
-          echo -e "> \n\n### PPL Test Results\n" >> test-summary.md
+          echo -e "><details>" >> test-summary.md
+          sed '1,2d' sql-test-summary2.md >> test-summary.md
+          echo -e "</details> \n\n### PPL Test Results\n" >> test-summary.md
           head -c 150 ppl-test-summary.md | sed 's/>.*//' >> test-summary.md
-          echo -e ">" >> test-summary.md
+          echo -e "><details>" >> test-summary.md
+          sed '1,2d' ppl-test-summary.md >> test-summary.md
+          echo -e "</details>" >> test-summary.md
         if: always()
 
       - name: Upload Compiled Results

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -28,40 +28,40 @@ jobs:
     runs-on: ${{ matrix.entry.os }}
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.entry.java }}
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.entry.java }}
 
-      - name: Install xmlstarlet
-        run: |
-          sudo apt-get update
-          sudo apt-get install xmlstarlet
+    - name: Install xmlstarlet
+      run: |
+        sudo apt-get update
+        sudo apt-get install xmlstarlet
 
-      - name: Build with Gradle
-        run: ./gradlew --continue integ-test:integTest
+    - name: Build with Gradle
+      run: ./gradlew --continue integ-test:integTest
 
-      - name: Delete failure text in XML files
-        run: xmlstarlet ed --inplace -d '//text()' integ-test/build/test-results/integTest/*.xml
-        if: always()
+    - name: Delete failure text in XML files
+      run: xmlstarlet ed --inplace -d '//text()' integ-test/build/test-results/integTest/*.xml
+      if: always()
 
-      - name: Test Summary
-        uses: test-summary/action@v2
-        with:
-          output: test-summary.md
-          paths: integ-test/build/test-results/integTest/*.xml
-        if: always()
+    - name: Test Summary
+      uses: test-summary/action@v2
+      with:
+        output: test-summary.md
+        paths: integ-test/build/test-results/integTest/*.xml
+      if: always()
 
-      - name: Upload Compiled Results
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-summary
-          path: test-summary.md
-        if: always()
+    - name: Upload Compiled Results
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-summary
+        path: test-summary.md
+      if: always()
 
-      - name: Show Compiled Results
-        run: cat test-summary.md >> $GITHUB_STEP_SUMMARY
-        if: always()
+    - name: Show Compiled Results
+      run: cat test-summary.md >> $GITHUB_STEP_SUMMARY
+      if: always()

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -59,6 +59,13 @@ jobs:
           path: test-summary.md
         if: always()
 
+      - name: Upload xml file
+        uses: actions/upload-artifact@v3
+        with:
+          name: xmlfile
+          path: integ-test/build/test-results/integTest/TEST-org.opensearch.sql.legacy.DateFormatIT.xml
+        if: always()
+
       - name: Show Compiled Results
         run: cat test-summary.md >> $GITHUB_STEP_SUMMARY
         if: always()

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -39,95 +39,17 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew --continue integ-test:integTest
 
-      - name: Copy test result file
-        run: |
-          mkdir test-folder
-          mkdir test-folder/legacy
-          mkdir test-folder/sql1
-          mkdir test-folder/sql2
-          mkdir test-folder/ppl
-          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.legacy.*.xml test-folder/legacy
-          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.sql.[A-M]*.xml test-folder/sql1
-          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.sql.[N-Z]*.xml test-folder/sql2
-          cp integ-test/build/test-results/integTest/TEST-org.opensearch.sql.ppl.*.xml test-folder/ppl
+      - name: Delete failure text in XML files
+        uses: Mudlet/xmlstarlet-action@master
+        with:
+          args: ed --inplace -d '//text()' integ-test/build/test-results/integTest/*.xml
         if: always()
 
-      - name: Legacy Test Summary
+      - name: Test Summary
         uses: test-summary/action@v2
         with:
-          output: legacy-test-summary.md
-          paths: test-folder/legacy/*.xml
-        if: always()
-
-      - name: Upload legacy test summary
-        uses: actions/upload-artifact@v3
-        with:
-          name: legacy-test-summary
-          path: legacy-test-summary.md
-        if: always()
-
-      - name: SQL Test Summary 1
-        uses: test-summary/action@v2
-        with:
-          output: sql-test-summary1.md
-          paths: test-folder/sql1/*.xml
-        if: always()
-
-      - name: Upload SQL test summary 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: sql-test-summary1
-          path: sql-test-summary1.md
-        if: always()
-
-      - name: SQL Test Summary 2
-        uses: test-summary/action@v2
-        with:
-          output: sql-test-summary2.md
-          paths: test-folder/sql2/*.xml
-        if: always()
-
-      - name: Upload SQL test summary 2
-        uses: actions/upload-artifact@v3
-        with:
-          name: sql-test-summary2
-          path: sql-test-summary2.md
-        if: always()
-
-      - name: PPL Test Summary
-        uses: test-summary/action@v2
-        with:
-          output: ppl-test-summary.md
-          paths: test-folder/ppl/*.xml
-        if: always()
-
-      - name: Upload PPL test summary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ppl-test-summary
-          path: ppl-test-summary.md
-        if: always()
-
-      - name: Compile Results
-        run: |
-          touch test-summary.md
-          echo -e "### Legacy Test Results\n" > test-summary.md
-          head -c 150 legacy-test-summary.md | sed 's/>.*//' >> test-summary.md
-          echo -e "><details>" >> test-summary.md
-          sed '1,2d' legacy-test-summary.md >> test-summary.md
-          echo -e "</details> \n\n### SQL.[A-M] Test Results\n" >> test-summary.md
-          head -c 150 sql-test-summary1.md | sed 's/>.*//' >> test-summary.md
-          echo -e "><details>" >> test-summary.md
-          sed '1,2d' sql-test-summary1.md >> test-summary.md
-          echo -e "</details> \n\n### SQL.[N-Z] Test Results\n" >> test-summary.md
-          head -c 150 sql-test-summary2.md | sed 's/>.*//' >> test-summary.md
-          echo -e "><details>" >> test-summary.md
-          sed '1,2d' sql-test-summary2.md >> test-summary.md
-          echo -e "</details> \n\n### PPL Test Results\n" >> test-summary.md
-          head -c 150 ppl-test-summary.md | sed 's/>.*//' >> test-summary.md
-          echo -e "><details>" >> test-summary.md
-          sed '1,2d' ppl-test-summary.md >> test-summary.md
-          echo -e "</details>" >> test-summary.md
+          output: test-summary.md
+          paths: integ-test/build/test-results/integTest/*.xml
         if: always()
 
       - name: Upload Compiled Results

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -62,13 +62,6 @@ jobs:
           path: test-summary.md
         if: always()
 
-      - name: Upload xml file
-        uses: actions/upload-artifact@v3
-        with:
-          name: xmlfile
-          path: integ-test/build/test-results/integTest/TEST-org.opensearch.sql.legacy.DateFormatIT.xml
-        if: always()
-
       - name: Show Compiled Results
         run: cat test-summary.md >> $GITHUB_STEP_SUMMARY
         if: always()

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -155,10 +155,9 @@ public class RestSqlAction extends BaseRestHandler {
                             if (newSqlRequest.isExplainRequest()) {
                                 LOG.info("Request is falling back to old SQL engine due to: " + exception.getMessage());
                             }
-                            LOG.debug("[{}] Request {} is not supported and falling back to old SQL engine",
+                            LOG.info("[{}] Request {} is not supported in the new engine",
                                 QueryContext.getRequestId(), newSqlRequest);
-                            QueryAction queryAction = explainRequest(client, sqlRequest, format);
-                            executeSqlRequest(request, queryAction, client, restChannel);
+                            throw new SQLFeatureDisabledException("Query is unsupported in the new engine");
                         } catch (Exception e) {
                             logAndPublishMetrics(e);
                             reportError(restChannel, e, isClientError(e) ? BAD_REQUEST : SERVICE_UNAVAILABLE);


### PR DESCRIPTION
### Description
Legacy is disabled to force all integration tests to be run on the new engine. The test summary will be shown in GitHub Actions and can also be downloaded from the artifacts.
<img width="551" alt="Screenshot 2023-01-17 at 3 25 37 PM" src="https://user-images.githubusercontent.com/29149268/213034351-1e0d274b-aff7-415d-a419-6db7113e4292.png">


 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1144
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).