### PR TITLE
Modified returning NaN to NULL

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -240,7 +240,8 @@ public class MathematicalFunction {
    */
   private static DefaultFunctionResolver ln() {
     return baseMathFunction(BuiltinFunctionName.LN.getName(),
-            v -> new ExprDoubleValue(Math.log(v.doubleValue())), DOUBLE);
+        v -> v.doubleValue() <= 0 ? ExprNullValue.of() :
+            new ExprDoubleValue(Math.log(v.doubleValue())), DOUBLE);
   }
 
   /**
@@ -255,7 +256,8 @@ public class MathematicalFunction {
     // build unary log(x), SHORT/INTEGER/LONG/FLOAT/DOUBLE -> DOUBLE
     for (ExprType type : ExprCoreType.numberTypes()) {
       builder.add(FunctionDSL.impl(FunctionDSL
-              .nullMissingHandling(v -> new ExprDoubleValue(Math.log(v.doubleValue()))),
+              .nullMissingHandling(v -> v.doubleValue() <= 0 ? ExprNullValue.of() :
+                  new ExprDoubleValue(Math.log(v.doubleValue()))),
           DOUBLE, type));
     }
 
@@ -263,7 +265,8 @@ public class MathematicalFunction {
     for (ExprType baseType : ExprCoreType.numberTypes()) {
       for (ExprType numberType : ExprCoreType.numberTypes()) {
         builder.add(FunctionDSL.impl(FunctionDSL
-                .nullMissingHandling((b, x) -> new ExprDoubleValue(
+                .nullMissingHandling((b, x) -> b.doubleValue() <= 0 || x.doubleValue() <= 0
+                    ? ExprNullValue.of() : new ExprDoubleValue(
                     Math.log(x.doubleValue()) / Math.log(b.doubleValue()))),
             DOUBLE, baseType, numberType));
       }
@@ -278,7 +281,8 @@ public class MathematicalFunction {
    */
   private static DefaultFunctionResolver log10() {
     return baseMathFunction(BuiltinFunctionName.LOG10.getName(),
-            v -> new ExprDoubleValue(Math.log10(v.doubleValue())), DOUBLE);
+        v -> v.doubleValue() <= 0 ? ExprNullValue.of() :
+            new ExprDoubleValue(Math.log10(v.doubleValue())), DOUBLE);
   }
 
   /**
@@ -287,7 +291,8 @@ public class MathematicalFunction {
    */
   private static DefaultFunctionResolver log2() {
     return baseMathFunction(BuiltinFunctionName.LOG2.getName(),
-            v -> new ExprDoubleValue(Math.log(v.doubleValue()) / Math.log(2)), DOUBLE);
+        v -> v.doubleValue() <= 0 ? ExprNullValue.of() :
+            new ExprDoubleValue(Math.log(v.doubleValue()) / Math.log(2)), DOUBLE);
   }
 
   /**

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -81,6 +81,13 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     return builder.add(Arguments.of(2D, 2D)).build();
   }
 
+  private static Stream<Arguments> testLogInvalidDoubleArguments() {
+    Stream.Builder<Arguments> builder = Stream.builder();
+    return builder.add(Arguments.of(0D, -2D))
+        .add(Arguments.of(0D, 2D))
+        .add(Arguments.of(2D, 0D)).build();
+  }
+
   private static Stream<Arguments> trigonometricArguments() {
     Stream.Builder<Arguments> builder = Stream.builder();
     return builder
@@ -725,7 +732,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test ln with integer value.
    */
   @ParameterizedTest(name = "ln({0})")
-  @ValueSource(ints = {2, -2})
+  @ValueSource(ints = {2, 3})
   public void ln_int_value(Integer value) {
     FunctionExpression ln = DSL.ln(DSL.literal(value));
     assertThat(
@@ -738,7 +745,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test ln with long value.
    */
   @ParameterizedTest(name = "ln({0})")
-  @ValueSource(longs = {2L, -2L})
+  @ValueSource(longs = {2L, 3L})
   public void ln_long_value(Long value) {
     FunctionExpression ln = DSL.ln(DSL.literal(value));
     assertThat(
@@ -751,7 +758,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test ln with float value.
    */
   @ParameterizedTest(name = "ln({0})")
-  @ValueSource(floats = {2F, -2F})
+  @ValueSource(floats = {2F, 3F})
   public void ln_float_value(Float value) {
     FunctionExpression ln = DSL.ln(DSL.literal(value));
     assertThat(
@@ -764,13 +771,24 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test ln with double value.
    */
   @ParameterizedTest(name = "ln({0})")
-  @ValueSource(doubles = {2D, -2D})
+  @ValueSource(doubles = {2D, 3D})
   public void ln_double_value(Double value) {
     FunctionExpression ln = DSL.ln(DSL.literal(value));
     assertThat(
         ln.valueOf(valueEnv()),
         allOf(hasType(DOUBLE), hasValue(Math.log(value))));
     assertEquals(String.format("ln(%s)", value.toString()), ln.toString());
+  }
+
+  /**
+   * Test ln with invalid value.
+   */
+  @ParameterizedTest(name = "ln({0})")
+  @ValueSource(doubles = {0D, -3D})
+  public void ln_invalid_value(Double value) {
+    FunctionExpression ln = DSL.ln(DSL.literal(value));
+    assertEquals(DOUBLE, ln.type());
+    assertTrue(ln.valueOf(valueEnv()).isNull());
   }
 
   /**
@@ -854,6 +872,17 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
   }
 
   /**
+   * Test log with 1 invalid value.
+   */
+  @ParameterizedTest(name = "log({0})")
+  @ValueSource(doubles = {0D, -3D})
+  public void log_invalid_value(Double value) {
+    FunctionExpression log = DSL.log(DSL.literal(value));
+    assertEquals(DOUBLE, log.type());
+    assertTrue(log.valueOf(valueEnv()).isNull());
+  }
+
+  /**
    * Test log with 1 null value argument.
    */
   @Test
@@ -929,6 +958,17 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
         getDoubleValue(log.valueOf(valueEnv())),
         closeTo(Math.log(v2) / Math.log(v1), 0.0001));
     assertEquals(String.format("log(%s, %s)", v1.toString(), v2.toString()), log.toString());
+  }
+
+  /**
+   * Test log with 2 invalid double arguments.
+   */
+  @ParameterizedTest(name = "log({0}, {2})")
+  @MethodSource("testLogInvalidDoubleArguments")
+  public void log_two_invalid_double_value(Double v1, Double v2) {
+    FunctionExpression log = DSL.log(DSL.literal(v1), DSL.literal(v2));
+    assertEquals(log.type(), DOUBLE);
+    assertTrue(log.valueOf(valueEnv()).isNull());
   }
 
   /**
@@ -1052,6 +1092,17 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
   }
 
   /**
+   * Test log10 with 1 invalid double argument.
+   */
+  @ParameterizedTest(name = "log10({0})")
+  @ValueSource(doubles = {0D, -3D})
+  public void log10_two_invalid_value(Double v) {
+    FunctionExpression log = DSL.log10(DSL.literal(v));
+    assertEquals(log.type(), DOUBLE);
+    assertTrue(log.valueOf(valueEnv()).isNull());
+  }
+
+  /**
    * Test log10 with null value.
    */
   @Test
@@ -1131,6 +1182,17 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
         closeTo(Math.log(v) / Math.log(2), 0.0001)
     );
     assertEquals(String.format("log2(%s)", v.toString()), log.toString());
+  }
+
+  /**
+   * Test log2 with an invalid double value.
+   */
+  @ParameterizedTest(name = "log2({0})")
+  @ValueSource(doubles = {0D, -2D})
+  public void log2_invalid_double_value(Double v) {
+    FunctionExpression log = DSL.log2(DSL.literal(v));
+    assertEquals(log.type(), DOUBLE);
+    assertTrue(log.valueOf(valueEnv()).isNull());
   }
 
   /**

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -82,10 +82,9 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
   }
 
   private static Stream<Arguments> testLogInvalidDoubleArguments() {
-    Stream.Builder<Arguments> builder = Stream.builder();
-    return builder.add(Arguments.of(0D, -2D))
-        .add(Arguments.of(0D, 2D))
-        .add(Arguments.of(2D, 0D)).build();
+    return Stream.of(Arguments.of(0D, -2D),
+        Arguments.of(0D, 2D),
+        Arguments.of(2D, 0D));
   }
 
   private static Stream<Arguments> trigonometricArguments() {

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
@@ -197,19 +197,6 @@ public class MathematicalFunctionIT extends SQLIntegTestCase {
     verifyDataRows(result, rows(Math.atan2(2, 3)));
   }
 
-  protected JSONObject executeQuery(String query) throws IOException {
-    Request request = new Request("POST", QUERY_API_ENDPOINT);
-    request.setJsonEntity(String.format(Locale.ROOT, "{\n" + "  \"query\": \"%s\"\n" + "}", query));
-
-    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
-    restOptionsBuilder.addHeader("Content-Type", "application/json");
-    request.setOptions(restOptionsBuilder);
-
-    Response response = client().performRequest(request);
-    return new JSONObject(getResponseBody(response));
-  }
-
-
   @Test
   public void testCbrt() throws IOException {
     JSONObject result = executeQuery("select cbrt(8)");
@@ -223,5 +210,53 @@ public class MathematicalFunctionIT extends SQLIntegTestCase {
     result = executeQuery("select cbrt(-27)");
     verifySchema(result, schema("cbrt(-27)", "double"));
     verifyDataRows(result, rows(-3.0));
+  }
+
+  @Test
+  public void testLnReturnsNull() throws IOException {
+    JSONObject result = executeQuery("select ln(0), ln(-2)");
+    verifySchema(result,
+        schema("ln(0)", "double"),
+        schema("ln(-2)", "double"));
+    verifyDataRows(result, rows(null, null));
+  }
+
+  @Test
+  public void testLogReturnsNull() throws IOException {
+    JSONObject result = executeQuery("select log(0), log(-2)");
+    verifySchema(result,
+        schema("log(0)", "double"),
+        schema("log(-2)", "double"));
+    verifyDataRows(result, rows(null, null));
+  }
+
+  @Test
+  public void testLog10ReturnsNull() throws IOException {
+    JSONObject result = executeQuery("select log10(0), log10(-2)");
+    verifySchema(result,
+        schema("log10(0)", "double"),
+        schema("log10(-2)", "double"));
+    verifyDataRows(result, rows(null, null));
+  }
+
+  @Test
+  public void testLog2ReturnsNull() throws IOException {
+    JSONObject result = executeQuery("select log2(0), log2(-2)");
+    verifySchema(result,
+        schema("log2(0)", "double"),
+        schema("log2(-2)", "double"));
+    verifyDataRows(result, rows(null, null));
+  }
+
+  protected JSONObject executeQuery(String query) throws IOException {
+    Request request = new Request("POST", QUERY_API_ENDPOINT);
+    request.setJsonEntity(String.format(Locale.ROOT, "{\n" + "  \"query\": \"%s\"\n" + "}", query));
+
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+
+    Response response = client().performRequest(request);
+    return new JSONObject(getResponseBody(response));
   }
 }


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guian.gumpac@improving.com>

### Description
Modified `ln`, `log`, `log10`, and `log2` functions to return `null` when the Math functions return `NaN`.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1280
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).