### PR TITLE
Added Correctness Tests for String Functions

### DIFF
--- a/integ-test/src/test/resources/correctness/expressions/string_functions.txt
+++ b/integ-test/src/test/resources/correctness/expressions/string_functions.txt
@@ -1,0 +1,16 @@
+ASCII(customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+CONCAT(customer_first_name, customer_last_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+CONCAT_WS(customer_first_name, ' ', customer_last_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+LOWER(customer_full_name) As COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+UPPER(customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+LEFT(customer_full_name, LENGTH(customer_full_name) - 1) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+RIGHT(customer_full_name, LENGTH(customer_full_name) - 1) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+LTRIM(customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+RTRIM(customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+TRIM(customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+REPLACE(customer_full_name, customer_first_name, email) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+SUBSTR(customer_full_name, 1, LENGTH(customer_full_name) - 1) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+SUBSTRING(customer_full_name, 1, LENGTH(customer_full_name) - 1) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+LENGTH(customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+LOCATE(customer_first_name, customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce
+POSITION(customer_last_name IN customer_full_name) AS COLUMN FROM opensearch_dashboards_sample_data_ecommerce


### PR DESCRIPTION
### Description
Added tests for all string functions in OpenSearch that has at least one corresponding function in either SQLite and/or H2. This includes the following functions:

- ASCII
- CONCAT
- CONCAT_WS
- LOWER
- UPPER
- LEFT
- RIGHT
- RTRIM
- LTRIM
- TRIM
- REPLACE
- SUBSTR
- SUBSTRING
- LENGTH
- LOCATE
- POSITION

I have not included the `REVERSE()` function as I have not found a good way of testing it as OpenSearch returns a `VARCHAR` value and SQLITE returns a `TEXT` value. I have tried many methods of trying to get them to be comparable in the testing including typecasting and substringing, but the closest I could get is prove that the `LENGTH()` of both are the same. Visually it is obvious that the functions are the same other than the type returned
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).