### PR TITLE
Add `Timestampdiff` Function To OpenSearch SQL

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -928,6 +928,16 @@ public class DSL {
     return compile(functionProperties, BuiltinFunctionName.TIMESTAMPADD, expressions);
   }
 
+  public static FunctionExpression timestampdiff(Expression... expressions) {
+    return timestampdiff(FunctionProperties.None, expressions);
+  }
+
+  public static FunctionExpression timestampdiff(FunctionProperties functionProperties,
+                                                Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.TIMESTAMPDIFF, expressions);
+  }
+
+
   public static FunctionExpression utc_date(FunctionProperties functionProperties,
                                                 Expression... args) {
     return compile(functionProperties, BuiltinFunctionName.UTC_DATE, args);

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -928,10 +928,6 @@ public class DSL {
     return compile(functionProperties, BuiltinFunctionName.TIMESTAMPADD, expressions);
   }
 
-  public static FunctionExpression timestampdiff(Expression... expressions) {
-    return timestampdiff(FunctionProperties.None, expressions);
-  }
-
   public static FunctionExpression timestampdiff(FunctionProperties functionProperties,
                                                 Expression... expressions) {
     return compile(functionProperties, BuiltinFunctionName.TIMESTAMPDIFF, expressions);

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -109,6 +109,7 @@ public enum BuiltinFunctionName {
   TIME_TO_SEC(FunctionName.of("time_to_sec")),
   TIMESTAMP(FunctionName.of("timestamp")),
   TIMESTAMPADD(FunctionName.of("timestampadd")),
+  TIMESTAMPDIFF(FunctionName.of("timestampdiff")),
   TIME_FORMAT(FunctionName.of("time_format")),
   TO_DAYS(FunctionName.of("to_days")),
   TO_SECONDS(FunctionName.of("to_seconds")),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
@@ -218,9 +218,9 @@ class TimeStampDiffTest extends ExpressionTestBase {
   public void testTimestampdiff(String unit,
                                ExprValue datetimeExpr1,
                                ExprValue datetimeExpr2,
-                               int expected) {
+                               long expected) {
     FunctionExpression expr = timestampdiffQuery(unit, datetimeExpr1, datetimeExpr2);
-    assertEquals(expected, eval(expr));
+    assertEquals(expected, eval(expr).longValue());
   }
 
   private static Stream<Arguments> getUnits() {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
@@ -72,7 +72,9 @@ class TimeStampDiffTest extends ExpressionTestBase {
         arg = base.plusYears(added);
         break;
       default:
-        arg = null;
+        throw new SemanticCheckException(String.format(
+            "%s is not a valid interval type.",
+            intervalType));
     }
 
     switch (argType) {
@@ -95,7 +97,9 @@ class TimeStampDiffTest extends ExpressionTestBase {
             arg.getSecond(),
             arg.getNano() / 1000));
       default:
-        return null;
+        throw new SemanticCheckException(String.format(
+            "%s is not a valid ExprCoreValueType.",
+            argType));
     }
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
@@ -182,7 +182,7 @@ class TimeStampDiffTest extends ExpressionTestBase {
             "DAY",
             new ExprDatetimeValue("2020-02-28 00:00:00"),
             new ExprDatetimeValue("2020-03-01 00:00:00"),
-            2)
+            2),
 
         //Test around year change
         Arguments.of(
@@ -268,7 +268,7 @@ class TimeStampDiffTest extends ExpressionTestBase {
 
   @ParameterizedTest
   @MethodSource("getTimestampDiffInvalidArgs")
-  public void testTimestampAddWithInvalidArgs(String unit, String arg1, String arg2) {
+  public void testTimestampDiffWithInvalidArgs(String unit, String arg1, String arg2) {
     FunctionExpression expr = timestampdiffQuery(
         unit,
         new ExprDatetimeValue(arg1),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
@@ -224,7 +224,7 @@ class TimeStampDiffTest extends ExpressionTestBase {
   private static FunctionExpression timestampdiffQuery(FunctionProperties functionProperties,
                                                        String unit,
                                                        ExprValue datetimeExpr1,
-                                                      ExprValue datetimeExpr2) {
+                                                       ExprValue datetimeExpr2) {
     return DSL.timestampdiff(
         functionProperties,
         DSL.literal(unit),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.datetime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionTestBase;
+import org.opensearch.sql.expression.FunctionExpression;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TimeStampDiffTest extends ExpressionTestBase {
+
+  private static Stream<Arguments> getTestDataForTimestampDiff() {
+    return Stream.of(
+        //Test Date
+        Arguments.of(
+            "DAY",
+            new ExprDateValue("2000-01-01 00:00:00"),
+            new ExprDateValue("2000-01-01"),
+            0),
+        Arguments.of(
+            "DAY",
+            new ExprDateValue("2000-01-01"),
+            new ExprDateValue("2000-01-06"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprDateValue("2000-01-06"),
+            new ExprDateValue("2000-01-01"),
+            -5),
+
+        //Test Datetime
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            0),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            -5),
+
+        //Test Timestamp
+        Arguments.of(
+            "DAY",
+            new ExprTimestampValue("2000-01-01 00:00:00"),
+            new ExprTimestampValue("2000-01-01 00:00:00"),
+            0),
+        Arguments.of(
+            "DAY",
+            new ExprTimestampValue("2000-01-01 00:00:00"),
+            new ExprTimestampValue("2000-01-06 00:00:00"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprTimestampValue("2000-01-06 00:00:00"),
+            new ExprTimestampValue("2000-01-01 00:00:00"),
+            -5),
+
+        //Test String
+        Arguments.of(
+            "DAY",
+            new ExprStringValue("2000-01-01 00:00:00"),
+            new ExprStringValue("2000-01-01 00:00:00"),
+            0),
+        Arguments.of(
+            "DAY",
+            new ExprStringValue("2000-01-01 00:00:00"),
+            new ExprStringValue("2000-01-06 00:00:00"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprStringValue("2000-01-06 00:00:00"),
+            new ExprStringValue("2000-01-01 00:00:00"),
+            -5),
+
+        //Test with different type arguments
+        Arguments.of(
+            "DAY",
+            new ExprTimestampValue("2000-01-01 00:00:00"),
+            new ExprStringValue("2000-01-06 00:00:00"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            new ExprTimestampValue("2000-01-06 00:00:00"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprDateValue("2000-01-06 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            5),
+        Arguments.of(
+            "DAY",
+            new ExprStringValue("2000-01-06 00:00:00"),
+            new ExprDateValue("2000-01-06 00:00:00"),
+            5),
+
+        //Test for all interval options
+        Arguments.of(
+            "MICROSECOND",
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 00:00:00.000123"),
+            123),
+        Arguments.of(
+            "SECOND",
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 00:00:12"),
+            12),
+        Arguments.of(
+            "MINUTE",
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 00:11:12"),
+            11),
+        Arguments.of(
+            "HOUR",
+            new ExprDatetimeValue("2000-01-06 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 10:11:12"),
+            10),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-01-06 10:11:12"),
+            5),
+        Arguments.of(
+            "WEEK",
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-01-31 10:11:12"),
+            4),
+        Arguments.of(
+            "MONTH",
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-12-31 10:11:12"),
+            11),
+        Arguments.of(
+            "QUARTER",
+            new ExprDatetimeValue("2000-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-12-31 10:11:12"),
+            3),
+        Arguments.of(
+            "YEAR",
+            new ExprDatetimeValue("1999-01-01 00:00:00"),
+            new ExprDatetimeValue("2000-12-31 10:11:12"),
+            1),
+
+        //Test around Leap Year
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2019-02-28 00:00:00"),
+            new ExprDatetimeValue("2019-03-01 00:00:00"),
+            1),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2020-02-28 00:00:00"),
+            new ExprDatetimeValue("2020-03-01 00:00:00"),
+            2)
+
+        //Test around year change
+        Arguments.of(
+            "SECOND",
+            new ExprDatetimeValue("2019-12-31 23:59:59"),
+            new ExprDatetimeValue("2020-01-01 00:00:00"),
+            1),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2019-12-31 23:59:59"),
+            new ExprDatetimeValue("2020-01-01 00:00:00"),
+            0),
+        Arguments.of(
+            "DAY",
+            new ExprDatetimeValue("2019-12-31 00:00:00"),
+            new ExprDatetimeValue("2020-01-01 00:00:00"),
+            1)
+    );
+  }
+
+  private static FunctionExpression timestampdiffQuery(String unit,
+                                                       ExprValue datetimeExpr1,
+                                                      ExprValue datetimeExpr2) {
+    return DSL.timestampdiff(
+        DSL.literal(unit),
+        DSL.literal(datetimeExpr1),
+        DSL.literal(datetimeExpr2)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTestDataForTimestampDiff")
+  public void testTimestampdiff(String unit,
+                               ExprValue datetimeExpr1,
+                               ExprValue datetimeExpr2,
+                               int expected) {
+    FunctionExpression expr = timestampdiffQuery(unit, datetimeExpr1, datetimeExpr2);
+    assertEquals(expected, eval(expr));
+  }
+
+  private static Stream<Arguments> getUnits() {
+    return Stream.of(
+        Arguments.of("MICROSECOND"),
+        Arguments.of("SECOND"),
+        Arguments.of("MINUTE"),
+        Arguments.of("HOUR"),
+        Arguments.of("DAY"),
+        Arguments.of("WEEK"),
+        Arguments.of("MONTH"),
+        Arguments.of("QUARTER"),
+        Arguments.of("YEAR")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getUnits")
+  public void testTimestampDiffWithTimeType(String unit) {
+    LocalDate dateToday = LocalDate.now();
+    LocalTime timeArg = LocalTime.of(10, 11, 12);
+    FunctionExpression expr = timestampdiffQuery(
+        unit,
+        new ExprDatetimeValue(LocalDateTime.of(dateToday, timeArg)),
+        new ExprTimeValue(timeArg)
+    );
+    assertEquals(0, eval(expr));
+  }
+
+  private static Stream<Arguments> getTimestampDiffInvalidArgs() {
+    return Stream.of(
+        Arguments.of("INVALID", "2023-01-01 10:11:12", "2000-01-01 10:11:12"),
+        Arguments.of("SECOND", "2023-13-01 10:11:12", "2000-01-01 10:11:12"),
+        Arguments.of("SECOND", "2023-01-40 10:11:12", "2000-01-01 10:11:12"),
+        Arguments.of("SECOND", "2023-01-01 25:11:12", "2000-01-01 10:11:12"),
+        Arguments.of("SECOND", "2023-01-01 10:70:12", "2000-01-01 10:11:12"),
+        Arguments.of("SECOND", "2023-01-01 10:11:70", "2000-01-01 10:11:12"),
+        Arguments.of("SECOND", "2023-01-01 10:11:12", "2000-13-01 10:11:12"),
+        Arguments.of("SECOND", "2023-01-01 10:11:12", "2000-01-40 10:11:12"),
+        Arguments.of("SECOND", "2023-01-01 10:11:12", "2000-01-01 25:11:12"),
+        Arguments.of("SECOND", "2023-01-01 10:11:12", "2000-01-01 10:70:12"),
+        Arguments.of("SECOND", "2023-01-01 10:11:12", "2000-01-01 10:11:70")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTimestampDiffInvalidArgs")
+  public void testTimestampAddWithInvalidArgs(String unit, String arg1, String arg2) {
+    FunctionExpression expr = timestampdiffQuery(
+        unit,
+        new ExprDatetimeValue(arg1),
+        new ExprTimeValue(arg2)
+    );
+    assertThrows(SemanticCheckException.class, () -> eval(expr));
+  }
+
+
+  //Test that different input types have the same result
+  @Test
+  public void testDifferentInputTypesHaveSameResult() {
+    String part = "SECOND";
+    FunctionExpression dateExpr = timestampdiffQuery(
+        part,
+        new ExprDateValue("2000-01-01"),
+        new ExprDateValue("2000-01-02"));
+
+    FunctionExpression stringExpr = timestampdiffQuery(
+        part,
+        new ExprStringValue("2000-01-01 00:00:00"),
+        new ExprStringValue("2000-01-02 00:00:00"));
+
+    FunctionExpression datetimeExpr = timestampdiffQuery(
+        part,
+        new ExprDatetimeValue("2000-01-01 00:00:00"),
+        new ExprDatetimeValue("2000-01-02 00:00:00"));
+
+    FunctionExpression timestampExpr = timestampdiffQuery(
+        part,
+        new ExprTimestampValue("2000-01-01 00:00:00"),
+        new ExprTimestampValue("2000-01-02 00:00:00"));
+
+    assertAll(
+        () -> assertEquals(eval(dateExpr), eval(stringExpr)),
+        () -> assertEquals(eval(dateExpr), eval(datetimeExpr)),
+        () -> assertEquals(eval(dateExpr), eval(timestampExpr))
+    );
+  }
+  private ExprValue eval(Expression expression) {
+    return expression.valueOf();
+  }
+}

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2733,7 +2733,7 @@ TIMESTAMPDIFF
 Description
 >>>>>>>>>>>
 
-Usage: Returns a LONG representing the difference in time for the input arguments arguments. It takes an INTERVAL argument which determine the unit of time used to measure the difference and two additional arguments for the start and end times.
+Usage: TIMESTAMPDIFF(interval, start, end) returns the difference between the start and end date/times in interval units.
 If a TIME is provided as an argument, it will be converted to a DATETIME with the DATE portion filled in using the current date.
 Arguments will be automatically converted to a DATETIME/TIME/TIMESTAMP when appropriate.
 Any argument that is a STRING must be formatted as a valid DATETIME.

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2735,9 +2735,10 @@ Description
 
 Usage: Returns a LONG representing the difference in time for the input arguments arguments. It takes an INTERVAL argument which determine the unit of time used to measure the difference and two additional arguments for the start and end times.
 If a TIME is provided as an argument, it will be converted to a DATETIME with the DATE portion filled in using the current date.
-Arguments will be automaically converted to a DATETIME/TIME/TIMESTAMP when appropriate.
+Arguments will be automatically converted to a DATETIME/TIME/TIMESTAMP when appropriate.
+Any argument that is a STRING must be formatted as a valid DATETIME.
 
-Argument type: INTERVAL, INTEGER, DATE/DATETIME/TIME/TIMESTAMP/STRING
+Argument type: INTERVAL, DATE/DATETIME/TIME/TIMESTAMP/STRING, DATE/DATETIME/TIME/TIMESTAMP/STRING
 INTERVAL must be one of the following tokens: [MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR]
 
 Examples::

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2707,7 +2707,6 @@ Example::
 TIMESTAMPADD
 ------------
 
-
 Description
 >>>>>>>>>>>
 
@@ -2727,6 +2726,29 @@ Examples::
     |------------------------------------------------+----------------------------------------------------|
     | 2000-01-18 00:00:00                            | 1999-10-01 00:00:00                                |
     +------------------------------------------------+----------------------------------------------------+
+
+TIMESTAMPDIFF
+-------------
+
+Description
+>>>>>>>>>>>
+
+Usage: Returns a LONG representing the difference in time for the input arguments arguments. It takes an INTERVAL argument which determine the unit of time used to measure the difference and two additional arguments for the start and end times.
+If a TIME is provided as an argument, it will be converted to a DATETIME with the DATE portion filled in using the current date.
+Arguments will be automaically converted to a DATETIME/TIME/TIMESTAMP when appropriate.
+
+Argument type: INTERVAL, INTEGER, DATE/DATETIME/TIME/TIMESTAMP/STRING
+INTERVAL must be one of the following tokens: [MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR]
+
+Examples::
+
+    os> SELECT TIMESTAMPDIFF(YEAR, '1997-01-01 00:00:00', '2001-03-06 00:00:00'), TIMESTAMPDIFF(SECOND, time('00:00:23'), time('00:00:00'))
+    fetched rows / total rows = 1/1
+    +---------------------------------------------------------------------+-------------------------------------------------------------+
+    | TIMESTAMPDIFF(YEAR, '1997-01-01 00:00:00', '2001-03-06 00:00:00')   | TIMESTAMPDIFF(SECOND, time('00:00:23'), time('00:00:00'))   |
+    |---------------------------------------------------------------------+-------------------------------------------------------------|
+    | 4                                                                   | -23                                                         |
+    +---------------------------------------------------------------------+-------------------------------------------------------------+
 
 TO_DAYS
 -------

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -974,6 +974,18 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testTimstampdiff() throws  IOException {
+    JSONObject result = executeQuery(
+        String.format("SELECT timestampdiff(WEEK, time0, datetime0) FROM %s LIMIT 3", TEST_INDEX_CALCS));
+
+    verifyDataRows(result,
+        rows(38176),
+        rows(38191),
+        rows(38198));
+  }
+
+
+  @Test
   public void testTimeToSec() throws IOException {
     JSONObject result = executeQuery("select time_to_sec(time('17:30:00'))");
     verifySchema(result, schema("time_to_sec(time('17:30:00'))", null, "long"));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -976,14 +976,13 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   @Test
   public void testTimstampdiff() throws  IOException {
     JSONObject result = executeQuery(
-        String.format("SELECT timestampdiff(WEEK, time0, datetime0) FROM %s LIMIT 3", TEST_INDEX_CALCS));
+        String.format("SELECT timestampdiff(DAY, time0, datetime0) FROM %s LIMIT 3", TEST_INDEX_CALCS));
 
     verifyDataRows(result,
         rows(38176),
         rows(38191),
         rows(38198));
   }
-
 
   @Test
   public void testTimeToSec() throws IOException {

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -333,6 +333,7 @@ STATS:                              'STATS';
 TERM:                               'TERM';
 TERMS:                              'TERMS';
 TIMESTAMPADD:                       'TIMESTAMPADD';
+TIMESTAMPDIFF:                      'TIMESTAMPDIFF';
 TOPHITS:                            'TOPHITS';
 TYPEOF:                             'TYPEOF';
 WEEK_OF_YEAR:                       'WEEK_OF_YEAR';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -316,6 +316,11 @@ functionCall
 
 timestampAddFunction
     : TIMESTAMPADD LR_BRACKET simpleDateTimePart COMMA length=functionArg COMMA timestampExpr=functionArg RR_BRACKET
+    | timestampDiffFunction                                         #timestampDiffFunctionCall
+    ;
+
+timestampDiffFunction
+    : TIMESTAMPDIFF LR_BRACKET datetimePart COMMA firstTimestampExpr=functionArg COMMA secondTimestampExpr=functionArg RR_BRACKET
     ;
 
 getFormatFunction

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -311,16 +311,16 @@ functionCall
     | positionFunction                                              #positionFunctionCall
     | extractFunction                                               #extractFunctionCall
     | getFormatFunction                                             #getFormatFunctionCall
-    | timestampAddFunction                                          #timestampAddFunctionCall
+    | timestampFunction                                             #timestampFunctionCall
     ;
 
-timestampAddFunction
-    : TIMESTAMPADD LR_BRACKET simpleDateTimePart COMMA length=functionArg COMMA timestampExpr=functionArg RR_BRACKET
-    | timestampDiffFunction                                         #timestampDiffFunctionCall
+timestampFunction
+    : timestampFunctionName LR_BRACKET simpleDateTimePart COMMA firstArg=functionArg COMMA secondArg=functionArg RR_BRACKET
     ;
 
-timestampDiffFunction
-    : TIMESTAMPDIFF LR_BRACKET datetimePart COMMA firstTimestampExpr=functionArg COMMA secondTimestampExpr=functionArg RR_BRACKET
+timestampFunctionName
+    : TIMESTAMPADD
+    | TIMESTAMPDIFF
     ;
 
 getFormatFunction

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -62,6 +62,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.StringLite
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TableFilterContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimeLiteralContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampAddFunctionCallContext;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampDiffFunctionCallContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampLiteralContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.WindowFunctionClauseContext;
 import static org.opensearch.sql.sql.parser.ParserUtils.createSortOption;
@@ -180,6 +181,13 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     return new Function(
         ctx.timestampAddFunction().TIMESTAMPADD().toString(),
         timestampAddFunctionArguments(ctx));
+  }
+
+  @Override
+  public UnresolvedExpression visitTimestampDiffFunctionCall(TimestampDiffFunctionCallContext ctx) {
+    return new Function(
+        ctx.timestampDiffFunction().TIMESTAMPDIFF().toString(),
+        timestampDiffFunctionArguments(ctx));
   }
 
   @Override
@@ -586,18 +594,6 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     List<UnresolvedExpression> args = Arrays.asList(
         new Literal(ctx.getFormatFunction().getFormatType().getText(), DataType.STRING),
         visitFunctionArg(ctx.getFormatFunction().functionArg())
-    );
-    return args;
-  }
-
-  private List<UnresolvedExpression> timestampAddFunctionArguments(
-      TimestampAddFunctionCallContext ctx) {
-    List<UnresolvedExpression> args = Arrays.asList(
-        new Literal(
-            ctx.timestampAddFunction().simpleDateTimePart().getText(),
-            DataType.STRING),
-        visitFunctionArg(ctx.timestampAddFunction().length),
-        visitFunctionArg(ctx.timestampAddFunction().timestampExpr)
     );
     return args;
   }

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -61,8 +61,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.StringCont
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.StringLiteralContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TableFilterContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimeLiteralContext;
-import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampAddFunctionCallContext;
-import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampDiffFunctionCallContext;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampFunctionCallContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampLiteralContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.WindowFunctionClauseContext;
 import static org.opensearch.sql.sql.parser.ParserUtils.createSortOption;
@@ -177,17 +176,10 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
 
   @Override
-  public UnresolvedExpression visitTimestampAddFunctionCall(TimestampAddFunctionCallContext ctx) {
+  public UnresolvedExpression visitTimestampFunctionCall(TimestampFunctionCallContext ctx) {
     return new Function(
-        ctx.timestampAddFunction().TIMESTAMPADD().toString(),
-        timestampAddFunctionArguments(ctx));
-  }
-
-  @Override
-  public UnresolvedExpression visitTimestampDiffFunctionCall(TimestampDiffFunctionCallContext ctx) {
-    return new Function(
-        ctx.timestampDiffFunction().TIMESTAMPDIFF().toString(),
-        timestampDiffFunctionArguments(ctx));
+        ctx.timestampFunction().timestampFunctionName().getText(),
+        timestampFunctionArguments(ctx));
   }
 
   @Override
@@ -594,6 +586,18 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     List<UnresolvedExpression> args = Arrays.asList(
         new Literal(ctx.getFormatFunction().getFormatType().getText(), DataType.STRING),
         visitFunctionArg(ctx.getFormatFunction().functionArg())
+    );
+    return args;
+  }
+
+  private List<UnresolvedExpression> timestampFunctionArguments(
+      TimestampFunctionCallContext ctx) {
+    List<UnresolvedExpression> args = Arrays.asList(
+        new Literal(
+            ctx.timestampFunction().simpleDateTimePart().getText(),
+            DataType.STRING),
+        visitFunctionArg(ctx.timestampFunction().firstArg),
+        visitFunctionArg(ctx.timestampFunction().secondArg)
     );
     return args;
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -609,6 +609,12 @@ class SQLSyntaxParserTest {
   }
   
   @Test
+  public void can_parse_timestampdiff_function() {
+    assertNotNull(parser.parse("SELECT TIMESTAMPDIFF(MINUTE, 1, '2003-01-02')"));
+    assertNotNull(parser.parse("SELECT TIMESTAMPDIFF(WEEK,1,'2003-01-02')"));
+  }
+
+  @Test
   public void can_parse_to_seconds_function() {
     assertNotNull(parser.parse("SELECT to_seconds(\"2023-02-20\")"));
     assertNotNull(parser.parse("SELECT to_seconds(950501)"));

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -610,8 +610,8 @@ class SQLSyntaxParserTest {
   
   @Test
   public void can_parse_timestampdiff_function() {
-    assertNotNull(parser.parse("SELECT TIMESTAMPDIFF(MINUTE, 1, '2003-01-02')"));
-    assertNotNull(parser.parse("SELECT TIMESTAMPDIFF(WEEK,1,'2003-01-02')"));
+    assertNotNull(parser.parse("SELECT TIMESTAMPDIFF(MINUTE, '2003-01-02', '2003-01-02')"));
+    assertNotNull(parser.parse("SELECT TIMESTAMPDIFF(WEEK,'2003-01-02','2003-01-02')"));
   }
 
   @Test

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -238,6 +238,18 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void canBuildTimstampDiffFunctionCall() {
+    assertEquals(
+        function(
+            "timestampdiff",
+            stringLiteral("WEEK"),
+            timestampLiteral("2023-03-15 00:00:01"),
+            dateLiteral("2023-03-14")),
+        buildExprAst("timestampdiff(WEEK, TIMESTAMP '2023-03-15 00:00:01', DATE '2023-03-14')")
+    );
+  }
+
+  @Test
   public void canBuildComparisonExpression() {
     assertEquals(
         function("!=", intLiteral(1), intLiteral(2)),


### PR DESCRIPTION
### Description
Add the `timestampdiff` function to the SQL plugin. The function takes a first argument for the unit of time used to measure the difference between the second argument (start time) and third argument (end time). The units allowed for the first argument are the same as those allowed for the `timestampadd` [function and are also aligned with MySQL]( https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_timestampadd:~:text=MICROSECOND%20(microseconds)%2C%20SECOND%2C%20MINUTE%2C%20HOUR%2C%20DAY%2C%20WEEK%2C%20MONTH%2C%20QUARTER%2C%20or%20YEAR.).

Example:
```
opensearchsql> SELECT TIMESTAMPDIFF(YEAR, '1997-01-01 00:00:00', '2001-03-06 00:00:00'), TIMESTAMPDIFF(SECOND, time('00:00:23'), time('00:00:00'));
fetched rows / total rows = 1/1
+---------------------------------------------------------------------+-------------------------------------------------------------+
| TIMESTAMPDIFF(YEAR, '1997-01-01 00:00:00', '2001-03-06 00:00:00')   | TIMESTAMPDIFF(SECOND, time('00:00:23'), time('00:00:00'))   |
|---------------------------------------------------------------------+-------------------------------------------------------------|
| 4                                                                   | -23                                                         |
+---------------------------------------------------------------------+-------------------------------------------------------------+
 
```
### Issues Resolved
[722](https://github.com/opensearch-project/sql/issues/722)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).