### PR TITLE
Added Support For Other Formats For `GET_FORMAT` Function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -106,12 +106,27 @@ public class DateTimeFunction {
   // Map used to determine format output for the get_format function
   private static final Table<String, String, String> formats =
       ImmutableTable.<String, String, String>builder()
-      //TODO: Add support for other formats
-      .put("date", "usa", "%m.%d.%Y")
-      .put("time", "usa", "%h:%i:%s %p")
-      .put("datetime", "usa", "%Y-%m-%d %H.%i.%s")
-      .put("timestamp", "usa", "%Y-%m-%d %H.%i.%s")
-      .build();
+          .put("date", "usa", "%m.%d.%Y")
+          .put("date", "jis", "%Y-%m-%d")
+          .put("date", "iso", "%Y-%m-%d")
+          .put("date", "eur", "%d.%m.%Y")
+          .put("date", "internal", "%Y%m%d")
+          .put("datetime", "usa", "%Y-%m-%d %H.%i.%s")
+          .put("datetime", "jis", "%Y-%m-%d %H:%i:%s")
+          .put("datetime", "iso", "%Y-%m-%d %H:%i:%s")
+          .put("datetime", "eur", "%Y-%m-%d %H.%i.%s")
+          .put("datetime", "internal", "%Y%m%d%H%i%s")
+          .put("time", "usa", "%h:%i:%s %p")
+          .put("time", "jis", "%H:%i:%s")
+          .put("time", "iso", "%H:%i:%s")
+          .put("time", "eur", "%H.%i.%s")
+          .put("time", "internal", "%H%i%s")
+          .put("timestamp", "usa", "%Y-%m-%d %H.%i.%s")
+          .put("timestamp", "jis", "%Y-%m-%d %H:%i:%s")
+          .put("timestamp", "iso", "%Y-%m-%d %H:%i:%s")
+          .put("timestamp", "eur", "%Y-%m-%d %H.%i.%s")
+          .put("timestamp", "internal", "%Y%m%d%H%i%s")
+          .build();
 
   /**
    * Register Date and Time Functions.

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -678,9 +678,25 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   private static Stream<Arguments> getTestDataForGetFormat() {
     return Stream.of(
         Arguments.of("DATE", "USA", "%m.%d.%Y"),
+        Arguments.of("DATE", "JIS", "%Y-%m-%d"),
+        Arguments.of("DATE", "ISO", "%Y-%m-%d"),
+        Arguments.of("DATE", "EUR", "%d.%m.%Y"),
+        Arguments.of("DATE", "INTERNAL", "%Y%m%d"),
         Arguments.of("DATETIME", "USA", "%Y-%m-%d %H.%i.%s"),
+        Arguments.of("DATETIME", "JIS", "%Y-%m-%d %H:%i:%s"),
+        Arguments.of("DATETIME", "ISO", "%Y-%m-%d %H:%i:%s"),
+        Arguments.of("DATETIME", "EUR", "%Y-%m-%d %H.%i.%s"),
+        Arguments.of("DATETIME", "INTERNAL", "%Y%m%d%H%i%s"),
+        Arguments.of("TIME", "USA", "%h:%i:%s %p"),
+        Arguments.of("TIME", "JIS", "%H:%i:%s"),
+        Arguments.of("TIME", "ISO", "%H:%i:%s"),
+        Arguments.of("TIME", "EUR", "%H.%i.%s"),
+        Arguments.of("TIME", "INTERNAL", "%H%i%s"),
         Arguments.of("TIMESTAMP", "USA", "%Y-%m-%d %H.%i.%s"),
-        Arguments.of("TIME", "USA", "%h:%i:%s %p")
+        Arguments.of("TIMESTAMP", "JIS", "%Y-%m-%d %H:%i:%s"),
+        Arguments.of("TIMESTAMP", "ISO", "%Y-%m-%d %H:%i:%s"),
+        Arguments.of("TIMESTAMP", "EUR", "%Y-%m-%d %H.%i.%s"),
+        Arguments.of("TIMESTAMP", "INTERNAL", "%Y%m%d%H%i%s")
     );
   }
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1761,7 +1761,7 @@ Usage: Returns a string value containing string format specifiers based on the i
 
 Argument type: TYPE, STRING
 TYPE must be one of the following tokens: [DATE, TIME, DATETIME, TIMESTAMP].
-STRING must be one of the following tokens: ["USA"] (" can be replaced by ').
+STRING must be one of the following tokens: ["USA", "JIS", "ISO", "EUR", "INTERNAL"] (" can be replaced by ').
 
 Examples::
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
@@ -418,7 +418,7 @@ public class PluginIT extends SQLIntegTestCase {
 
     actual = new JSONObject(TestUtils.getResponseBody(response));
     assertThat(actual.getInt("status"), equalTo(400));
-    assertThat(actual.query("/error/type"), equalTo("illegal_argument_exception"));
+    assertThat(actual.query("/error/type"), equalTo("settings_exception"));
     assertThat(
         actual.query("/error/reason"),
         equalTo("transient setting [plugins.sql.query.state.city], not recognized")


### PR DESCRIPTION
Signed-off-by: GabeFernandez310 <Gabriel.Fernandez@improving.com>

### Description
Adds the support for more formats for the `get_format` function to the OpenSearch SQL Plugin. Its implementation is aligned with the [MySQL Documentation](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_get-format).
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/722
 
### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).