### PR TITLE
Added deleteSQLCLI to be called before the sql-cli is cloned in case …

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -99,6 +99,11 @@ task stopPrometheus() {
         }
     }
 }
+
+task deleteSQLCLI (type: Delete) {
+    delete 'sql-cli'
+}
+
 if(getOSFamilyType() != "windows") {
     stopPrometheus.mustRunAfter startPrometheus
     startOpenSearch.dependsOn startPrometheus
@@ -108,6 +113,7 @@ doctest.dependsOn startOpenSearch
 doctest.finalizedBy stopOpenSearch
 check.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
+cloneSqlCli.dependsOn(deleteSQLCLI)
 
 // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
 String opensearch_no_snapshot = opensearch_version.replace('-SNAPSHOT', '')


### PR DESCRIPTION
### Description
`cloneSqlCli` now depends on new task `deleteSQLCLI` which deletes `doctest/sql-cli` before it is used.

When execution of doctests is halted during execution the `doctest/sql-cli` directory is not deleted.

**Steps to reproduce the behavior:**
Run OpenSearch SQL Plugin build and stop build during doctest execution.
Run OpenSearch SQL Plugin build again and observe Execution failed for task ':doctest:cloneSqlCli'. error.

**What is the expected behavior?**
doctest/sql-cli should be deleted before clone is attempted.



### Issues Resolved
[#1675
](https://github.com/opensearch-project/sql/issues/1675) 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).