### PR TITLE
Add Support for Field Star in Nested Function.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -186,7 +186,16 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
     FunctionName functionName = FunctionName.of(node.getFuncName());
     List<Expression> arguments =
         node.getFuncArgs().stream()
-            .map(unresolvedExpression -> analyze(unresolvedExpression, context))
+            .map(unresolvedExpression -> {
+              var ret = analyze(unresolvedExpression, context);
+              if (ret == null) {
+                throw new UnsupportedOperationException(
+                    String.format("Invalid use of expression %s", unresolvedExpression)
+                );
+              } else {
+                return ret;
+              }
+            })
             .collect(Collectors.toList());
     return (Expression) repository.compile(context.getFunctionProperties(),
         functionName, arguments);

--- a/core/src/main/java/org/opensearch/sql/analysis/TypeEnvironment.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/TypeEnvironment.java
@@ -86,6 +86,17 @@ public class TypeEnvironment implements Environment<Symbol, ExprType> {
   }
 
   /**
+   * Resolve all fields in the current environment.
+   * @param namespace     a namespace
+   * @return              all symbols in the namespace
+   */
+  public Map<String, ExprType> lookupAllTupleFields(Namespace namespace) {
+    Map<String, ExprType> result = new LinkedHashMap<>();
+    symbolTable.lookupAllTupleFields(namespace).forEach(result::putIfAbsent);
+    return result;
+  }
+
+  /**
    * Define symbol with the type.
    *
    * @param symbol symbol to define

--- a/core/src/main/java/org/opensearch/sql/analysis/symbol/SymbolTable.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/symbol/SymbolTable.java
@@ -129,6 +129,21 @@ public class SymbolTable {
   }
 
   /**
+   * Look up all top level symbols in the namespace.
+   *
+   * @param namespace     a namespace
+   * @return              all symbols in the namespace map
+   */
+  public Map<String, ExprType> lookupAllTupleFields(Namespace namespace) {
+    final LinkedHashMap<String, ExprType> allSymbols =
+        orderedTable.getOrDefault(namespace, new LinkedHashMap<>());
+    final LinkedHashMap<String, ExprType> result = new LinkedHashMap<>();
+    allSymbols.entrySet().stream()
+        .forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+    return result;
+  }
+
+  /**
    * Check if namespace map in empty (none definition).
    *
    * @param namespace a namespace

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -25,6 +25,7 @@ import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
@@ -235,6 +236,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitAllFields(AllFields node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitNestedAllTupleFields(NestedAllTupleFields node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -30,6 +30,7 @@ import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -375,6 +376,10 @@ public class AstDSL {
 
   public Alias alias(String name, UnresolvedExpression expr, String alias) {
     return new Alias(name, expr, alias);
+  }
+
+  public NestedAllTupleFields nestedAllTupleFields(String name) {
+    return new NestedAllTupleFields(name);
   }
 
   public static List<UnresolvedExpression> exprList(UnresolvedExpression... exprList) {

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -378,8 +378,8 @@ public class AstDSL {
     return new Alias(name, expr, alias);
   }
 
-  public NestedAllTupleFields nestedAllTupleFields(String name) {
-    return new NestedAllTupleFields(name);
+  public NestedAllTupleFields nestedAllTupleFields(String path) {
+    return new NestedAllTupleFields(path);
   }
 
   public static List<UnresolvedExpression> exprList(UnresolvedExpression... exprList) {

--- a/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.ast.expression;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+
+/**
+ * Represents all tuple fields used in nested function.
+ */
+@ToString
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class NestedAllTupleFields extends UnresolvedExpression {
+  @Getter
+  private final String path;
+
+  @Override
+  public List<? extends Node> getChild() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
+    return nodeVisitor.visitNestedAllTupleFields(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
@@ -34,4 +34,9 @@ public class NestedAllTupleFields extends UnresolvedExpression {
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
     return nodeVisitor.visitNestedAllTupleFields(this, context);
   }
+
+  @Override
+  public String toString() {
+    return String.format("nested(%s.*)", path);
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -578,6 +578,34 @@ class AnalyzerTest extends AnalyzerTestBase {
   }
 
   @Test
+  public void sort_with_nested_all_tuple_fields_throws_exception() {
+    assertThrows(UnsupportedOperationException.class, () -> analyze(
+        AstDSL.project(
+          AstDSL.sort(
+                AstDSL.relation("schema"),
+                field(nestedAllTupleFields("message"))
+              ),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message"))
+        )
+    ));
+  }
+
+  @Test
+  public void filter_with_nested_all_tuple_fields_throws_exception() {
+    assertThrows(UnsupportedOperationException.class, () -> analyze(
+        AstDSL.project(
+            AstDSL.filter(
+                AstDSL.relation("schema"),
+                AstDSL.function("=", nestedAllTupleFields("message"), AstDSL.intLiteral(1))),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message"))
+        )
+    ));
+  }
+
+
+  @Test
   public void project_nested_field_star_arg() {
     List<Map<String, ReferenceExpression>> nestedArgs =
         List.of(

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -4458,6 +4458,17 @@ Example with ``field`` and ``path`` parameters::
     | b                               |
     +---------------------------------+
 
+Example with ``field.*`` used in SELECT clause::
+
+    os> SELECT nested(message.*) FROM nested;
+    fetched rows / total rows = 2/2
+    +--------------------------+-----------------------------+------------------------+
+    | nested(message.author)   | nested(message.dayOfWeek)   | nested(message.info)   |
+    |--------------------------+-----------------------------+------------------------|
+    | e                        | 1                           | a                      |
+    | f                        | 2                           | b                      |
+    +--------------------------+-----------------------------+------------------------+
+
 
 Example with ``field`` and ``path`` parameters in the SELECT and WHERE clause::
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
@@ -53,6 +53,9 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   private static final Set<String> messageFields = Sets.newHashSet(
       "message.dayOfWeek", "message.info", "message.author");
 
+  private static final Set<String> messageFieldsWithNestedFunction = Sets.newHashSet(
+      "nested(message.dayOfWeek)", "nested(message.info)", "nested(message.author)");
+
   private static final Set<String> commentFields = Sets.newHashSet("comment.data", "comment.likes");
 
   private static final List<String> nameFields = Arrays.asList("firstname", "lastname");
@@ -211,7 +214,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
         String.format(Locale.ROOT, "SELECT nested(message.*) FROM %s",
             TestsConstants.TEST_INDEX_NESTED_TYPE));
 
-    assertContainsColumnsInAnyOrder(getSchema(response), messageFields);
+    assertContainsColumnsInAnyOrder(getSchema(response), messageFieldsWithNestedFunction);
     assertContainsData(getDataRows(response), messageFields);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -102,6 +102,41 @@ public class NestedIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void nested_all_function_in_a_function_in_select_test() {
+    String query = "SELECT nested(message.*) FROM " +
+        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " WHERE nested(message.info) = 'a'";
+    JSONObject result = executeJdbcRequest(query);
+    verifyDataRows(result, rows("e", 1, "a"));
+  }
+
+  @Test
+  public void invalid_multiple_nested_all_function_in_a_function_in_select_test() {
+    String query = "SELECT nested(message.*), nested(message.info) FROM " +
+        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+    RuntimeException result = assertThrows(
+        RuntimeException.class,
+        () -> executeJdbcRequest(query)
+    );
+    assertTrue(
+        result.getMessage().contains("IllegalArgumentException")
+        && result.getMessage().contains("Multiple entries with same key")
+    );
+  }
+
+  @Test
+  public void nested_all_function_with_limit_test() {
+    String query = "SELECT nested(message.*) FROM " +
+        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " LIMIT 3";
+    JSONObject result = executeJdbcRequest(query);
+    verifyDataRows(result,
+        rows("e", 1, "a"),
+        rows("f", 2, "b"),
+        rows("g", 1, "c")
+    );
+  }
+
+
+  @Test
   public void nested_function_with_array_of_multi_nested_field_test() {
     String query = "SELECT nested(message.author.name) FROM " + TEST_INDEX_MULTI_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -328,7 +328,8 @@ nullNotnull
     ;
 
 functionCall
-    : scalarFunctionName LR_BRACKET functionArgs RR_BRACKET         #scalarFunctionCall
+    : nestedFunctionName LR_BRACKET allTupleFields RR_BRACKET       #nestedAllFunctionCall
+    | scalarFunctionName LR_BRACKET functionArgs RR_BRACKET         #scalarFunctionCall
     | specificFunction                                              #specificFunctionCall
     | windowFunctionClause                                          #windowFunctionCall
     | aggregateFunction                                             #aggregateFunctionCall
@@ -811,6 +812,10 @@ tableName
 
 columnName
     : qualifiedName
+    ;
+
+allTupleFields
+    : qualifiedName DOT STAR
     ;
 
 alias

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -815,7 +815,7 @@ columnName
     ;
 
 allTupleFields
-    : qualifiedName DOT STAR
+    : path=qualifiedName DOT STAR
     ;
 
 alias

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -40,6 +40,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.IsNullPred
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.LikePredicateContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.MathExpressionAtomContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.MultiFieldRelevanceFunctionContext;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NestedAllFunctionCallContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NoFieldRelevanceFunctionContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NotExpressionContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NullLiteralContext;
@@ -153,9 +154,9 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
   @Override
   public UnresolvedExpression visitNestedAllFunctionCall(
-      OpenSearchSQLParser.NestedAllFunctionCallContext ctx) {
+      NestedAllFunctionCallContext ctx) {
     return new NestedAllTupleFields(
-        visitQualifiedName(ctx.allTupleFields().qualifiedName()).toString()
+        visitQualifiedName(ctx.allTupleFields().path).toString()
     );
   }
 

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -9,7 +9,6 @@ package org.opensearch.sql.sql.parser;
 import static org.opensearch.sql.ast.dsl.AstDSL.between;
 import static org.opensearch.sql.ast.dsl.AstDSL.not;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
-import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.LIKE;
@@ -90,6 +89,7 @@ import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.IntervalUnit;
 import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
@@ -102,6 +102,7 @@ import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AlternateMultiMatchQueryContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AndExpressionContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.ColumnNameContext;
@@ -148,6 +149,14 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitNestedExpressionAtom(NestedExpressionAtomContext ctx) {
     return visit(ctx.expression()); // Discard parenthesis around
+  }
+
+  @Override
+  public UnresolvedExpression visitNestedAllFunctionCall(
+      OpenSearchSQLParser.NestedAllFunctionCallContext ctx) {
+    return new NestedAllTupleFields(
+        visitQualifiedName(ctx.allTupleFields().qualifiedName()).toString()
+    );
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -39,6 +39,7 @@ import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 
 class AstBuilderTest extends AstBuilderTestBase {
@@ -84,6 +85,19 @@ class AstBuilderTest extends AstBuilderTestBase {
     );
 
     assertThrows(SyntaxCheckException.class, () -> buildAST("SELECT *"));
+  }
+
+  @Test
+  public void can_build_nested_select_all() {
+    assertEquals(
+        project(
+            relation("test"),
+            alias("nested(field.*)",
+                new NestedAllTupleFields("field")
+            )
+        ),
+        buildAST("SELECT nested(field.*) FROM test")
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description
Add support for using the `*` at end of field parameter in the nested function. All nested fields under supplied path will be expanded as column identifiers. Grammar has been added to only support the `AllTupleFields` usage with the nested function since this change will effect field usage in all queries and needs further planning with V2 implementation.
 
### Example Queries
```sql
SELECT nested(message.*) from nested_objects;
```

### Issues Resolved
Portion of Issue: [1111](https://github.com/opensearch-project/sql/issues/1111)

### Changes From Legacy
- Path parameter is redundant therefore not supported in parser and will fallback to legacy engine.

### Edge Cases
Queries that produce repeating column identifiers like: 
```sql
SELECT nested(field.*), nested(field.innerField) ...
```
Or 
```sql
SELECT nested(field.*), nested(field.*) ...
```
Will result in error:
```json
{
  "error": {
    "reason": "Invalid SQL query",
    "details": "Multiple entries with same key: nested(message.info)=\"a\" and nested(message.info)=\"a\"",
    "type": "IllegalArgumentException"
  },
  "status": 400
}
```


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).