### PR TITLE
Pagination, phase 1: Add unit tests for SQL module with coverage.

### DIFF
--- a/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
@@ -13,6 +13,7 @@ import org.opensearch.sql.ast.statement.Statement;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.executor.QueryId;
 import org.opensearch.sql.executor.QueryManager;
 import org.opensearch.sql.executor.execution.AbstractPlan;
 import org.opensearch.sql.executor.execution.QueryPlanFactory;
@@ -68,9 +69,19 @@ public class SQLService {
     if (request.getCursor().isPresent()) {
       // Handle v2 cursor here -- legacy cursor was handled earlier.
       if (queryListener.isEmpty() && explainListener.isPresent()) { // explain request
+        // TODO explain should be processed inside the plan
         explainListener.get().onFailure(new UnsupportedOperationException(
             "`explain` request for cursor requests is not supported. "
             + "Use `explain` for the initial query request."));
+        return new AbstractPlan(QueryId.queryId()) {
+          @Override
+          public void execute() {
+          }
+
+          @Override
+          public void explain(ResponseListener<ExplainResponse> listener) {
+          }
+        };
       }
       // non-explain request
       return queryExecutionFactory.create(request.getCursor().get(), queryListener.get());

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -93,7 +93,7 @@ public class SQLQueryRequest {
     var noContent = jsonContent == null || jsonContent.isEmpty();
 
     return ((!noCursor && noQuery && noParams && noContent) // if cursor is given, but other things
-        || (noCursor && !noQuery))                          // of if cursor is not given, but query
+        || (noCursor && !noQuery))                          // or if cursor is not given, but query
         && isOnlySupportedFieldInPayload()        // and request has supported fields only
         && isSupportedFormat();                   // and request is in supported format
   }

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -6,13 +6,12 @@
 
 package org.opensearch.sql.sql.domain;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -64,7 +63,7 @@ public class SQLQueryRequest {
   @Accessors(fluent = true)
   private boolean sanitize = true;
 
-  private String cursor = "";
+  private String cursor;
 
   /**
    * Constructor of SQLQueryRequest that passes request params.
@@ -77,8 +76,7 @@ public class SQLQueryRequest {
     this.params = params;
     this.format = getFormat(params);
     this.sanitize = shouldSanitize(params);
-    // TODO hack
-    this.cursor = cursor == null ? "" : cursor;
+    this.cursor = cursor;
   }
 
   /**
@@ -86,20 +84,27 @@ public class SQLQueryRequest {
    *  1.Only supported fields present in request body, ex. "filter" and "cursor" are not supported
    *  2.Response format is default or can be supported.
    *
-   * @return  true if supported.
+   * @return true if supported.
    */
   public boolean isSupported() {
-    return (isCursor() || isOnlySupportedFieldInPayload())
-        && isSupportedFormat();
+    var noCursor = !isCursor();
+    var noQuery = query == null;
+    var noParams = params.isEmpty();
+    var noContent = jsonContent == null || jsonContent.isEmpty();
+
+    return ((!noCursor && noQuery && noParams && noContent) // if cursor is given, but other things
+        || (noCursor && !noQuery))                          // of if cursor is not given, but query
+        && isOnlySupportedFieldInPayload()        // and request has supported fields only
+        && isSupportedFormat();                   // and request is in supported format
   }
 
   private boolean isCursor() {
-    return cursor != null &&  cursor.isEmpty() == false;
+    return cursor != null && !cursor.isEmpty();
   }
 
   /**
    * Check if request is to explain rather than execute the query.
-   * @return  true if it is a explain request
+   * @return true if it is an explain request
    */
   public boolean isExplainRequest() {
     return path.endsWith("/_explain");
@@ -122,13 +127,8 @@ public class SQLQueryRequest {
     return jsonContent == null || SUPPORTED_FIELDS.containsAll(jsonContent.keySet());
   }
 
-
   public Optional<String> getCursor() {
-    return cursor != "" ? Optional.of(cursor) : Optional.empty();
-  }
-
-  public boolean mayReturnCursor() {
-    return cursor != "" || getFetchSize() > 0;
+    return Optional.ofNullable(cursor);
   }
 
   public int getFetchSize() {
@@ -136,15 +136,11 @@ public class SQLQueryRequest {
   }
 
   private boolean isSupportedFormat() {
-    return Strings.isNullOrEmpty(format) || "jdbc".equalsIgnoreCase(format)
-        || "csv".equalsIgnoreCase(format) || "raw".equalsIgnoreCase(format);
+    return Stream.of("csv", "jdbc", "raw").anyMatch(format::equalsIgnoreCase);
   }
 
   private String getFormat(Map<String, String> params) {
-    if (params.containsKey(QUERY_PARAMS_FORMAT)) {
-      return params.get(QUERY_PARAMS_FORMAT);
-    }
-    return "jdbc";
+    return params.getOrDefault(QUERY_PARAMS_FORMAT, "jdbc");
   }
 
   private boolean shouldSanitize(Map<String, String> params) {

--- a/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
@@ -7,16 +7,19 @@
 package org.opensearch.sql.sql;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -30,11 +33,11 @@ import org.opensearch.sql.executor.PaginatedPlanCache;
 import org.opensearch.sql.executor.QueryService;
 import org.opensearch.sql.executor.execution.PaginatedQueryService;
 import org.opensearch.sql.executor.execution.QueryPlanFactory;
-import org.opensearch.sql.opensearch.executor.Cursor;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
 import org.opensearch.sql.sql.domain.SQLQueryRequest;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SQLServiceTest {
 
   private static String QUERY = "/_plugins/_sql";
@@ -52,9 +55,6 @@ class SQLServiceTest {
   private PaginatedQueryService paginatedQueryService;
 
   @Mock
-  private ExecutionEngine.Schema schema;
-
-  @Mock
   private PaginatedPlanCache paginatedPlanCache;
 
   @BeforeEach
@@ -70,13 +70,7 @@ class SQLServiceTest {
   }
 
   @Test
-  public void canExecuteSqlQuery() {
-    doAnswer(invocation -> {
-      ResponseListener<QueryResponse> listener = invocation.getArgument(1);
-      listener.onResponse(new QueryResponse(schema, Collections.emptyList(), Cursor.None));
-      return null;
-    }).when(queryService).execute(any(), any());
-
+  public void can_execute_sql_query() {
     sqlService.execute(
         new SQLQueryRequest(new JSONObject(), "SELECT 123", QUERY, "jdbc"),
         new ResponseListener<>() {
@@ -93,13 +87,24 @@ class SQLServiceTest {
   }
 
   @Test
-  public void canExecuteCsvFormatRequest() {
-    doAnswer(invocation -> {
-      ResponseListener<QueryResponse> listener = invocation.getArgument(1);
-      listener.onResponse(new QueryResponse(schema, Collections.emptyList(), Cursor.None));
-      return null;
-    }).when(queryService).execute(any(), any());
+  public void can_execute_cursor_query() {
+    sqlService.execute(
+        new SQLQueryRequest(new JSONObject(), null, QUERY, Map.of("format", "jdbc"), "n:cursor"),
+        new ResponseListener<>() {
+          @Override
+          public void onResponse(QueryResponse response) {
+            assertNotNull(response);
+          }
 
+          @Override
+          public void onFailure(Exception e) {
+            fail(e);
+          }
+        });
+  }
+
+  @Test
+  public void can_execute_csv_format_request() {
     sqlService.execute(
         new SQLQueryRequest(new JSONObject(), "SELECT 123", QUERY, "csv"),
         new ResponseListener<QueryResponse>() {
@@ -116,7 +121,7 @@ class SQLServiceTest {
   }
 
   @Test
-  public void canExplainSqlQuery() {
+  public void can_explain_sql_query() {
     doAnswer(invocation -> {
       ResponseListener<ExplainResponse> listener = invocation.getArgument(1);
       listener.onResponse(new ExplainResponse(new ExplainResponseNode("Test")));
@@ -138,7 +143,25 @@ class SQLServiceTest {
   }
 
   @Test
-  public void canCaptureErrorDuringExecution() {
+  public void cannot_explain_cursor_query() {
+    sqlService.explain(new SQLQueryRequest(new JSONObject(), null, EXPLAIN,
+            Map.of("format", "jdbc"), "n:cursor"),
+        new ResponseListener<ExplainResponse>() {
+          @Override
+          public void onResponse(ExplainResponse response) {
+            fail(response.toString());
+          }
+
+          @Override
+          public void onFailure(Exception e) {
+            assertTrue(e.getMessage()
+                .contains("`explain` request for cursor requests is not supported."));
+          }
+        });
+  }
+
+  @Test
+  public void can_capture_error_during_execution() {
     sqlService.execute(
         new SQLQueryRequest(new JSONObject(), "SELECT", QUERY, ""),
         new ResponseListener<QueryResponse>() {
@@ -155,7 +178,7 @@ class SQLServiceTest {
   }
 
   @Test
-  public void canCaptureErrorDuringExplain() {
+  public void can_capture_error_during_explain() {
     sqlService.explain(
         new SQLQueryRequest(new JSONObject(), "SELECT", EXPLAIN, ""),
         new ResponseListener<ExplainResponse>() {
@@ -170,5 +193,4 @@ class SQLServiceTest {
           }
         });
   }
-
 }

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -6,38 +6,43 @@
 
 package org.opensearch.sql.sql.domain;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.protocol.response.format.Format;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class SQLQueryRequestTest {
 
   @Test
-  public void shouldSupportQuery() {
+  public void should_support_query() {
     SQLQueryRequest request = SQLQueryRequestBuilder.request("SELECT 1").build();
     assertTrue(request.isSupported());
   }
 
   @Test
-  public void shouldSupportQueryWithJDBCFormat() {
+  public void should_support_query_with_JDBC_format() {
     SQLQueryRequest request = SQLQueryRequestBuilder.request("SELECT 1")
                                                     .format("jdbc")
                                                     .build();
-    assertTrue(request.isSupported());
-    assertEquals(request.format(), Format.JDBC);
+    assertAll(
+        () -> assertTrue(request.isSupported()),
+        () -> assertEquals(request.format(), Format.JDBC)
+    );
   }
 
   @Test
-  public void shouldSupportQueryWithQueryFieldOnly() {
+  public void should_support_query_with_query_field_only() {
     SQLQueryRequest request =
         SQLQueryRequestBuilder.request("SELECT 1")
                               .jsonContent("{\"query\": \"SELECT 1\"}")
@@ -46,16 +51,32 @@ public class SQLQueryRequestTest {
   }
 
   @Test
-  public void shouldSupportQueryWithParameters() {
-    SQLQueryRequest request =
+  public void should_support_query_with_parameters() {
+    SQLQueryRequest requestWithContent =
         SQLQueryRequestBuilder.request("SELECT 1")
             .jsonContent("{\"query\": \"SELECT 1\", \"parameters\":[]}")
             .build();
-    assertTrue(request.isSupported());
+    SQLQueryRequest requestWithParams =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .params(Map.of("one", "two"))
+            .build();
+    assertAll(
+        () -> assertTrue(requestWithContent.isSupported()),
+        () -> assertTrue(requestWithParams.isSupported())
+    );
   }
 
   @Test
-  public void shouldSupportQueryWithZeroFetchSize() {
+  public void should_support_query_without_parameters() {
+    SQLQueryRequest requestWithNoParams =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .params(Map.of())
+            .build();
+    assertTrue(requestWithNoParams.isSupported());
+  }
+
+  @Test
+  public void should_support_query_with_zero_fetch_size() {
     SQLQueryRequest request =
         SQLQueryRequestBuilder.request("SELECT 1")
                               .jsonContent("{\"query\": \"SELECT 1\", \"fetch_size\": 0}")
@@ -64,7 +85,7 @@ public class SQLQueryRequestTest {
   }
 
   @Test
-  public void shouldSupportQueryWithParametersAndZeroFetchSize() {
+  public void should_support_query_with_parameters_and_zero_fetch_size() {
     SQLQueryRequest request =
         SQLQueryRequestBuilder.request("SELECT 1")
             .jsonContent("{\"query\": \"SELECT 1\", \"fetch_size\": 0, \"parameters\":[]}")
@@ -73,71 +94,143 @@ public class SQLQueryRequestTest {
   }
 
   @Test
-  public void shouldSupportExplain() {
+  public void should_support_explain() {
     SQLQueryRequest explainRequest =
         SQLQueryRequestBuilder.request("SELECT 1")
                               .path("_plugins/_sql/_explain")
                               .build();
-    assertTrue(explainRequest.isExplainRequest());
-    assertTrue(explainRequest.isSupported());
+
+    assertAll(
+        () -> assertTrue(explainRequest.isExplainRequest()),
+        () -> assertTrue(explainRequest.isSupported())
+    );
   }
 
   @Test
-  @Disabled("SQLQueryRequest does support cursor requests")
-  public void shouldNotSupportCursorRequest() {
+  public void should_support_cursor_request() {
     SQLQueryRequest fetchSizeRequest =
         SQLQueryRequestBuilder.request("SELECT 1")
                               .jsonContent("{\"query\": \"SELECT 1\", \"fetch_size\": 5}")
                               .build();
-    assertFalse(fetchSizeRequest.isSupported());
 
     SQLQueryRequest cursorRequest =
-        SQLQueryRequestBuilder.request("SELECT 1")
-                              .jsonContent("{\"cursor\": \"abcdefgh...\"}")
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("abcdefgh...")
                               .build();
-    assertFalse(cursorRequest.isSupported());
+
+    assertAll(
+        () -> assertTrue(fetchSizeRequest.isSupported()),
+        () -> assertTrue(cursorRequest.isSupported())
+    );
   }
 
   @Test
-  public void shouldUseJDBCFormatByDefault() {
+  public void should_not_support_request_with_empty_cursor() {
+    SQLQueryRequest requestWithEmptyCursor =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("")
+                              .build();
+    SQLQueryRequest requestWithNullCursor =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor(null)
+                              .build();
+    assertAll(
+        () -> assertFalse(requestWithEmptyCursor.isSupported()),
+        () -> assertFalse(requestWithNullCursor.isSupported())
+    );
+  }
+
+  @Test
+  public void should_not_support_request_with_unknown_field() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+                              .jsonContent("{\"pewpew\": 42}")
+                              .build();
+    assertFalse(request.isSupported());
+  }
+
+  @Test
+  public void should_not_support_request_with_cursor_and_something_else() {
+    SQLQueryRequest requestWithQuery =
+        SQLQueryRequestBuilder.request("SELECT 1")
+                              .cursor("n:12356")
+                              .build();
+    SQLQueryRequest requestWithParams =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("n:12356")
+                              .params(Map.of("one", "two"))
+                              .build();
+    SQLQueryRequest requestWithFetchSize =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("n:12356")
+                              .jsonContent("{\"fetch_size\": 5}")
+                              .build();
+    SQLQueryRequest requestWithNoParams =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("n:12356")
+                              .params(Map.of())
+                              .build();
+    SQLQueryRequest requestWithNoContent =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("n:12356")
+                              .jsonContent("{}")
+                              .build();
+    assertAll(
+        () -> assertFalse(requestWithQuery.isSupported()),
+        () -> assertFalse(requestWithParams.isSupported()),
+        () -> assertFalse(requestWithFetchSize.isSupported()),
+        () -> assertTrue(requestWithNoParams.isSupported()),
+        () -> assertTrue(requestWithNoContent.isSupported())
+    );
+  }
+
+  @Test
+  public void should_use_JDBC_format_by_default() {
     SQLQueryRequest request =
         SQLQueryRequestBuilder.request("SELECT 1").params(ImmutableMap.of()).build();
     assertEquals(request.format(), Format.JDBC);
   }
 
   @Test
-  public void shouldSupportCSVFormatAndSanitize() {
+  public void should_support_CSV_format_and_sanitize() {
     SQLQueryRequest csvRequest =
         SQLQueryRequestBuilder.request("SELECT 1")
                               .format("csv")
                               .build();
-    assertTrue(csvRequest.isSupported());
-    assertEquals(csvRequest.format(), Format.CSV);
-    assertTrue(csvRequest.sanitize());
+    assertAll(
+        () -> assertTrue(csvRequest.isSupported()),
+        () -> assertEquals(csvRequest.format(), Format.CSV),
+        () -> assertTrue(csvRequest.sanitize())
+    );
   }
 
   @Test
-  public void shouldSkipSanitizeIfSetFalse() {
+  public void should_skip_sanitize_if_set_false() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     Map<String, String> params = builder.put("format", "csv").put("sanitize", "false").build();
     SQLQueryRequest csvRequest = SQLQueryRequestBuilder.request("SELECT 1").params(params).build();
-    assertEquals(csvRequest.format(), Format.CSV);
-    assertFalse(csvRequest.sanitize());
+    assertAll(
+        () -> assertEquals(csvRequest.format(), Format.CSV),
+        () -> assertFalse(csvRequest.sanitize())
+    );
   }
 
   @Test
-  public void shouldNotSupportOtherFormat() {
+  public void should_not_support_other_format() {
     SQLQueryRequest csvRequest =
         SQLQueryRequestBuilder.request("SELECT 1")
             .format("other")
             .build();
-    assertFalse(csvRequest.isSupported());
-    assertThrows(IllegalArgumentException.class, csvRequest::format,
-        "response in other format is not supported.");
+
+    assertAll(
+        () -> assertFalse(csvRequest.isSupported()),
+        () -> assertEquals("response in other format is not supported.",
+            assertThrows(IllegalArgumentException.class, csvRequest::format).getMessage())
+    );
   }
 
   @Test
-  public void shouldSupportRawFormat() {
+  public void should_support_raw_format() {
     SQLQueryRequest csvRequest =
             SQLQueryRequestBuilder.request("SELECT 1")
                     .format("raw")
@@ -153,7 +246,8 @@ public class SQLQueryRequestTest {
     private String query;
     private String path = "_plugins/_sql";
     private String format;
-    private Map<String, String> params;
+    private String cursor;
+    private Map<String, String> params = new HashMap<>();
 
     static SQLQueryRequestBuilder request(String query) {
       SQLQueryRequestBuilder builder = new SQLQueryRequestBuilder();
@@ -181,15 +275,17 @@ public class SQLQueryRequestTest {
       return this;
     }
 
+    SQLQueryRequestBuilder cursor(String cursor) {
+      this.cursor = cursor;
+      return this;
+    }
+
     SQLQueryRequest build() {
-      if (jsonContent == null) {
-        jsonContent = "{\"query\": \"" + query + "\"}";
+      if (format != null) {
+        params.put("format", format);
       }
-      if (params != null) {
-        return new SQLQueryRequest(new JSONObject(jsonContent), query, path, params,
-            "");
-      }
-      return new SQLQueryRequest(new JSONObject(jsonContent), query, path, format);
+      return new SQLQueryRequest(jsonContent == null ? null : new JSONObject(jsonContent),
+          query, path, params, cursor);
     }
   }
 


### PR DESCRIPTION
### Description
Add unit tests for SQL module with coverage.
The only uncovered thing remains in `SQLService.java` is https://github.com/Bit-Quill/opensearch-project-sql/blob/2019e84714313784400fdafa8af0e0c359a7378f/sql/src/main/java/org/opensearch/sql/sql/SQLService.java#L71-L75
This entire block will be reworked soon
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).