### PR TITLE
Ensure Nested Function Falls Back to Legacy Engine Where Not Supported

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -60,6 +60,7 @@ import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.data.model.ExprMissingValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
@@ -67,11 +68,13 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.aggregation.Aggregator;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.TableFunctionImplementation;
@@ -217,11 +220,33 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   public LogicalPlan visitFilter(Filter node, AnalysisContext context) {
     LogicalPlan child = node.getChild().get(0).accept(this, context);
     Expression condition = expressionAnalyzer.analyze(node.getCondition(), context);
+    verifySupportsCondition(condition);
 
     ExpressionReferenceOptimizer optimizer =
         new ExpressionReferenceOptimizer(expressionAnalyzer.getRepository(), child);
     Expression optimized = optimizer.optimize(condition, context);
     return new LogicalFilter(child, optimized);
+  }
+
+  /**
+   * Ensure NESTED function is not used in WHERE clause. Fallback to legacy engine. Can remove when
+   * support is added for NESTED function in WHERE and GROUP BY clauses.
+   * @param condition : Filter condition
+   */
+  private void verifySupportsCondition(Expression condition) {
+    if (condition instanceof FunctionExpression) {
+      if (((FunctionExpression) condition).getFunctionName().getFunctionName().equalsIgnoreCase(
+          BuiltinFunctionName.NESTED.name()
+      )) {
+        throw new SyntaxCheckException(
+            "Falling back to legacy engine. Nested function is not supported in WHERE"
+                + " and GROUP BY clauses."
+        );
+      }
+      ((FunctionExpression)condition).getArguments().stream()
+          .forEach(e -> verifySupportsCondition(e)
+      );
+    }
   }
 
   /**
@@ -273,7 +298,9 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     }
 
     for (UnresolvedExpression expr : node.getGroupExprList()) {
-      groupbyBuilder.add(namedExpressionAnalyzer.analyze(expr, context));
+      NamedExpression resolvedExpr = namedExpressionAnalyzer.analyze(expr, context);
+      verifySupportsCondition(resolvedExpr.getDelegated());
+      groupbyBuilder.add(resolvedExpr);
     }
     ImmutableList<NamedExpression> groupBys = groupbyBuilder.build();
 

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -79,6 +79,7 @@ import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
@@ -1015,6 +1016,53 @@ class AnalyzerTest extends AnalyzerTestBase {
         )
     );
   }
+
+  /**
+   * Ensure Nested function falls back to legacy engine when used in GROUP BY clause.
+   * TODO Remove this test when support is added.
+   */
+  @Test
+  public void nested_group_by_clause_throws_syntax_exception() {
+    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
+        () -> analyze(
+            AstDSL.project(
+                AstDSL.agg(
+                    AstDSL.relation("schema"),
+                    emptyList(),
+                    emptyList(),
+                    ImmutableList.of(alias("nested(message.info)",
+                        function("nested",
+                            qualifiedName("message", "info")))),
+                    emptyList()
+                )))
+    );
+    assertEquals("Falling back to legacy engine. Nested function is not supported in WHERE"
+            + " and GROUP BY clauses.",
+        exception.getMessage());
+  }
+
+  /**
+   * Ensure Nested function falls back to legacy engine when used in WHERE clause.
+   * TODO Remove this test when support is added.
+   */
+  @Test
+  public void nested_where_clause_throws_syntax_exception() {
+    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
+        () -> analyze(
+            AstDSL.filter(
+                AstDSL.relation("schema"),
+                AstDSL.equalTo(
+                    AstDSL.function("nested", qualifiedName("message", "info")),
+                    AstDSL.stringLiteral("str")
+                )
+            )
+        )
+    );
+    assertEquals("Falling back to legacy engine. Nested function is not supported in WHERE"
+            + " and GROUP BY clauses.",
+        exception.getMessage());
+  }
+
 
   /**
    * SELECT name, AVG(age) FROM test GROUP BY name.

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -17,7 +17,6 @@ import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -169,6 +168,32 @@ public class NestedIT extends SQLIntegTestCase {
         rows("c", "b"),
         rows("a", "b"),
         rows("zz", "a"));
+  }
+
+  @Test
+  public void nested_function_with_where_clause() {
+    String query =
+        "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE + " WHERE nested(message.info) = 'a'";
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(2, result.getInt("total"));
+    verifyDataRows(result,
+        rows("a"),
+        rows("a"));
+  }
+
+  // Nested function in GROUP BY clause is not yet implemented for JDBC format. This test ensures
+  // that the V2 engine falls back to legacy implementation.
+  // TODO Fix the test when NESTED is supported in GROUP BY in the V2 engine.
+  @Test
+  public void nested_function_with_group_by_clause() {
+    String query =
+        "SELECT count(*) FROM " + TEST_INDEX_NESTED_TYPE + " GROUP BY nested(message.info)";
+    JSONObject result = executeJdbcRequest(query);
+
+    assertTrue(result.getJSONObject("error").get("details").toString().contains(
+        "Aggregation type nested is not yet implemented"
+    ));
   }
 
   @Test


### PR DESCRIPTION
### Description
Fallback to legacy engine when the nested function is used in the `WHERE` and `GROUP BY` clauses. Support has not been added to the V2 engine for the nested query in these clauses.
 
### Issues Resolved
[1548](https://github.com/opensearch-project/sql/issues/1548)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).