### PR TITLE
Fallback to v1 engine for pagination

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.sql;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
+import static org.opensearch.sql.util.TestUtils.verifyIsV1Cursor;
+import static org.opensearch.sql.util.TestUtils.verifyIsV2Cursor;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+import org.opensearch.sql.util.TestUtils;
+
+public class PaginationFallbackIT extends SQLIntegTestCase {
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.PHRASE);
+    loadIndex(Index.ONLINE);
+  }
+
+  @Test
+  public void testWhereClause() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM %s WHERE 1 = 1", TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testSelectAll() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM %s", TEST_INDEX_ONLINE);
+    verifyIsV2Cursor(response);
+  }
+
+  @Test
+  public void testSelectWithOpenSearchFuncInFilter() throws IOException {
+    var response = executeQueryTemplate(
+        "SELECT * FROM %s WHERE `11` = match_phrase('96')", TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testSelectWithHighlight() throws IOException {
+    var response = executeQueryTemplate(
+        "SELECT highlight(`11`) FROM %s WHERE match_query(`11`, '96')", TEST_INDEX_ONLINE);
+    // As of 2023-03-08, WHERE clause sends the query to legacy engine and legacy engine
+    // does not support highlight as an expression.
+    assertTrue(response.has("error"));
+  }
+
+  @Test
+  public void testSelectWithFullTextSearch() throws IOException {
+    var response = executeQueryTemplate(
+        "SELECT * FROM %s WHERE match_phrase(`11`, '96')", TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testSelectFromIndexWildcard() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM %s*", TEST_INDEX);
+    verifyIsV2Cursor(response);
+  }
+
+  @Test
+  public void testSelectFromDataSource() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM @opensearch.%s",
+        TEST_INDEX_ONLINE);
+    verifyIsV2Cursor(response);
+  }
+
+  @Test
+  public void testSelectColumnReference() throws IOException {
+    var response = executeQueryTemplate("SELECT `107` from %s", TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testSubquery() throws IOException {
+    var response = executeQueryTemplate("SELECT `107` from (SELECT * FROM %s)",
+        TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testSelectExpression() throws IOException {
+    var response = executeQueryTemplate("SELECT 1 + 1 - `107` from %s",
+        TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testGroupBy() throws IOException {
+    // GROUP BY is not paged by either engine.
+     var response = executeQueryTemplate("SELECT * FROM %s GROUP BY `107`",
+      TEST_INDEX_ONLINE);
+    TestUtils.verifyNoCursor(response);
+  }
+
+  @Test
+  public void testGroupByHaving() throws IOException {
+    // GROUP BY is not paged by either engine.
+    var response = executeQueryTemplate("SELECT * FROM %s GROUP BY `107` HAVING `107` > 400",
+        TEST_INDEX_ONLINE);
+    TestUtils.verifyNoCursor(response);
+  }
+
+  @Test
+  public void testLimit() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM %s LIMIT 8", TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testLimitOffset() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM %s LIMIT 8 OFFSET 4",
+        TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  @Test
+  public void testOrderBy() throws IOException {
+    var response = executeQueryTemplate("SELECT * FROM %s ORDER By `107`",
+        TEST_INDEX_ONLINE);
+    verifyIsV1Cursor(response);
+  }
+
+  private JSONObject executeQueryTemplate(String queryTemplate, String index) throws IOException {
+    var query = String.format(queryTemplate, index);
+    return new JSONObject(executeFetchQuery(query, 4, "jdbc"));
+  }
+
+}

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.sql;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+public class PaginationIT extends SQLIntegTestCase {
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.CALCS);
+    loadIndex(Index.BEER);
+    loadIndex(Index.ONLINE);
+  }
+
+  @Test
+  public void testSmallDataSet() throws IOException {
+    var query = "SELECT * from " + TEST_INDEX_CALCS;
+    var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
+    assertTrue(response.has("cursor"));
+    assertEquals(4, response.getInt("total"));
+    verifyIsV2Cursor(response);
+  }
+
+  @Test
+  public void testLargeDataSet() throws IOException {
+    var query = "SELECT * from " + TEST_INDEX_ONLINE;
+    var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
+    assertTrue(response.has("cursor"));
+    assertEquals(4, response.getInt("total"));
+    verifyIsV2Cursor(response);
+
+    var v1query = "SELECT * from " + TEST_INDEX_ONLINE + " WHERE 1 = 1";
+    var v1response = new JSONObject(executeFetchQuery(v1query, 4, "jdbc"));
+    assertTrue(v1response.has("cursor"));
+    verifyIsV1Cursor(v1response);
+  }
+
+  private void verifyIsV2Cursor(JSONObject response) {
+    if (!response.has("cursor")) {
+      return;
+    }
+
+    var cursor = response.getString("cursor");
+    if (cursor.isEmpty()) {
+      return;
+    }
+    assertTrue("The cursor '" + cursor + "' is not from v2 engine.", cursor.startsWith("n:"));
+  }
+
+  private void verifyIsV1Cursor(JSONObject response) {
+    if (!response.has("cursor")) {
+      return;
+    }
+
+    var cursor = response.getString("cursor");
+    if (cursor.isEmpty()) {
+      return;
+    }
+    assertTrue("The cursor '" + cursor + "' is not from v2 engine.", cursor.startsWith("d:"));
+  }
+
+}

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.sql;
 
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
 
@@ -19,7 +18,6 @@ public class PaginationIT extends SQLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.CALCS);
-    loadIndex(Index.BEER);
     loadIndex(Index.ONLINE);
   }
 
@@ -28,21 +26,23 @@ public class PaginationIT extends SQLIntegTestCase {
     var query = "SELECT * from " + TEST_INDEX_CALCS;
     var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
     assertTrue(response.has("cursor"));
-    assertEquals(4, response.getInt("total"));
+    assertEquals(4, response.getInt("size"));
     TestUtils.verifyIsV2Cursor(response);
   }
 
   @Test
-  public void testLargeDataSet() throws IOException {
-    var query = "SELECT * from " + TEST_INDEX_ONLINE;
-    var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
-    assertTrue(response.has("cursor"));
-    assertEquals(4, response.getInt("total"));
-    TestUtils.verifyIsV2Cursor(response);
-
+  public void testLargeDataSetV1() throws IOException {
     var v1query = "SELECT * from " + TEST_INDEX_ONLINE + " WHERE 1 = 1";
     var v1response = new JSONObject(executeFetchQuery(v1query, 4, "jdbc"));
-    assertTrue(v1response.has("cursor"));
+    assertEquals(4, v1response.getInt("size"));
     TestUtils.verifyIsV1Cursor(v1response);
+  }
+
+  @Test
+  public void testLargeDataSetV2() throws IOException {
+    var query = "SELECT * from " + TEST_INDEX_ONLINE;
+    var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
+    assertEquals(4, response.getInt("size"));
+    TestUtils.verifyIsV2Cursor(response);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
+import org.opensearch.sql.util.TestUtils;
 
 public class PaginationIT extends SQLIntegTestCase {
   @Override
@@ -28,7 +29,7 @@ public class PaginationIT extends SQLIntegTestCase {
     var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
     assertTrue(response.has("cursor"));
     assertEquals(4, response.getInt("total"));
-    verifyIsV2Cursor(response);
+    TestUtils.verifyIsV2Cursor(response);
   }
 
   @Test
@@ -37,36 +38,11 @@ public class PaginationIT extends SQLIntegTestCase {
     var response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
     assertTrue(response.has("cursor"));
     assertEquals(4, response.getInt("total"));
-    verifyIsV2Cursor(response);
+    TestUtils.verifyIsV2Cursor(response);
 
     var v1query = "SELECT * from " + TEST_INDEX_ONLINE + " WHERE 1 = 1";
     var v1response = new JSONObject(executeFetchQuery(v1query, 4, "jdbc"));
     assertTrue(v1response.has("cursor"));
-    verifyIsV1Cursor(v1response);
+    TestUtils.verifyIsV1Cursor(v1response);
   }
-
-  private void verifyIsV2Cursor(JSONObject response) {
-    if (!response.has("cursor")) {
-      return;
-    }
-
-    var cursor = response.getString("cursor");
-    if (cursor.isEmpty()) {
-      return;
-    }
-    assertTrue("The cursor '" + cursor + "' is not from v2 engine.", cursor.startsWith("n:"));
-  }
-
-  private void verifyIsV1Cursor(JSONObject response) {
-    if (!response.has("cursor")) {
-      return;
-    }
-
-    var cursor = response.getString("cursor");
-    if (cursor.isEmpty()) {
-      return;
-    }
-    assertTrue("The cursor '" + cursor + "' is not from v2 engine.", cursor.startsWith("d:"));
-  }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/util/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/TestUtils.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.util;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -838,5 +839,27 @@ public class TestUtils {
     }
 
     return result;
+  }
+
+  public static void verifyIsV1Cursor(JSONObject response) {
+    verifyCursor(response, "d:", "v1");
+  }
+
+
+  public static void verifyIsV2Cursor(JSONObject response) {
+    verifyCursor(response, "n:", "v2");
+  }
+
+  private static void verifyCursor(JSONObject response, String cursorPrefix, String engineName) {
+      assertTrue("'cursor' property does not exist", response.has("cursor"));
+
+      var cursor = response.getString("cursor");
+      assertTrue("'cursor' property is empty", !cursor.isEmpty());
+      assertTrue("The cursor '" + cursor + "' is not from " + engineName + " engine.",
+          cursor.startsWith(cursorPrefix));
+    }
+
+  public static void verifyNoCursor(JSONObject response) {
+    assertTrue(!response.has("cursor"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/util/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/TestUtils.java
@@ -842,21 +842,21 @@ public class TestUtils {
   }
 
   public static void verifyIsV1Cursor(JSONObject response) {
-    verifyCursor(response, "d:", "v1");
+    verifyCursor(response, List.of("d:", "j:", "a:"), "v1");
   }
 
 
   public static void verifyIsV2Cursor(JSONObject response) {
-    verifyCursor(response, "n:", "v2");
+    verifyCursor(response, List.of("n:"), "v2");
   }
 
-  private static void verifyCursor(JSONObject response, String cursorPrefix, String engineName) {
+  private static void verifyCursor(JSONObject response, List<String> validCursorPrefix, String engineName) {
       assertTrue("'cursor' property does not exist", response.has("cursor"));
 
       var cursor = response.getString("cursor");
       assertTrue("'cursor' property is empty", !cursor.isEmpty());
       assertTrue("The cursor '" + cursor + "' is not from " + engineName + " engine.",
-          cursor.startsWith(cursorPrefix));
+          validCursorPrefix.stream().anyMatch(cursor::startsWith));
     }
 
   public static void verifyNoCursor(JSONObject response) {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
@@ -83,13 +83,6 @@ public class RestSQLQueryActionCursorFallbackTest extends BaseRestHandler {
     assertFalse(doesQueryFallback(request));
   }
 
-  @Test
-  public void fallback_with_aggregation() throws Exception {
-    var query = "SELECT name FROM test1 GROUP BY age";
-    SQLQueryRequest request = createSqlQueryRequest(query, Optional.empty(), Optional.of(45));
-    assertTrue(doesQueryFallback(request));
-  }
-
   private static SQLQueryRequest createSqlQueryRequest(String query, Optional<String> cursorId,
                                                        Optional<Integer> fetchSize) throws IOException {
     var builder = XContentFactory.jsonBuilder()

--- a/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.legacy.plugin;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.Strings;
+import org.opensearch.common.inject.Injector;
+import org.opensearch.common.inject.ModulesBuilder;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.executor.QueryManager;
+import org.opensearch.sql.executor.execution.QueryPlanFactory;
+import org.opensearch.sql.sql.SQLService;
+import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
+import org.opensearch.sql.sql.domain.SQLQueryRequest;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * A test suite that verifies fallback behaviour of cursor queries.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RestSQLQueryActionCursorFallbackTest extends BaseRestHandler {
+
+  private NodeClient nodeClient;
+
+  @Mock
+  private ThreadPool threadPool;
+
+  @Mock
+  private QueryManager queryManager;
+
+  @Mock
+  private QueryPlanFactory factory;
+
+  @Mock
+  private RestChannel restChannel;
+
+  private Injector injector;
+
+  @Before
+  public void setup() {
+    nodeClient = new NodeClient(org.opensearch.common.settings.Settings.EMPTY, threadPool);
+    ModulesBuilder modules = new ModulesBuilder();
+    modules.add(b -> {
+      b.bind(SQLService.class).toInstance(new SQLService(new SQLSyntaxParser(), queryManager, factory));
+    });
+    injector = modules.createInjector();
+    Mockito.lenient().when(threadPool.getThreadContext())
+        .thenReturn(new ThreadContext(org.opensearch.common.settings.Settings.EMPTY));
+  }
+
+  // Initial page request test cases
+
+  @Test
+  public void no_fallback_with_column_reference() throws Exception {
+    String query = "SELECT name FROM test1";
+    SQLQueryRequest request = createSqlQueryRequest(query, Optional.empty(),
+        Optional.of(5));
+
+    assertFalse(doesQueryFallback(request));
+  }
+
+  @Test
+  public void fallback_with_aggregation() throws Exception {
+    var query = "SELECT name FROM test1 GROUP BY age";
+    SQLQueryRequest request = createSqlQueryRequest(query, Optional.empty(), Optional.of(45));
+    assertTrue(doesQueryFallback(request));
+  }
+
+  private static SQLQueryRequest createSqlQueryRequest(String query, Optional<String> cursorId,
+                                                       Optional<Integer> fetchSize) throws IOException {
+    var builder = XContentFactory.jsonBuilder()
+        .startObject()
+        .field("query").value(query);
+    if (cursorId.isPresent()) {
+      builder.field("cursor").value(cursorId.get());
+    }
+
+    if (fetchSize.isPresent()) {
+      builder.field("fetch_size").value(fetchSize.get());
+    }
+    builder.endObject();
+    JSONObject jsonContent = new JSONObject(Strings.toString(builder));
+
+    return  new SQLQueryRequest(jsonContent, query, QUERY_API_ENDPOINT,
+        Map.of("format", "jdbc"), cursorId.orElse(""));
+  }
+
+  boolean doesQueryFallback(SQLQueryRequest request) throws Exception {
+    AtomicBoolean fallback = new AtomicBoolean(false);
+    RestSQLQueryAction queryAction = new RestSQLQueryAction(injector);
+    queryAction.prepareRequest(request, (channel, exception) -> {
+      fallback.set(true);
+      assertTrue(exception instanceof SyntaxCheckException);
+    }, (channel, exception) -> {
+    }).accept(restChannel);
+    return fallback.get();
+  }
+
+  @Override
+  public String getName() {
+    // do nothing, RestChannelConsumer is protected which required to extend BaseRestHandler
+    return null;
+  }
+
+  @Override
+  protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient nodeClient)
+     {
+    // do nothing, RestChannelConsumer is protected which required to extend BaseRestHandler
+    return null;
+  }
+}


### PR DESCRIPTION
### Description
At the moment, some queries can only be paginated by the legacy engine.
Add tests to confirm fallback happens in those scenarios.
 
Fallback logic already exists in the target branch so this PR adds test coverage.
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).