### PR TITLE
Stop prometheus in doctest build.gradle now runs upon project failure in startOpenSearch

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import java.util.concurrent.Callable
 import org.opensearch.gradle.testclusters.RunTask
 
 plugins {
@@ -51,7 +50,7 @@ task startPrometheus(type: SpawnProcessTask) {
     }
     command "$projectDir/bin/prometheus/prometheus --storage.tsdb.path=$projectDir/bin/prometheus/data --config.file=$projectDir/bin/prometheus/prometheus.yml"
     ready 'TSDB started'
-    pidLockFileName '.prom.pid.lock'
+    pidLockFileName ".prom.pid.lock"
 }
 
 //evaluationDependsOn(':')
@@ -78,36 +77,26 @@ task doctest(type: Exec, dependsOn: ['bootstrap']) {
 
 task stopOpenSearch(type: KillProcessTask)
 
-task stopPrometheus() {
-
+task stopPrometheus(type: KillProcessTask) {
+    pidLockFileName ".prom.pid.lock"
     doLast {
-        def pidFile = new File(path, ".prom.pid.lock")
-        if (!pidFile.exists()) {
-            logger.quiet "No Prometheus server running!"
-            return
-        }
-
-        def pid = pidFile.text
-        def process = "kill $pid".execute()
-
-        try {
-            process.waitFor()
-        } finally {
-            pidFile.delete()
-            file("$projectDir/bin/prometheus").deleteDir()
-            file("$projectDir/bin/prometheus.tar.gz").delete()
-        }
+        file("$projectDir/bin/prometheus").deleteDir()
+        file("$projectDir/bin/prometheus.tar.gz").delete()
     }
 }
+
+// Stop Prom AFTER Start Prom...
 if(getOSFamilyType() != "windows") {
     stopPrometheus.mustRunAfter startPrometheus
     startOpenSearch.dependsOn startPrometheus
     stopOpenSearch.finalizedBy stopPrometheus
+    startOpenSearch.finalizedBy stopPrometheus
 }
 doctest.dependsOn startOpenSearch
 doctest.finalizedBy stopOpenSearch
 check.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
+clean.dependsOn(stopPrometheus)
 
 // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
 String opensearch_no_snapshot = opensearch_version.replace('-SNAPSHOT', '')

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'java'
 apply plugin: 'io.freefair.lombok'
 apply plugin: 'com.wiredforcode.spawn'
 
-String baseVersion = "2.8.0"
+String baseVersion = "2.9.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"


### PR DESCRIPTION
startOpenSearch is now finalizedBy stopPrometheus allowing stop prometheus to run after crash. This stops a left-over prometheus instance from running after causing future start Prometheus tasks from running.



Steps to reproduce error that is fixed.

1. Run an OpenSearch instance
2. Run build in OpenSearch SQL
3. Observe that OpenSearch SQL crashes due to step 1
4. Stop OpenSearch instance started in step 1
5. Re-run build for OpenSearch SQL
6. Observe that there is error about Prometheus already running.

Same steps can be taken working from this PR branch and it will not show the error in step 6.

 
### Issues Resolved
[1083](https://github.com/opensearch-project/sql/issues/1083) 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).