### PR TITLE
Adding support for NESTED in WHERE clause

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -8,8 +8,6 @@ package org.opensearch.sql.analysis;
 
 import static org.opensearch.sql.ast.dsl.AstDSL.and;
 import static org.opensearch.sql.ast.dsl.AstDSL.compare;
-import static org.opensearch.sql.expression.function.BuiltinFunctionName.GTE;
-import static org.opensearch.sql.expression.function.BuiltinFunctionName.LTE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -49,13 +47,11 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.When;
 import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.expression.Xor;
-import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.HighlightExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -55,6 +55,7 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.HighlightExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
@@ -325,17 +326,6 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
     ReferenceExpression ref = DSL.ref(ident,
         typeEnv.resolve(new Symbol(Namespace.FIELD_NAME, ident)));
 
-    // Fall back to old engine too if type is not supported semantically
-    if (isTypeNotSupported(ref.type())) {
-      throw new SyntaxCheckException(String.format(
-          "Identifier [%s] of type [%s] is not supported yet", ident, ref.type()));
-    }
     return ref;
   }
-
-  // Array type is not supporte yet.
-  private boolean isTypeNotSupported(ExprType type) {
-    return "array".equalsIgnoreCase(type.typeName());
-  }
-
 }

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -90,13 +90,15 @@ public class QueryService {
    * Analyze {@link UnresolvedPlan}.
    */
   public LogicalPlan analyze(UnresolvedPlan plan) {
-    return analyzer.analyze(plan, new AnalysisContext());
+    var ret = analyzer.analyze(plan, new AnalysisContext());
+    return ret;
   }
 
   /**
    * Translate {@link LogicalPlan} to {@link PhysicalPlan}.
    */
   public PhysicalPlan plan(LogicalPlan plan) {
-    return planner.plan(plan);
+    var ret = planner.plan(plan);
+    return ret;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -90,15 +90,13 @@ public class QueryService {
    * Analyze {@link UnresolvedPlan}.
    */
   public LogicalPlan analyze(UnresolvedPlan plan) {
-    var ret = analyzer.analyze(plan, new AnalysisContext());
-    return ret;
+    return analyzer.analyze(plan, new AnalysisContext());
   }
 
   /**
    * Translate {@link LogicalPlan} to {@link PhysicalPlan}.
    */
   public PhysicalPlan plan(LogicalPlan plan) {
-    var ret = planner.plan(plan);
-    return ret;
+    return planner.plan(plan);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -97,6 +97,7 @@ public class QueryService {
    * Translate {@link LogicalPlan} to {@link PhysicalPlan}.
    */
   public PhysicalPlan plan(LogicalPlan plan) {
-    return planner.plan(plan);
+    var ret = planner.plan(plan);
+    return ret;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/nested/NestedFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/nested/NestedFunctions.java
@@ -3,15 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.expression.nested;
-
-import lombok.experimental.UtilityClass;
-import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.expression.function.BuiltinFunctionName;
-import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
-import org.opensearch.sql.expression.function.DefaultFunctionResolver;
-import org.opensearch.sql.expression.function.FunctionDSL;
 
 import static org.opensearch.sql.data.type.ExprCoreType.ARRAY;
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
@@ -29,6 +21,15 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
 import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 
+import lombok.experimental.UtilityClass;
+import org.opensearch.sql.data.model.ExprCollectionValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.DefaultFunctionResolver;
+import org.opensearch.sql.expression.function.FunctionDSL;
+import java.util.List;
+
 @UtilityClass
 public class NestedFunctions {
   public static void register(BuiltinFunctionRepository repository) {
@@ -38,38 +39,48 @@ public class NestedFunctions {
   private static DefaultFunctionResolver nested() {
     return FunctionDSL.define(BuiltinFunctionName.NESTED.getName(),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), BYTE, BYTE),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), BYTE, BYTE),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), SHORT, SHORT),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), SHORT, SHORT),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), INTEGER, INTEGER),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), INTEGER, INTEGER),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), LONG, LONG),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), LONG, LONG),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), FLOAT, FLOAT),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), FLOAT, FLOAT),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), DOUBLE, DOUBLE),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), DOUBLE, DOUBLE),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), STRING, STRING),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), STRING, STRING),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), BOOLEAN, BOOLEAN),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), BOOLEAN, BOOLEAN),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), DATE, DATE),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), DATE, DATE),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), TIME, TIME),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), TIME, TIME),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), DATETIME, DATETIME),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), DATETIME, DATETIME),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), TIMESTAMP, TIMESTAMP),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), TIMESTAMP, TIMESTAMP),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), INTERVAL, INTERVAL),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), INTERVAL, INTERVAL),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), STRUCT, STRUCT),
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), STRUCT, STRUCT),
         FunctionDSL.impl(
-            FunctionDSL.nullMissingHandling(NestedFunctions::nested_returns_val), ARRAY, ARRAY));
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), ARRAY, ARRAY),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_single_param), STRING, ARRAY),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_double_param), STRING, STRING, ARRAY),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(NestedFunctions::nested_double_param), BOOLEAN, ARRAY, BOOLEAN));
   }
 
-  private ExprValue nested_returns_val(ExprValue field) {
+  private ExprValue nested_single_param(ExprValue field) {
     return field;
+  }
+
+  private ExprValue nested_double_param(ExprValue field1, ExprValue field2) {
+    return new ExprCollectionValue(List.of(field1, field2));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -5,24 +5,46 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
+import java.util.List;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
-import java.io.IOException;
-
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_MULTI_NESTED;
-
 public class NestedIT extends SQLIntegTestCase {
   @Override
   public void init() throws IOException {
-    loadIndex(Index.MULTI_NESTED);
+    loadIndex(Index.NESTED);
   }
 
   @Test
   public void nested_string_subfield_test() {
-    String query = "SELECT nested(message.info) FROM " + TEST_INDEX_MULTI_NESTED;
+    String query = "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
-    assertEquals(6, result.getInt("total"));
+    assertEquals(5, result.getInt("total"));
+  }
+
+  @Test
+  public void test_nested_where_with_and_conditional() {
+    String query = "SELECT nested(message.info), nested(message.author) FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message, message.info = 'a' AND message.author = 'e')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows("a", "e"));
+  }
+
+  @Test
+  public void test_nested_where_as_predicate_expression() {
+    String query = "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message.info) = 'a'";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(2, result.getInt("total"));
+    // Returns whole array with each containing 'message.info'. Maybe not how we want to handle in future.
+    verifyDataRows(result, rows("a"), rows(new JSONArray(List.of("c", "a"))));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -19,6 +19,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.ScriptQueryBuilder;
 import org.opensearch.script.Script;
+import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionNodeVisitor;
 import org.opensearch.sql.expression.FunctionExpression;
@@ -26,6 +27,7 @@ import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LikeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.NestedQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery.Comparison;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.TermQuery;
@@ -75,6 +77,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName(), new MatchPhrasePrefixQuery())
           .put(BuiltinFunctionName.WILDCARD_QUERY.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.WILDCARDQUERY.getName(), new WildcardQuery())
+          .put(BuiltinFunctionName.NESTED.getName(), new NestedQuery())
           .build();
 
   /**
@@ -98,7 +101,15 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
         return buildBoolQuery(func, context, BoolQueryBuilder::mustNot);
       default: {
         LuceneQuery query = luceneQueries.get(name);
-        if (query != null && query.canSupport(func)) {
+        // Nested used in predicate expression with syntax 'WHERE nested(field | field, path) = ...'
+        //TODO Can we interpret nested used in predicate expression as NestedQuery?
+        if (func.getArguments().get(0) instanceof FunctionExpression) {
+          return query.build(func, BoolQueryBuilder::filter);
+        // Nested used with syntax 'WHERE nested(path, condition)'
+        } else if (name.getFunctionName().equalsIgnoreCase(BuiltinFunctionName.NESTED.name())) {
+          // TODO Throw exception if does not have conditional parameter.
+          return query.build(func, BoolQueryBuilder::filter);
+        } else if (query != null && query.canSupport(func)) {
           return query.build(func);
         }
         return buildScriptQuery(func);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -17,7 +17,6 @@ import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.sql.data.model.ExprBooleanValue;
 import org.opensearch.sql.data.model.ExprByteValue;
 import org.opensearch.sql.data.model.ExprDateValue;
@@ -255,6 +254,7 @@ public abstract class LuceneQuery {
         "Subclass doesn't implement this and build method either");
   }
 
+  // TODO Maybe overload doBuild for override in NestedQuery?
   protected QueryBuilder doBuildNested(FunctionExpression fieldName, ExprValue literal) {
     throw new UnsupportedOperationException(
         "Subclass doesn't implement this and build method either");

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+
+public class NestedQuery extends LuceneQuery {
+  @Override
+  protected QueryBuilder doBuild(FunctionExpression predicate, ReferenceExpression path) {
+    String fieldName = convertTextToKeyword(predicate.getArguments().get(0).toString(), predicate.getArguments().get(1).type());
+    TermQueryBuilder termQuery = QueryBuilders.termQuery(fieldName, value(predicate.getArguments().get(1).valueOf()));
+    NestedQueryBuilder nestedQueryBuilder =  QueryBuilders.nestedQuery(path.toString(), termQuery, ScoreMode.None);
+    return nestedQueryBuilder;
+  }
+
+  private Object value(ExprValue literal) {
+    if (literal.type().equals(ExprCoreType.TIMESTAMP)) {
+      return literal.timestampValue().toEpochMilli();
+    } else {
+      return literal.value();
+    }
+  }
+
+  /**
+   *
+   */
+  protected NestedQueryBuilder createBuilder(String field) {
+    return QueryBuilders.nestedQuery(field, matchAllQuery(), ScoreMode.None);
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
@@ -33,11 +33,4 @@ public class NestedQuery extends LuceneQuery {
       return literal.value();
     }
   }
-
-  /**
-   *
-   */
-  protected NestedQueryBuilder createBuilder(String field) {
-    return QueryBuilders.nestedQuery(field, matchAllQuery(), ScoreMode.None);
-  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
@@ -15,8 +15,6 @@ import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 
-import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
-
 public class NestedQuery extends LuceneQuery {
   @Override
   protected QueryBuilder doBuild(FunctionExpression predicate, ReferenceExpression path) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/TermQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/TermQuery.java
@@ -6,11 +6,15 @@
 
 package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 
+import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 
 /**
  * Lucene query that build term query for equality comparison.
@@ -21,6 +25,21 @@ public class TermQuery extends LuceneQuery {
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
     fieldName = convertTextToKeyword(fieldName, fieldType);
     return QueryBuilders.termQuery(fieldName, value(literal));
+  }
+
+  @Override
+  protected QueryBuilder doBuildNested(FunctionExpression field, ExprValue literal) {
+    // TODO Can we move this to NestedQuery?
+    return QueryBuilders.nestedQuery(getNestedPathString((ReferenceExpression) field.getArguments().get(0)),
+        doBuild(field.getArguments().get(0).toString(), field.getArguments().get(0).type(), literal), ScoreMode.None);
+  }
+
+  private String getNestedPathString(ReferenceExpression field) {
+    String ret = "";
+    for (int i = 0; i < field.getPaths().size() - 1; i++) {
+      ret +=  (i == 0) ? field.getPaths().get(i) : "." + field.getPaths().get(i);
+    }
+    return ret;
   }
 
   private Object value(ExprValue literal) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/TermQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/TermQuery.java
@@ -29,7 +29,7 @@ public class TermQuery extends LuceneQuery {
 
   @Override
   protected QueryBuilder doBuildNested(FunctionExpression field, ExprValue literal) {
-    // TODO Can we move this to NestedQuery?
+    // TODO Can we move this to NestedQuery::doBuild()?
     return QueryBuilders.nestedQuery(getNestedPathString((ReferenceExpression) field.getArguments().get(0)),
         doBuild(field.getArguments().get(0).toString(), field.getArguments().get(0).type(), literal), ScoreMode.None);
   }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -319,11 +319,11 @@ nestedFunction
     ;
 
 nestedField
-    : ID DOT ID (DOT ID)*
+    : nestedIdent DOT nestedIdent (DOT nestedIdent)*
     ;
 
 nestedPath
-    : ID (DOT ID)*
+    : nestedIdent (DOT nestedIdent)*
     ;
 
 highlightFunction
@@ -625,6 +625,13 @@ qualifiedName
 
 ident
     : DOT? ID
+    | BACKTICK_QUOTE_ID
+    | keywordsCanBeId
+    | scalarFunctionName
+    ;
+
+nestedIdent
+    : ID
     | BACKTICK_QUOTE_ID
     | keywordsCanBeId
     | scalarFunctionName

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -313,11 +313,17 @@ functionCall
     ;
 
 nestedFunction
-    : NESTED LR_BRACKET nestedField RR_BRACKET
+    : NESTED LR_BRACKET
+    (nestedField | nestedField COMMA nestedPath | nestedPath COMMA expression)
+    RR_BRACKET
     ;
 
 nestedField
     : ID DOT ID (DOT ID)*
+    ;
+
+nestedPath
+    : ID (DOT ID)*
     ;
 
 highlightFunction


### PR DESCRIPTION
Signed-off-by: forestmvey <forestv@bitquilltech.com>

### Description
POC for supporting nested function in WHERE clause. 

### Syntax
`nested( field | field, path | path, condition )`

### Sample Queries
```
SELECT * FROM nested_objects WHERE nested(message, message.info = 'a' AND message.author = 'e');
SELECT * FROM nested_objects WHERE nested(message.info) = 'a';
```

### Legacy Bugs
SELECT * FROM nested_objects WHERE nested(message, message.info = 'a') = 'b';

```json
{
    "from": 0,
    "size": 200,
    "query": {
        "bool": {
            "filter": [
                {
                    "bool": {
                        "must": [
                            {
                                "nested": {
                                    "query": {
                                        "term": {
                                            "message": {
                                                "value": "b",
                                                "boost": 1.0
                                            }
                                        }
                                    },
                                    "path": "message",
                                    "ignore_unmapped": false,
                                    "score_mode": "none",
                                    "boost": 1.0
                                }
                            }
                        ],
                        "adjust_pure_negative": true,
                        "boost": 1.0
                    }
                }
            ],
            "adjust_pure_negative": true,
            "boost": 1.0
        }
    }
}
```


### Added Functionality Over Legacy
- Nested function used in WHERE clause as a predicate expression must not include the optional `condition` parameter.
- Nested function used in WHERE clause not as a predicate expression must include the `condition` parameter.
- Added support in V2 engine for predicate expression of FunctionExpression on left and LiteralExpression on right.

### TODO list
- Move query building for NestedQuery from TermQuery to NestedQuery for predicate expressions.
- Add exceptions for incorrect uses of nested function in WHERE clause.

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).