### PR TITLE
Doctest fix for protocol.rst for update of PPL query error message

### DIFF
--- a/docs/user/ppl/interfaces/protocol.rst
+++ b/docs/user/ppl/interfaces/protocol.rst
@@ -129,7 +129,7 @@ PPL query::
     {
       "error": {
         "reason": "Error occurred in OpenSearch engine: no such index [unknown]",
-        "details": "org.opensearch.index.IndexNotFoundException: no such index [unknown]\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
+        "details": "[unknown] IndexNotFoundException[no such index [unknown]]\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
         "type": "IndexNotFoundException"
       },
       "status": 404


### PR DESCRIPTION
### Description
Fixes error in `protocol.rst` test.

**Old:**
```
  "error": {
    "reason": "Error occurred in OpenSearch engine: no such index [unknown]",
    "details": "org.opensearch.index.IndexNotFoundException: no such index [unknown]\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "IndexNotFoundException"
```
**New:**
```
  "error": {
    "reason": "Error occurred in OpenSearch engine: no such index [unknown]",
    "details": "[unknown] IndexNotFoundException[no such index [unknown]]\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "IndexNotFoundException"
```

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).