### PR TITLE
Add `GET_FORMAT` Function To OpenSearch SQL Plugin

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -357,6 +357,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.FROM_DAYS, expressions);
   }
 
+  public static FunctionExpression get_format(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.GET_FORMAT, expressions);
+  }
+
   public static FunctionExpression hour(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.HOUR, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -97,6 +97,7 @@ public class DateTimeFunction {
 
   // Map used to determine format output for the get_format function
   private static final Map<String, String> formats = ImmutableMap.<String, String>builder()
+      //TODO: Add support for other formats
       .put("date-usa", "%m.%d.%Y")
       .put("time-usa", "%h:%i:%s %p")
       .put("datetime-usa", "%Y-%m-%d %H.%i.%s")

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -56,6 +56,8 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableMap;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
@@ -97,11 +99,12 @@ public class DateTimeFunction {
   private static final ExprIntegerValue DEFAULT_WEEK_OF_YEAR_MODE = new ExprIntegerValue(0);
 
   // Map used to determine format output for the get_format function
-  private static final Map<String, String> formats = Stream.of(new String[][] {
-      {"date-usa", "%m.%d.%Y"},
-      {"time-usa", "%h:%i:%s %p"},
-      {"datetime-usa", "%Y-%m-%d %H.%i.%s"}
-      }).collect(Collectors.toMap(keyValPair -> keyValPair[0], keyValPair -> keyValPair[1]));
+  private static final Map<String, String> formats = ImmutableMap.<String, String>builder()
+      .put("date-usa", "%m.%d.%Y")
+      .put("time-usa", "%h:%i:%s %p")
+      .put("datetime-usa", "%Y-%m-%d %H.%i.%s")
+      .put("timestamp-usa", "%Y-%m-%d %H.%i.%s")
+      .build();
 
   /**
    * Register Date and Time Functions.
@@ -1162,8 +1165,11 @@ public class DateTimeFunction {
    */
   private ExprValue exprGetFormat(ExprValue type, ExprValue format) {
     String key = type.stringValue() + "-" + format.stringValue();
-    String val = formats.get(key.toLowerCase());
-    return new ExprStringValue(val);
+    if (formats.containsKey(key)) {
+      return new ExprStringValue((formats.get(key.toLowerCase())));
+    }
+
+    return ExprNullValue.of();
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -34,6 +34,7 @@ import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_ST
 import static org.opensearch.sql.utils.DateTimeUtils.extractDate;
 import static org.opensearch.sql.utils.DateTimeUtils.extractDateTime;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
@@ -54,10 +55,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import com.google.common.collect.ImmutableMap;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
@@ -1165,7 +1162,7 @@ public class DateTimeFunction {
    */
   private ExprValue exprGetFormat(ExprValue type, ExprValue format) {
     String key = type.stringValue() + "-" + format.stringValue();
-    if (formats.containsKey(key)) {
+    if (formats.containsKey(key.toLowerCase())) {
       return new ExprStringValue((formats.get(key.toLowerCase())));
     }
 

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -51,8 +51,11 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.format.TextStyle;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
@@ -92,6 +95,13 @@ public class DateTimeFunction {
 
   // Mode used for week/week_of_year function by default when no argument is provided
   private static final ExprIntegerValue DEFAULT_WEEK_OF_YEAR_MODE = new ExprIntegerValue(0);
+
+  // Map used to determine format output for the get_format function
+  private static final Map<String, String> formats = Stream.of(new String[][] {
+      {"date-usa", "%m.%d.%Y"},
+      {"time-usa", "%h:%i:%s %p"},
+      {"datetime-usa", "%Y-%m-%d %H.%i.%s"}
+      }).collect(Collectors.toMap(keyValPair -> keyValPair[0], keyValPair -> keyValPair[1]));
 
   /**
    * Register Date and Time Functions.
@@ -1151,7 +1161,9 @@ public class DateTimeFunction {
    * @return ExprValue..
    */
   private ExprValue exprGetFormat(ExprValue type, ExprValue format) {
-    return new ExprStringValue("test");
+    String key = type.stringValue() + "-" + format.stringValue();
+    String val = formats.get(key.toLowerCase());
+    return new ExprStringValue(val);
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -122,6 +122,7 @@ public class DateTimeFunction {
     repository.register(dayOfYear(BuiltinFunctionName.DAY_OF_YEAR));
     repository.register(from_days());
     repository.register(from_unixtime());
+    repository.register(get_format());
     repository.register(hour(BuiltinFunctionName.HOUR));
     repository.register(hour(BuiltinFunctionName.HOUR_OF_DAY));
     repository.register(localtime());
@@ -504,6 +505,12 @@ public class DateTimeFunction {
         impl(nullMissingHandling(DateTimeFunction::exprFromUnixTime), DATETIME, DOUBLE),
         impl(nullMissingHandling(DateTimeFunction::exprFromUnixTimeFormat),
             STRING, DOUBLE, STRING));
+  }
+
+  private DefaultFunctionResolver get_format() {
+    return define(BuiltinFunctionName.GET_FORMAT.getName(),
+        impl(nullMissingHandling(DateTimeFunction::exprGetFormat), STRING, STRING, STRING)
+    );
   }
 
   /**
@@ -1134,6 +1141,17 @@ public class DateTimeFunction {
       return ExprNullValue.of();
     }
     return DateTimeFormatterUtil.getFormattedDate(value, format);
+  }
+
+  /**
+   * get_format implementation for ExprValue.
+   *
+   * @param type ExprValue of the type.
+   * @param format ExprValue of Time/String type
+   * @return ExprValue..
+   */
+  private ExprValue exprGetFormat(ExprValue type, ExprValue format) {
+    return new ExprStringValue("test");
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -76,6 +76,7 @@ public enum BuiltinFunctionName {
   DAY_OF_YEAR(FunctionName.of("day_of_year")),
   FROM_DAYS(FunctionName.of("from_days")),
   FROM_UNIXTIME(FunctionName.of("from_unixtime")),
+  GET_FORMAT(FunctionName.of("get_format")),
   HOUR(FunctionName.of("hour")),
   HOUR_OF_DAY(FunctionName.of("hour_of_day")),
   MAKEDATE(FunctionName.of("makedate")),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -894,21 +894,14 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   }
 
   @Test
-  public void testGetFormatInvalidType() {
-    FunctionExpression expr = DSL.get_format(
-        DSL.literal("DATETEIM"),
-        DSL.literal("USA"));
-    assertThrows(SemanticCheckException.class, () ->  eval(expr));
-  }
-
-  @Test
   public void testGetFormatInvalidFormat() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
     FunctionExpression expr = DSL.get_format(
         DSL.literal("DATE"),
         DSL.literal("1SA"));
-    assertEquals("NULL", eval(expr).stringValue());
+    assertEquals(nullValue(), eval(expr));
   }
-
 
   @Test
   public void hour() {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -867,20 +867,20 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   private static Stream<Arguments> getTestDataForGetFormat() {
     return Stream.of(
         Arguments.of("DATE", "USA", "%m.%d.%Y"),
-        Arguments.of("DATE", "JIS", "%Y-%m-%d"),
-        Arguments.of("DATE", "ISO", "%Y-%m-%d"),
-        Arguments.of("DATE", "EUR", "%d.%m.%Y"),
-        Arguments.of("DATE", "INTERNAL",	"%Y%m%d"),
+        //Arguments.of("DATE", "JIS", "%Y-%m-%d"),
+        //Arguments.of("DATE", "ISO", "%Y-%m-%d"),
+        //Arguments.of("DATE", "EUR", "%d.%m.%Y"),
+        //Arguments.of("DATE", "INTERNAL",	"%Y%m%d"),
         Arguments.of("DATETIME", "USA",	"%Y-%m-%d %H.%i.%s"),
-        Arguments.of("DATETIME", "JIS",	"%Y-%m-%d %H:%i:%s"),
-        Arguments.of("DATETIME", "ISO",	"%Y-%m-%d %H:%i:%s"),
-        Arguments.of("DATETIME", "EUR",	"%Y-%m-%d %H.%i.%s"),
-        Arguments.of("DATETIME", "INTERNAL", "%Y%m%d%H%i%s"),
-        Arguments.of("TIME", "USA",	"%h:%i:%s %p"),
-        Arguments.of("TIME", "JIS",	"%H:%i:%s"),
-        Arguments.of("TIME", "ISO",	"%H:%i:%s"),
-        Arguments.of("TIME", "EUR",	"%H.%i.%s"),
-        Arguments.of("TIME", "INTERNAL",	"%H%i%s")
+        //Arguments.of("DATETIME", "JIS",	"%Y-%m-%d %H:%i:%s"),
+        //Arguments.of("DATETIME", "ISO",	"%Y-%m-%d %H:%i:%s"),
+        //Arguments.of("DATETIME", "EUR",	"%Y-%m-%d %H.%i.%s"),
+        //Arguments.of("DATETIME", "INTERNAL", "%Y%m%d%H%i%s"),
+        Arguments.of("TIME", "USA",	"%h:%i:%s %p")
+        //Arguments.of("TIME", "JIS",	"%H:%i:%s"),
+        //Arguments.of("TIME", "ISO",	"%H:%i:%s"),
+        //Arguments.of("TIME", "EUR",	"%H.%i.%s"),
+        //Arguments.of("TIME", "INTERNAL",	"%H%i%s")
     );
   }
 
@@ -904,16 +904,6 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         DSL.literal(arg),
         DSL.literal(new ExprStringValue(format)),
         expectedResult);
-  }
-
-  @Test
-  public void testGetFormatWithNullFormat() {
-    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
-    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
-    FunctionExpression expr = DSL.get_format(
-        DSL.literal("DATE"),
-        ExprNullValue.of());
-    assertNull(eval(expr));
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -9,7 +9,6 @@ package org.opensearch.sql.expression.datetime;
 import static java.time.temporal.ChronoField.ALIGNED_WEEK_OF_YEAR;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
@@ -43,7 +42,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
 import org.opensearch.sql.data.model.ExprLongValue;
-import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
@@ -868,6 +866,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     return Stream.of(
         Arguments.of("DATE", "USA", "%m.%d.%Y"),
         Arguments.of("DATETIME", "USA", "%Y-%m-%d %H.%i.%s"),
+        Arguments.of("TIMESTAMP", "USA", "%Y-%m-%d %H.%i.%s"),
         Arguments.of("TIME", "USA", "%h:%i:%s %p")
     );
   }
@@ -893,6 +892,23 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         DSL.literal(new ExprStringValue(format)),
         expectedResult);
   }
+
+  @Test
+  public void testGetFormatInvalidType() {
+    FunctionExpression expr = DSL.get_format(
+        DSL.literal("DATETEIM"),
+        DSL.literal("USA"));
+    assertThrows(SemanticCheckException.class, () ->  eval(expr));
+  }
+
+  @Test
+  public void testGetFormatInvalidFormat() {
+    FunctionExpression expr = DSL.get_format(
+        DSL.literal("DATE"),
+        DSL.literal("1SA"));
+    assertEquals("NULL", eval(expr).stringValue());
+  }
+
 
   @Test
   public void hour() {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -867,20 +867,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   private static Stream<Arguments> getTestDataForGetFormat() {
     return Stream.of(
         Arguments.of("DATE", "USA", "%m.%d.%Y"),
-        //Arguments.of("DATE", "JIS", "%Y-%m-%d"),
-        //Arguments.of("DATE", "ISO", "%Y-%m-%d"),
-        //Arguments.of("DATE", "EUR", "%d.%m.%Y"),
-        //Arguments.of("DATE", "INTERNAL",	"%Y%m%d"),
-        Arguments.of("DATETIME", "USA",	"%Y-%m-%d %H.%i.%s"),
-        //Arguments.of("DATETIME", "JIS",	"%Y-%m-%d %H:%i:%s"),
-        //Arguments.of("DATETIME", "ISO",	"%Y-%m-%d %H:%i:%s"),
-        //Arguments.of("DATETIME", "EUR",	"%Y-%m-%d %H.%i.%s"),
-        //Arguments.of("DATETIME", "INTERNAL", "%Y%m%d%H%i%s"),
-        Arguments.of("TIME", "USA",	"%h:%i:%s %p")
-        //Arguments.of("TIME", "JIS",	"%H:%i:%s"),
-        //Arguments.of("TIME", "ISO",	"%H:%i:%s"),
-        //Arguments.of("TIME", "EUR",	"%H.%i.%s"),
-        //Arguments.of("TIME", "INTERNAL",	"%H%i%s")
+        Arguments.of("DATETIME", "USA", "%Y-%m-%d %H.%i.%s"),
+        Arguments.of("TIME", "USA", "%h:%i:%s %p")
     );
   }
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1756,6 +1756,28 @@ Examples::
     +-----------------------------------+
 
 
+GET_FORMAT
+----------
+
+
+Description
+>>>>>>>>>>>
+
+Usage: Returns a string value containing string format specifiers based on the input arguments
+
+Argument type: TYPE, STRING
+
+Examples::
+
+    os> select GET_FORMAT(DATE, 'USA');
+    fetched rows / total rows = 1/1
+    +---------------------------+
+    | GET_FORMAT(DATE, 'USA')   |
+    |---------------------------|
+    | %m.%d.%Y                  |
+    +---------------------------+
+
+
 HOUR
 ----
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1765,7 +1765,8 @@ Description
 Usage: Returns a string value containing string format specifiers based on the input arguments.
 
 Argument type: TYPE, STRING
-(Where TYPE can be one of [DATE, TIME, DATETIME, TIMESTAMP])
+TYPE must be one of the following tokens: [DATE, TIME, DATETIME, TIMESTAMP].
+STRING must be one of the following tokens: ["USA", "JIS", "ISO", "EUR", "INTERNAL"] (" can be replaced by ').
 
 Examples::
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1759,13 +1759,13 @@ Examples::
 GET_FORMAT
 ----------
 
-
 Description
 >>>>>>>>>>>
 
-Usage: Returns a string value containing string format specifiers based on the input arguments
+Usage: Returns a string value containing string format specifiers based on the input arguments.
 
 Argument type: TYPE, STRING
+(Where TYPE can be one of [DATE, TIME, DATETIME, TIMESTAMP])
 
 Examples::
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -1099,6 +1099,12 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testGetFormatAsArgument() throws IOException{
+    var result = executeQuery("SELECT DATE_FORMAT('2003-10-03',GET_FORMAT(DATE,'USA'))");
+    verifyDataRows(result, rows("10.03.2003"));
+  }
+
+  @Test
   public void testUnixTimeStamp() throws IOException {
     var result = executeQuery(
         "select UNIX_TIMESTAMP(MAKEDATE(1984, 1984)) f1, "

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -213,6 +213,7 @@ EXPM1:                              'EXPM1';
 FLOOR:                              'FLOOR';
 FROM_DAYS:                          'FROM_DAYS';
 FROM_UNIXTIME:                      'FROM_UNIXTIME';
+GET_FORMAT:                         'GET_FORMAT';
 IF:                                 'IF';
 IFNULL:                             'IFNULL';
 ISNULL:                             'ISNULL';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -309,6 +309,7 @@ functionCall
     | relevanceFunction                                             #relevanceFunctionCall
     | highlightFunction                                             #highlightFunctionCall
     | positionFunction                                              #positionFunctionCall
+    | GET_FORMAT LR_BRACKET functionArgs RR_BRACKET                 #getFormatFunctionCall
     ;
 
 
@@ -318,6 +319,17 @@ highlightFunction
 
 positionFunction
     : POSITION LR_BRACKET functionArg IN functionArg RR_BRACKET
+    ;
+
+//getFormatFunction
+//    : GET_FORMAT LR_BRACKET argumentType=getFormatTypes COMMA functionArgs RR_BRACKET
+//    ;
+
+getFormatTypes
+    :DATETIME
+    |DATE
+    |TIME
+    |TIMESTAMP
     ;
 
 matchQueryAltSyntaxFunction

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -309,7 +309,18 @@ functionCall
     | relevanceFunction                                             #relevanceFunctionCall
     | highlightFunction                                             #highlightFunctionCall
     | positionFunction                                              #positionFunctionCall
-    | GET_FORMAT LR_BRACKET functionArgs RR_BRACKET                 #getFormatFunctionCall
+    | GET_FORMAT LR_BRACKET getFormatArgs RR_BRACKET                #getFormatFunctionCall
+    ;
+
+getFormatArgs
+    : getFormatType COMMA functionArg
+    ;
+
+getFormatType
+    : DATE
+    | DATETIME
+    | TIME
+    | TIMESTAMP
     ;
 
 

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -309,11 +309,11 @@ functionCall
     | relevanceFunction                                             #relevanceFunctionCall
     | highlightFunction                                             #highlightFunctionCall
     | positionFunction                                              #positionFunctionCall
-    | GET_FORMAT LR_BRACKET getFormatArgs RR_BRACKET                #getFormatFunctionCall
+    | getFormatFunction                                             #getFormatFunctionCall
     ;
 
-getFormatArgs
-    : getFormatType COMMA functionArg
+getFormatFunction
+    : GET_FORMAT LR_BRACKET getFormatType COMMA functionArg RR_BRACKET
     ;
 
 getFormatType

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -321,17 +321,6 @@ positionFunction
     : POSITION LR_BRACKET functionArg IN functionArg RR_BRACKET
     ;
 
-//getFormatFunction
-//    : GET_FORMAT LR_BRACKET argumentType=getFormatTypes COMMA functionArgs RR_BRACKET
-//    ;
-
-getFormatTypes
-    :DATETIME
-    |DATE
-    |TIME
-    |TIMESTAMP
-    ;
-
 matchQueryAltSyntaxFunction
     : field=relevanceField EQUAL_SYMBOL MATCH_QUERY LR_BRACKET query=relevanceQuery RR_BRACKET
     ;

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -154,7 +154,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitGetFormatFunctionCall(GetFormatFunctionCallContext ctx) {
     return new Function(
-        ctx.GET_FORMAT().toString(),
+        ctx.getFormatFunction().GET_FORMAT().toString(),
         getFormatFunctionArguments(ctx));
   }
 
@@ -566,8 +566,8 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   private List<UnresolvedExpression> getFormatFunctionArguments(
       GetFormatFunctionCallContext ctx) {
     List<UnresolvedExpression> args = Arrays.asList(
-        new Literal(ctx.getFormatArgs().getFormatType().getText(), DataType.STRING),
-        visitFunctionArg(ctx.getFormatArgs().functionArg())
+        new Literal(ctx.getFormatFunction().getFormatType().getText(), DataType.STRING),
+        visitFunctionArg(ctx.getFormatFunction().functionArg())
     );
     return args;
   }

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -66,8 +66,6 @@ import static org.opensearch.sql.sql.parser.ParserUtils.createSortOption;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -569,9 +569,14 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
       GetFormatFunctionCallContext ctx) {
     // all the arguments are defaulted to string values
     // to skip environment resolving and function signature resolving
-    return ctx.functionArgs().functionArg().stream()
+    List<UnresolvedExpression> args = ctx.functionArgs().functionArg().stream()
         .map(this::visitFunctionArg)
         .collect(Collectors.toList());
+
+    String arg0 = args.get(0).toString();
+    Literal temp = new Literal(arg0, DataType.STRING);
+    args.set(0, temp);
+    return args;
   }
 
   /**

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -565,7 +565,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
   private List<UnresolvedExpression> getFormatFunctionArguments(
       GetFormatFunctionCallContext ctx) {
-    // all the arguments are defaulted to string values
+    // first argument is defaulted to string values
     // to skip environment resolving and function signature resolving
     List<UnresolvedExpression> args = ctx.functionArgs().functionArg().stream()
         .map(this::visitFunctionArg)

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -574,8 +574,8 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
         .collect(Collectors.toList());
 
     String arg0 = args.get(0).toString();
-    Literal temp = new Literal(arg0, DataType.STRING);
-    args.set(0, temp);
+    Literal typeAsString = new Literal(arg0, DataType.STRING);
+    args.set(0, typeAsString);
     return args;
   }
 

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -569,10 +569,6 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
         new Literal(ctx.getFormatArgs().getFormatType().getText(), DataType.STRING),
         visitFunctionArg(ctx.getFormatArgs().functionArg())
     );
-
-    String arg0 = args.get(0).toString();
-    Literal typeAsString = new Literal(arg0, DataType.STRING);
-    args.set(0, typeAsString);
     return args;
   }
 

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -154,7 +154,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitGetFormatFunctionCall(GetFormatFunctionCallContext ctx) {
     return new Function(
-        "get_format",
+        ctx.GET_FORMAT().toString(),
         getFormatFunctionArguments(ctx));
   }
 
@@ -565,11 +565,10 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
   private List<UnresolvedExpression> getFormatFunctionArguments(
       GetFormatFunctionCallContext ctx) {
-    // first argument is defaulted to string values
-    // to skip environment resolving and function signature resolving
-    List<UnresolvedExpression> args = ctx.functionArgs().functionArg().stream()
-        .map(this::visitFunctionArg)
-        .collect(Collectors.toList());
+    List<UnresolvedExpression> args = Arrays.asList(
+        new Literal(ctx.getFormatArgs().getFormatType().getText(), DataType.STRING),
+        visitFunctionArg(ctx.getFormatArgs().functionArg())
+    );
 
     String arg0 = args.get(0).toString();
     Literal typeAsString = new Literal(arg0, DataType.STRING);

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -199,8 +199,8 @@ class SQLSyntaxParserTest {
     String[] types = {"DATE", "DATETIME", "TIME", "TIMESTAMP"};
     String[] formats = {"'USA'", "'JIS'", "'ISO'", "'EUR'", "'INTERNAL'"};
 
-    for(String type : types) {
-      for(String format : formats) {
+    for (String type : types) {
+      for (String format : formats) {
         args.add(Arguments.of(type, format));
       }
     }

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -217,7 +217,7 @@ class SQLSyntaxParserTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("get_format_arguments")
   public void can_parse_get_format_function(String get_format_query) {
-    assertNotNull(parser.parse(get_format_query));
+    assertNotNull(parser.parse(String.format("SELECT %s", get_format_query)));
   }
 
   @Test

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -221,6 +221,13 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void cannot_parse_get_format_function_with_bad_arg() {
+    assertThrows(
+        SyntaxCheckException.class, 
+        () -> parser.parse("GET_FORMAT(NONSENSE_ARG,'INTERNAL')"));
+  }
+
+  @Test
   public void can_parse_hour_functions() {
     assertNotNull(parser.parse("SELECT hour('2022-11-18 12:23:34')"));
     assertNotNull(parser.parse("SELECT hour_of_day('12:23:34')"));

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -194,6 +194,32 @@ class SQLSyntaxParserTest {
     assertNotNull(parser.parse("SELECT id FROM test WHERE " + String.join(" AND ", calls)));
   }
 
+  private static Stream<Arguments> get_format_arguments() {
+    return Stream.of(
+        Arguments.of("GET_FORMAT(DATE,'USA')"),
+        Arguments.of("GET_FORMAT(DATE,'JIS')"),
+        Arguments.of("GET_FORMAT(DATE,'ISO')"),
+        Arguments.of("GET_FORMAT(DATE,'EUR')"),
+        Arguments.of("GET_FORMAT(DATE,'INTERNAL')"),
+        Arguments.of("GET_FORMAT(DATETIME,'USA')"),
+        Arguments.of("GET_FORMAT(DATETIME,'JIS')"),
+        Arguments.of("GET_FORMAT(DATETIME,'ISO')"),
+        Arguments.of("GET_FORMAT(DATETIME,'EUR')"),
+        Arguments.of("GET_FORMAT(DATETIME,'INTERNAL')"),
+        Arguments.of("GET_FORMAT(TIME,'USA')"),
+        Arguments.of("GET_FORMAT(TIME,'JIS')"),
+        Arguments.of("GET_FORMAT(TIME,'ISO')"),
+        Arguments.of("GET_FORMAT(TIME,'EUR')"),
+        Arguments.of("GET_FORMAT(TIME,'INTERNAL')")
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("get_format_arguments")
+  public void can_parse_get_format_function(String get_format_query) {
+    assertNotNull(parser.parse(get_format_query));
+  }
+
   @Test
   public void can_parse_hour_functions() {
     assertNotNull(parser.parse("SELECT hour('2022-11-18 12:23:34')"));

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -216,8 +216,8 @@ class SQLSyntaxParserTest {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("get_format_arguments")
-  public void can_parse_get_format_function(String get_format_query) {
-    assertNotNull(parser.parse(String.format("SELECT %s", get_format_query)));
+  public void can_parse_get_format_function(String getFormatQuery) {
+    assertNotNull(parser.parse(String.format("SELECT %s", getFormatQuery)));
   }
 
   @Test

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -195,35 +195,29 @@ class SQLSyntaxParserTest {
   }
 
   private static Stream<Arguments> get_format_arguments() {
-    return Stream.of(
-        Arguments.of("GET_FORMAT(DATE,'USA')"),
-        Arguments.of("GET_FORMAT(DATE,'JIS')"),
-        Arguments.of("GET_FORMAT(DATE,'ISO')"),
-        Arguments.of("GET_FORMAT(DATE,'EUR')"),
-        Arguments.of("GET_FORMAT(DATE,'INTERNAL')"),
-        Arguments.of("GET_FORMAT(DATETIME,'USA')"),
-        Arguments.of("GET_FORMAT(DATETIME,'JIS')"),
-        Arguments.of("GET_FORMAT(DATETIME,'ISO')"),
-        Arguments.of("GET_FORMAT(DATETIME,'EUR')"),
-        Arguments.of("GET_FORMAT(DATETIME,'INTERNAL')"),
-        Arguments.of("GET_FORMAT(TIME,'USA')"),
-        Arguments.of("GET_FORMAT(TIME,'JIS')"),
-        Arguments.of("GET_FORMAT(TIME,'ISO')"),
-        Arguments.of("GET_FORMAT(TIME,'EUR')"),
-        Arguments.of("GET_FORMAT(TIME,'INTERNAL')")
-    );
+    Stream.Builder<Arguments> args = Stream.builder();
+    String[] types = {"DATE", "DATETIME", "TIME", "TIMESTAMP"};
+    String[] formats = {"'USA'", "'JIS'", "'ISO'", "'EUR'", "'INTERNAL'"};
+
+    for(String type : types) {
+      for(String format : formats) {
+        args.add(Arguments.of(type, format));
+      }
+    }
+
+    return args.build();
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("get_format_arguments")
-  public void can_parse_get_format_function(String getFormatQuery) {
-    assertNotNull(parser.parse(String.format("SELECT %s", getFormatQuery)));
+  public void can_parse_get_format_function(String type, String format) {
+    assertNotNull(parser.parse(String.format("SELECT GET_FORMAT(%s, %s)", type, format)));
   }
 
   @Test
   public void cannot_parse_get_format_function_with_bad_arg() {
     assertThrows(
-        SyntaxCheckException.class, 
+        SyntaxCheckException.class,
         () -> parser.parse("GET_FORMAT(NONSENSE_ARG,'INTERNAL')"));
   }
 

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -193,6 +193,14 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void canBuildGetFormatFunctionCall() {
+    assertEquals(
+        function("get_format", stringLiteral("DATE"), stringLiteral("USA")),
+        buildExprAst("get_format(DATE,\"USA\")")
+    );
+  }
+
+  @Test
   public void canBuildNestedFunctionCall() {
     assertEquals(
         function("abs",


### PR DESCRIPTION
### Description
Adds the `get_format` function to the OpenSearch SQL Plugin. It's implementation is aligned with the [MySQL Documentation](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_get-format).

**Note: This currently only supports a `USA` format for `DATE`, `TIME`, and `DATETIME`**

Examples:

```
opensearchsql> SELECT get_format(DATE, 'USA');
fetched rows / total rows = 1/1
+---------------------------+
| get_format(DATE, 'USA')   |
|---------------------------|
| %m.%d.%Y                  |
+---------------------------+
```

```
opensearchsql> SELECT DATE_FORMAT('2003-10-03',GET_FORMAT(DATE,'USA'));
fetched rows / total rows = 1/1
+----------------------------------------------------+
| DATE_FORMAT('2003-10-03',GET_FORMAT(DATE,'USA'))   |
|----------------------------------------------------|
| 10.03.2003                                         |
+----------------------------------------------------+
```

```
opensearchsql> SELECT DATE_FORMAT('2003-10-03', null);
fetched rows / total rows = 1/1
+-----------------------------------+
| DATE_FORMAT('2003-10-03', null)   |
|-----------------------------------|
| null                              |
+-----------------------------------+
```
 
### Issues Resolved
[#722](https://github.com/opensearch-project/sql/issues/722)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).