### PR TITLE
Add integration JDBC tests for cursor/fetch_size feature.

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -148,24 +148,35 @@ task stopPrometheus(type: KillProcessTask) {
 
 stopPrometheus.mustRunAfter startPrometheus
 
-task deleteJdbcDriverRepo {
-    // Delete local clone of the sql-jdbc repo
-    file("sql-jdbc").deleteDir()
-}
-
 task cloneJdbcDriverRepo {
-    doFirst {
-        file("sql-jdbc").deleteDir()
-
+    if (file("${buildDir}/sql-jdbc").exists()) {
         exec {
+            workingDir "${buildDir}/sql-jdbc"
+            commandLine 'git', 'remote', 'remove', 'origin'
+        }
+        exec {
+            workingDir "${buildDir}/sql-jdbc"
+            commandLine 'git', 'remote', 'add', 'origin', System.getProperty('jdbcRepo', 'https://github.com/opensearch-project/sql-jdbc.git')
+        }
+        exec {
+            workingDir "${buildDir}/sql-jdbc"
+            commandLine 'git', 'fetch', 'origin'
+        }
+        exec {
+            workingDir "${buildDir}/sql-jdbc"
+            commandLine 'git', 'reset', '--hard', 'origin/' + System.getProperty("jdbcBranch", 'main')
+        }
+    } else {
+        exec {
+            workingDir buildDir
             // clone the sql-jdbc repo locally
             commandLine 'git', 'clone', '--branch', System.getProperty("jdbcBranch", 'main'), System.getProperty('jdbcRepo', 'https://github.com/opensearch-project/sql-jdbc.git')
         }
-        // TODO would fail on windows
-        exec {
-            workingDir 'sql-jdbc'
-            commandLine 'sh', 'gradlew', 'shadowJar'
-        }
+    }
+    // TODO would fail on windows
+    exec {
+        workingDir "${buildDir}/sql-jdbc"
+        commandLine 'sh', 'gradlew', 'shadowJar'
     }
 }
 
@@ -213,15 +224,14 @@ task integDevJdbcTest(type: RestIntegTestTask) {
     }
 
     if (System.getProperty("jdbcFile") != null) {
-        file("sql-jdbc/build/libs").mkdirs()
+        file("${buildDir}/sql-jdbc/build/libs").mkdirs()
         copy {
             from System.getProperty("jdbcFile")
-            into "sql-jdbc/build/libs"
+            into "${buildDir}/sql-jdbc/build/libs"
         }
     } else {
         dependsOn cloneJdbcDriverRepo
     }
-    finalizedBy deleteJdbcDriverRepo
 
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -109,10 +109,10 @@ compileTestJava {
 
 testClusters.all {
     testDistribution = 'archive'
+    plugin ":opensearch-sql-plugin"
 }
 
 testClusters.integTest {
-    plugin ":opensearch-sql-plugin"
     keystore 'plugins.query.federation.datasources.config', new File("$projectDir/src/test/resources/datasource/", 'datasources.json')
 }
 
@@ -148,8 +148,113 @@ task stopPrometheus(type: KillProcessTask) {
 
 stopPrometheus.mustRunAfter startPrometheus
 
+task deleteJdbcDriverRepo {
+    // Delete local clone of the sql-jdbc repo
+    file("sql-jdbc").deleteDir()
+}
+
+task cloneJdbcDriverRepo {
+    doFirst {
+        file("sql-jdbc").deleteDir()
+
+        exec {
+            // clone the sql-jdbc repo locally
+            commandLine 'git', 'clone', System.getProperty('jdbcRepo', 'https://github.com/opensearch-project/sql-jdbc.git')
+        }
+        exec {
+            workingDir 'sql-jdbc'
+            commandLine 'git', 'switch', System.getProperty("jdbcBranch", 'main')
+        }
+        // TODO would fail on windows
+        exec {
+            workingDir 'sql-jdbc'
+            commandLine 'sh', 'gradlew', 'shadowJar'
+        }
+    }
+}
+
+task integJdbcTest(type: RestIntegTestTask) {
+    useJUnitPlatform()
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+    afterTest { desc, result ->
+        logger.quiet "${desc.className}.${desc.name}: ${result.resultType} ${(result.getEndTime() - result.getStartTime())/1000}s"
+    }
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Set default query size limit
+    systemProperty 'defaultQuerySizeLimit', '10000'
+
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst { systemProperty 'cluster.debug', getDebug() }
+
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+    }
+
+    filter {
+        includeTestsMatching '*.jdbc.*'
+    }
+}
+
+task integDevJdbcTest(type: RestIntegTestTask) {
+    useJUnitPlatform()
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+    afterTest { desc, result ->
+        logger.quiet "${desc.className}.${desc.name}: ${result.resultType} ${(result.getEndTime() - result.getStartTime())/1000}s"
+    }
+
+    if (System.getProperty("jdbcFile") != null) {
+        file("sql-jdbc/build/libs").mkdirs()
+        copy {
+            from System.getProperty("jdbcFile")
+            into "sql-jdbc/build/libs"
+        }
+    } else {
+        dependsOn cloneJdbcDriverRepo
+    }
+    finalizedBy deleteJdbcDriverRepo
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Set default query size limit
+    systemProperty 'defaultQuerySizeLimit', '10000'
+
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst { systemProperty 'cluster.debug', getDebug() }
+
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+    }
+
+    filter {
+        includeTestsMatching '*.devJdbc.*'
+    }
+}
+
 // Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
 integTest {
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
     dependsOn startPrometheus
     finalizedBy stopPrometheus
@@ -192,10 +297,17 @@ integTest {
 
     // Skip this IT because all assertions are against explain output
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
+
+    // Exclude JDBC related tests
+    exclude '**/jdbc/**'
+    exclude '**/devJdbc/**'
 }
 
 
 task comparisonTest(type: RestIntegTestTask) {
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
 
     systemProperty 'tests.security.manager', 'false'
@@ -213,6 +325,10 @@ task comparisonTest(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/doctest/**/*IT.class'
     exclude 'org/opensearch/sql/ppl/**/*IT.class'
     exclude 'org/opensearch/sql/legacy/**/*IT.class'
+
+    // Exclude JDBC related tests
+    exclude '**/jdbc/**'
+    exclude '**/devJdbc/**'
 
     // Enable logging output to console
     testLogging.showStandardStreams true
@@ -368,6 +484,9 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
 
 // A bwc test suite which runs all the bwc tasks combined
 task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
     exclude '**/*Test*'
     exclude '**/*IT*'
     dependsOn tasks.named("${baseName}#mixedClusterTask")
@@ -379,6 +498,9 @@ def opensearch_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()
 
 task integTestRemote(type: RestIntegTestTask) {
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
     systemProperty 'tests.security.manager', 'false'
@@ -406,4 +528,6 @@ task integTestRemote(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/legacy/TermQueryExplainIT.class'
     exclude 'org/opensearch/sql/legacy/QueryAnalysisIT.class'
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
+    exclude '**/jdbc/**'
+    exclude '**/devJdbc/**'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -198,7 +198,7 @@ task integJdbcTest(type: RestIntegTestTask) {
     }
 
     filter {
-        includeTestsMatching '*.jdbc.*'
+        includeTestsMatching 'org.opensearch.sql.jdbc.*'
     }
 }
 
@@ -242,7 +242,7 @@ task integDevJdbcTest(type: RestIntegTestTask) {
     }
 
     filter {
-        includeTestsMatching '*.devJdbc.*'
+        includeTestsMatching 'org.opensearch.sql.devJdbc.*'
     }
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -159,11 +159,7 @@ task cloneJdbcDriverRepo {
 
         exec {
             // clone the sql-jdbc repo locally
-            commandLine 'git', 'clone', System.getProperty('jdbcRepo', 'https://github.com/opensearch-project/sql-jdbc.git')
-        }
-        exec {
-            workingDir 'sql-jdbc'
-            commandLine 'git', 'switch', System.getProperty("jdbcBranch", 'main')
+            commandLine 'git', 'clone', '--branch', System.getProperty("jdbcBranch", 'main'), System.getProperty('jdbcRepo', 'https://github.com/opensearch-project/sql-jdbc.git')
         }
         // TODO would fail on windows
         exec {
@@ -299,8 +295,8 @@ integTest {
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
 
     // Exclude JDBC related tests
-    exclude '**/jdbc/**'
-    exclude '**/devJdbc/**'
+    exclude 'org/opensearch/sql/jdbc/**'
+    exclude 'org/opensearch/sql/devJdbc/**'
 }
 
 
@@ -327,8 +323,8 @@ task comparisonTest(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/legacy/**/*IT.class'
 
     // Exclude JDBC related tests
-    exclude '**/jdbc/**'
-    exclude '**/devJdbc/**'
+    exclude 'org/opensearch/sql/jdbc/**'
+    exclude 'org/opensearch/sql/devJdbc/**'
 
     // Enable logging output to console
     testLogging.showStandardStreams true
@@ -528,6 +524,6 @@ task integTestRemote(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/legacy/TermQueryExplainIT.class'
     exclude 'org/opensearch/sql/legacy/QueryAnalysisIT.class'
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
-    exclude '**/jdbc/**'
-    exclude '**/devJdbc/**'
+    exclude 'org/opensearch/sql/jdbc/**'
+    exclude 'org/opensearch/sql/devJdbc/**'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     testImplementation group: 'org.opensearch.test', name: 'framework', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
-    testImplementation group: 'org.opensearch.driver', name: 'opensearch-sql-jdbc', version: '1.2.0.0'
+    testImplementation group: 'org.opensearch.driver', name: 'opensearch-sql-jdbc', version: System.getProperty("jdbcDriverVersion", '1.2.0.0')
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     testImplementation project(':opensearch-sql-plugin')

--- a/integ-test/src/test/java/org/opensearch/sql/devJdbc/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/devJdbc/CursorIT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.devJdbc;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
+import static org.opensearch.sql.util.TestUtils.getResponseBody;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+import javax.annotation.Nullable;
+import lombok.SneakyThrows;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+public class CursorIT extends SQLIntegTestCase {
+
+  private static Connection connection;
+  private static Driver driver;
+  private boolean initialized = false;
+
+  @BeforeEach
+  @SneakyThrows
+  public void init() {
+    if (!initialized) {
+      initClient();
+      resetQuerySizeLimit();
+      loadIndex(Index.BANK);
+      loadIndex(Index.CALCS);
+      loadIndex(Index.ONLINE);
+      loadIndex(Index.ACCOUNT);
+      initialized = true;
+    }
+  }
+
+  @BeforeAll
+  @BeforeClass
+  @SneakyThrows
+  public static void loadDriver() {
+    var buildDir = String.format("%s/sql-jdbc/build/libs", System.getProperty("project.root"));
+    var driverFiles = new File(buildDir).
+        listFiles(pathname -> pathname.getAbsolutePath().endsWith(".jar"));
+
+    Assume.assumeTrue("Driver load failed", driverFiles != null && 1 == driverFiles.length);
+
+    URLClassLoader loader = new URLClassLoader(
+        new URL[] { driverFiles[0].toURI().toURL() },
+        ClassLoader.getSystemClassLoader()
+    );
+    driver = (Driver)Class.forName("org.opensearch.jdbc.Driver", true, loader)
+        .getDeclaredConstructor().newInstance();
+    connection = driver.connect(getConnectionString(), null);
+  }
+
+  @AfterAll
+  @AfterClass
+  @SneakyThrows
+  public static void closeConnection() {
+    // TODO should we close Statement and ResultSet?
+    if (connection != null) {
+      connection.close();
+      connection = null;
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void dev_select_all_small_table_small_cursor() {
+    Statement stmt = connection.createStatement();
+
+    for (var table : List.of(TEST_INDEX_CALCS, TEST_INDEX_BANK)) {
+      var query = String.format("SELECT * FROM %s", table);
+      stmt.setFetchSize(3);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+  }
+
+  /**
+   * Use OpenSearch cluster initialized by OpenSearch Gradle task.
+   */
+  private static String getConnectionString() {
+    // string like "[::1]:46751,127.0.0.1:34403"
+    var clusterUrls = System.getProperty("tests.rest.cluster").split(",");
+    return String.format("jdbc:opensearch://%s", clusterUrls[clusterUrls.length - 1]);
+  }
+
+  @SneakyThrows
+  protected JSONObject executeRestQuery(String query, @Nullable Integer fetch_size) {
+    Request request = new Request("POST", QUERY_API_ENDPOINT);
+    if (fetch_size != null) {
+      request.setJsonEntity(String.format("{ \"query\": \"%s\", \"fetch_size\": %d }", query, fetch_size));
+    } else {
+      request.setJsonEntity(String.format("{ \"query\": \"%s\" }", query));
+    }
+
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+
+    Response response = client().performRequest(request);
+    return new JSONObject(getResponseBody(response));
+  }
+
+}

--- a/integ-test/src/test/java/org/opensearch/sql/devJdbc/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/devJdbc/CursorIT.java
@@ -57,7 +57,7 @@ public class CursorIT extends SQLIntegTestCase {
   @BeforeClass
   @SneakyThrows
   public static void loadDriver() {
-    var buildDir = String.format("%s/sql-jdbc/build/libs", System.getProperty("project.root"));
+    var buildDir = String.format("%s/build/sql-jdbc/build/libs", System.getProperty("project.root"));
     var driverFiles = new File(buildDir).
         listFiles(pathname -> pathname.getAbsolutePath().endsWith(".jar"));
 

--- a/integ-test/src/test/java/org/opensearch/sql/jdbc/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/jdbc/CursorIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.jdbc;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
+import static org.opensearch.sql.util.TestUtils.getResponseBody;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import lombok.SneakyThrows;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class CursorIT extends SQLIntegTestCase {
+
+  private static Connection connection;
+
+  @Override
+  protected void init() throws Exception {
+    super.init();
+    loadIndex(Index.BANK);
+    loadIndex(Index.CALCS);
+    loadIndex(Index.ONLINE);
+    loadIndex(Index.ACCOUNT);
+  }
+
+  @AfterEach
+  @After
+  @SneakyThrows
+  public void closeConnection() {
+    // TODO should we close Statement and ResultSet?
+    if (connection != null) {
+      connection.close();
+      connection = null;
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void select_all_no_cursor() {
+    connection = DriverManager.getConnection(getConnectionString());
+    Statement stmt = connection.createStatement();
+
+    // 22 vs 29 sec
+    for (var table : List.of(TEST_INDEX_CALCS)){//, TEST_INDEX_ONLINE, TEST_INDEX_BANK, TEST_INDEX_ACCOUNT)) {
+      var query = String.format("SELECT * FROM %s", table);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+    connection.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void select_count_all_no_cursor() {
+    connection = DriverManager.getConnection(getConnectionString());
+    Statement stmt = connection.createStatement();
+
+    for (var table : List.of(TEST_INDEX_CALCS, TEST_INDEX_ONLINE, TEST_INDEX_BANK, TEST_INDEX_ACCOUNT)) {
+      var query = String.format("SELECT COUNT(*) FROM %s", table);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+    connection.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void select_all_small_table_big_cursor() {
+    connection = DriverManager.getConnection(getConnectionString());
+    Statement stmt = connection.createStatement();
+
+    for (var table : List.of(TEST_INDEX_CALCS, TEST_INDEX_BANK)) {
+      var query = String.format("SELECT COUNT(*) FROM %s", table);
+      stmt.setFetchSize(200);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+    connection.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void select_all_small_table_small_cursor() {
+    connection = DriverManager.getConnection(getConnectionString());
+    Statement stmt = connection.createStatement();
+
+    for (var table : List.of(TEST_INDEX_CALCS, TEST_INDEX_BANK)) {
+      var query = String.format("SELECT * FROM %s", table);
+      stmt.setFetchSize(3);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+    connection.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void select_all_big_table_small_cursor() {
+    connection = DriverManager.getConnection(getConnectionString());
+    Statement stmt = connection.createStatement();
+
+    for (var table : List.of(TEST_INDEX_ONLINE, TEST_INDEX_ACCOUNT)) {
+      var query = String.format("SELECT * FROM %s", table);
+      stmt.setFetchSize(10);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+    connection.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void select_all_big_table_big_cursor() {
+    connection = DriverManager.getConnection(getConnectionString());
+    Statement stmt = connection.createStatement();
+
+    for (var table : List.of(TEST_INDEX_ONLINE, TEST_INDEX_ACCOUNT)) {
+      var query = String.format("SELECT * FROM %s", table);
+      stmt.setFetchSize(500);
+      ResultSet rs = stmt.executeQuery(query);
+      int rows = 0;
+      for (; rs.next(); rows++) ;
+
+      var restResponse = executeRestQuery(query, null);
+      assertEquals(rows, restResponse.getInt("total"));
+    }
+    connection.close();
+  }
+
+  /**
+   * Use OpenSearch cluster initialized by OpenSearch Gradle task.
+   */
+  private String getConnectionString() {
+    return String.format("jdbc:opensearch://%s", client().getNodes().get(0).getHost());
+  }
+
+  @SneakyThrows
+  protected JSONObject executeRestQuery(String query, @Nullable Integer fetch_size) {
+    Request request = new Request("POST", QUERY_API_ENDPOINT);
+    if (fetch_size != null) {
+      request.setJsonEntity(String.format("{ \"query\": \"%s\", \"fetch_size\": %d }", query, fetch_size));
+    } else {
+      request.setJsonEntity(String.format("{ \"query\": \"%s\" }", query));
+    }
+
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+
+    Response response = client().performRequest(request);
+    return new JSONObject(getResponseBody(response));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
Add new IT suite which uses JDBC to issue queries with and without `fetch_size` set.
`fetch_size` parameter invokes pagination feature (`cursor`) which is currently supported by legacy engine only.

New `:integ-test` tasks:
#### `integJdbcTest`

Run ITs from `**/jdbc/*.java`. Existing tests in `CursorIT` create and use DB connection using JDBC driver from maven artifact.

Optional parameters:
* `-Dtest.debug`
Enabled test debug.
* `--tests '<test_filter>`
Filter test using wildcard, could be specified multiple times.
* `-DjdbcDriverVersion=<version>`
Maven artifact version for JDBC driver to use; optional, defaulted to `1.2.0.0`.

Test cluster log located in `integ-test/build/testclusters/integJdbcTest-0/logs/integJdbcTest.log`
Test report saved in `integ-test/build/reports/tests/integJdbcTest`

#### `integDevJdbcTest`

Run ITs from `**/devJdbc/*.java`. Existing tests in `CursorIT` create and use DB connection using JDBC driver from source code or existing binary.

Optional parameters:
* `-Dtest.debug`
Enabled test debug.
* `--tests '<test_filter>`
Filter test using wildcard, could be specified multiple times.
* `-DjdbcFile=<file>`
JDBC driver compiled binary (*.jar); if given, workflow uses it and ignores `jdbcRepo` and `jdbcBranch` parameters described below.
* `-DjdbcRepo=<repo_path>`
JDBC driver repo to checkout and build from; uses `https://github.com/opensearch-project/sql` by default.
* `-DjdbcBranch=<branch>`
Repository branch to pick code from; uses `main` by default.

Test cluster log located in `integ-test/build/testclusters/integDevJdbcTest-0/logs/integDevJdbcTest.log`
Test report saved in `integ-test/build/reports/tests/integDevJdbcTest`

Examples:
```
./gradlew :integ-test:integJdbcTest :integ-test:integDevJdbcTest

./gradlew :integ-test:integDevJdbcTest '-DjdbcFile=/mnt/c/GitHub/sql-jdbc/build/libs/opensearch-sql-jdbc-2.0.0.0.jar'

./gradlew :integ-test:integDevJdbcTest '-DjdbcRepo=https://github.com/Bit-Quill/sql-jdbc' '-DjdbcBranch=dev-feature-fix'
```

Output sample:
```
> Task :integ-test:integJdbcTest
org.opensearch.sql.jdbc.CursorIT.select_count_all_no_cursor(): SUCCESS 19.634s

CursorIT > select count all no cursor PASSED
org.opensearch.sql.jdbc.CursorIT.select_all_big_table_small_cursor(): SUCCESS 8.738s

CursorIT > select all big table small cursor PASSED
org.opensearch.sql.jdbc.CursorIT.select_all_small_table_small_cursor(): SUCCESS 0.238s

CursorIT > select all small table small cursor PASSED
org.opensearch.sql.jdbc.CursorIT.select_all_no_cursor(): SUCCESS 4.163s

CursorIT > select all no cursor PASSED
org.opensearch.sql.jdbc.CursorIT.select_all_small_table_big_cursor(): SUCCESS 0.132s

CursorIT > select all small table big cursor PASSED
org.opensearch.sql.jdbc.CursorIT.select_all_big_table_big_cursor(): SUCCESS 3.398s

CursorIT > select all big table big cursor PASSED

> Task :integ-test:integDevJdbcTest
org.opensearch.sql.devJdbc.CursorIT.dev_select_all_small_table_small_cursor(): SUCCESS 20.008s

CursorIT > dev_select_all_small_table_small_cursor() PASSED
```

### Notes

Test filter in gradle 
https://github.com/Bit-Quill/opensearch-project-sql/blob/24de6ff9eae35a824a664a865ad349788b744288/integ-test/build.gradle#L204-L206
requires
https://github.com/Bit-Quill/opensearch-project-sql/blob/24de6ff9eae35a824a664a865ad349788b744288/integ-test/build.gradle#L177
and doesn't work with JUnit 4. All IT framework uses Junit 4.
So, `init()` method of test classed isn't being called from superclasses automatically. 
`@BeforeAll`/`@BeforeClass` require a static method, so I can't call `initClient()` there. I have to move `initClient()` to `@BeforeEach` with `initialized` flag.

New gradle tasks are not included into CI workflow.

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).