### PR TITLE
Fix `ASCII` function and groom UT for text functions.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.data.model.ExprIntegerValue;
+import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
@@ -359,7 +360,8 @@ public class TextFunction {
   }
 
   private static ExprValue exprAscii(ExprValue expr) {
-    return new ExprIntegerValue((int) expr.stringValue().charAt(0));
+    return new ExprIntegerValue(expr.stringValue().length() == 0 ? 0
+        : (int) expr.stringValue().charAt(0));
   }
 
   private static ExprValue exprLocate(ExprValue subStr, ExprValue str) {

--- a/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
@@ -7,6 +7,8 @@
 package org.opensearch.sql.expression.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.data.model.ExprValueUtils.missingValue;
 import static org.opensearch.sql.data.model.ExprValueUtils.nullValue;
@@ -18,13 +20,12 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprValue;
@@ -32,49 +33,55 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionTestBase;
 import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.env.Environment;
 
-@ExtendWith(MockitoExtension.class)
 public class TextFunctionTest extends ExpressionTestBase {
-  @Mock
-  Environment<Expression, ExprValue> env;
 
-  @Mock
-  Expression nullRef;
+  private static Stream<SubstringInfo> getStringsForSubstr() {
+    return Stream.of(
+        new SubstringInfo("", 1, 1, ""),
+        new SubstringInfo("Quadratically", 5, null, "ratically"),
+        new SubstringInfo("foobarbar", 4, null, "barbar"),
+        new SubstringInfo("Quadratically", 5, 6, "ratica"),
+        new SubstringInfo("Quadratically", 5, 600, "ratically"),
+        new SubstringInfo("Quadratically", 500, 1, ""),
+        new SubstringInfo("Quadratically", 500, null, ""),
+        new SubstringInfo("Sakila", -3, null, "ila"),
+        new SubstringInfo("Sakila", -5, 3, "aki"),
+        new SubstringInfo("Sakila", -4, 2, "ki"),
+        new SubstringInfo("Quadratically", 0, null, ""),
+        new SubstringInfo("Sakila", 0, 2, ""),
+        new SubstringInfo("Sakila", 2, 0, ""),
+        new SubstringInfo("Sakila", 0, 0, ""));
+  }
 
-  @Mock
-  Expression missingRef;
+  private static Stream<String> getStringsForUpperAndLower() {
+    return Stream.of(
+        "test", " test", "test ", " test ", "TesT", "TEST", " TEST", "TEST ", " TEST ", " ", "");
+  }
 
+  private static Stream<StringPatternPair> getStringsForComparison() {
+    return Stream.of(
+        new StringPatternPair("Michael!", "Michael!"),
+        new StringPatternPair("hello", "world"),
+        new StringPatternPair("world", "hello"));
+  }
 
-  private static List<SubstringInfo> SUBSTRING_STRINGS = ImmutableList.of(
-      new SubstringInfo("", 1, 1, ""),
-      new SubstringInfo("Quadratically", 5, null, "ratically"),
-      new SubstringInfo("foobarbar", 4, null, "barbar"),
-      new SubstringInfo("Quadratically", 5, 6, "ratica"),
-      new SubstringInfo("Quadratically", 5, 600, "ratically"),
-      new SubstringInfo("Quadratically", 500, 1, ""),
-      new SubstringInfo("Quadratically", 500, null, ""),
-      new SubstringInfo("Sakila", -3, null, "ila"),
-      new SubstringInfo("Sakila", -5, 3, "aki"),
-      new SubstringInfo("Sakila", -4, 2, "ki"),
-      new SubstringInfo("Quadratically", 0, null, ""),
-      new SubstringInfo("Sakila", 0, 2, ""),
-      new SubstringInfo("Sakila", 2, 0, ""),
-      new SubstringInfo("Sakila", 0, 0, ""));
-  private static List<String> UPPER_LOWER_STRINGS = ImmutableList.of(
-      "test", " test", "test ", " test ", "TesT", "TEST", " TEST", "TEST ", " TEST ", " ", "");
-  private static List<StringPatternPair> STRING_PATTERN_PAIRS = ImmutableList.of(
-      new StringPatternPair("Michael!", "Michael!"),
-      new StringPatternPair("hello", "world"),
-      new StringPatternPair("world", "hello"));
-  private static List<String> TRIM_STRINGS = ImmutableList.of(
-      " test", "     test", "test     ", "test", "     test    ", "", " ");
-  private static List<List<String>> CONCAT_STRING_LISTS = ImmutableList.of(
-      ImmutableList.of("hello", "world"),
-      ImmutableList.of("123", "5325"));
-  private static List<List<String>> CONCAT_STRING_LISTS_WITH_MANY_STRINGS = ImmutableList.of(
-      ImmutableList.of("he", "llo", "wo", "rld", "!"),
-      ImmutableList.of("0", "123", "53", "25", "7"));
+  private static Stream<String> getStringsForTrim() {
+    return Stream.of(" test", "     test", "test     ", "test", "     test    ", "", " ");
+  }
+
+  private static Stream<List<String>> getStringsForConcat() {
+    return Stream.of(
+        ImmutableList.of("hello", "world"),
+        ImmutableList.of("123", "5325"));
+  }
+
+  private static Stream<List<String>> getMultipleStringsForConcat() {
+    return Stream.of(
+        ImmutableList.of("he", "llo", "wo", "rld", "!"),
+        ImmutableList.of("0", "123", "53", "25", "7"));
+  }
+
 
   interface SubstrSubstring {
     FunctionExpression getFunction(SubstringInfo strInfo);
@@ -128,30 +135,11 @@ public class TextFunctionTest extends ExpressionTestBase {
     String res;
   }
 
-  @BeforeEach
-  public void setup() {
-    when(nullRef.valueOf(env)).thenReturn(nullValue());
-    when(missingRef.valueOf(env)).thenReturn(missingValue());
-  }
-
-  @Test
-  public void substrSubstring() {
-    SUBSTRING_STRINGS.forEach(s -> substrSubstringTest(s, new Substr()));
-    SUBSTRING_STRINGS.forEach(s -> substrSubstringTest(s, new Substring()));
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.substr(missingRef, DSL.literal(1))));
-    assertEquals(nullValue(), eval(DSL.substr(nullRef, DSL.literal(1))));
-    assertEquals(missingValue(), eval(DSL.substring(missingRef, DSL.literal(1))));
-    assertEquals(nullValue(), eval(DSL.substring(nullRef, DSL.literal(1))));
-
-    when(nullRef.type()).thenReturn(INTEGER);
-    when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(missingValue(), eval(DSL.substr(DSL.literal("hello"), missingRef)));
-    assertEquals(nullValue(), eval(DSL.substr(DSL.literal("hello"), nullRef)));
-    assertEquals(missingValue(), eval(DSL.substring(DSL.literal("hello"), missingRef)));
-    assertEquals(nullValue(), eval(DSL.substring(DSL.literal("hello"), nullRef)));
+  @ParameterizedTest
+  @MethodSource("getStringsForSubstr")
+  void substrSubstring(SubstringInfo s) {
+    substrSubstringTest(s, new Substr());
+    substrSubstringTest(s, new Substring());
   }
 
   void substrSubstringTest(SubstringInfo strInfo, SubstrSubstring substrSubstring) {
@@ -160,79 +148,44 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(strInfo.getRes(), eval(expr).stringValue());
   }
 
-  @Test
-  public void ltrim() {
-    TRIM_STRINGS.forEach(this::ltrimString);
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.ltrim(missingRef)));
-    assertEquals(nullValue(), eval(DSL.ltrim(nullRef)));
-  }
-
-  @Test
-  public void rtrim() {
-    TRIM_STRINGS.forEach(this::rtrimString);
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.ltrim(missingRef)));
-    assertEquals(nullValue(), eval(DSL.ltrim(nullRef)));
-  }
-
-  @Test
-  public void trim() {
-    TRIM_STRINGS.forEach(this::trimString);
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.ltrim(missingRef)));
-    assertEquals(nullValue(), eval(DSL.ltrim(nullRef)));
-  }
-
-  void ltrimString(String str) {
+  /** Test `LTRIM` function. */
+  @ParameterizedTest
+  @MethodSource("getStringsForTrim")
+  void ltrim(String str) {
     FunctionExpression expression = DSL.ltrim(DSL.literal(str));
     assertEquals(STRING, expression.type());
     assertEquals(str.stripLeading(), eval(expression).stringValue());
   }
 
-  void rtrimString(String str) {
+  /** Test `RTRIM` function. */
+  @ParameterizedTest
+  @MethodSource("getStringsForTrim")
+  public void rtrim(String str) {
     FunctionExpression expression = DSL.rtrim(DSL.literal(str));
     assertEquals(STRING, expression.type());
     assertEquals(str.stripTrailing(), eval(expression).stringValue());
   }
 
-  void trimString(String str) {
+  /** Test `TRIM` function. */
+  @ParameterizedTest
+  @MethodSource("getStringsForTrim")
+  public void trim(String str) {
     FunctionExpression expression = DSL.trim(DSL.literal(str));
     assertEquals(STRING, expression.type());
     assertEquals(str.trim(), eval(expression).stringValue());
   }
 
-  @Test
-  public void lower() {
-    UPPER_LOWER_STRINGS.forEach(this::testLowerString);
+  @ParameterizedTest
+  @MethodSource("getStringsForConcat")
+  void concat(List<String> strings) {
+    testConcatString(strings);
 
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.lower(missingRef)));
-    assertEquals(nullValue(), eval(DSL.lower(nullRef)));
-  }
-
-  @Test
-  public void upper() {
-    UPPER_LOWER_STRINGS.forEach(this::testUpperString);
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.upper(missingRef)));
-    assertEquals(nullValue(), eval(DSL.upper(nullRef)));
-  }
-
-  @Test
-  void concat() {
-    CONCAT_STRING_LISTS.forEach(this::testConcatString);
-    CONCAT_STRING_LISTS_WITH_MANY_STRINGS.forEach(this::testConcatMultipleString);
-
+    // Since `concat` isn't wrapped with `nullMissingHandling` (which has its own tests),
+    // we have to test there case with NULL and MISSING values
+    Expression nullRef = mock(Expression.class);
+    Expression missingRef = mock(Expression.class);
+    when(nullRef.valueOf(any())).thenReturn(nullValue());
+    when(missingRef.valueOf(any())).thenReturn(missingValue());
     when(nullRef.type()).thenReturn(STRING);
     when(missingRef.type()).thenReturn(STRING);
     assertEquals(missingValue(), eval(
@@ -246,46 +199,10 @@ public class TextFunctionTest extends ExpressionTestBase {
             DSL.concat(DSL.literal("1"), nullRef)));
   }
 
-  @Test
-  void concat_ws() {
-    CONCAT_STRING_LISTS.forEach(s -> testConcatString(s, ","));
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(
-        DSL.concat_ws(missingRef, DSL.literal("1"), DSL.literal("1"))));
-    assertEquals(nullValue(), eval(
-        DSL.concat_ws(nullRef, DSL.literal("1"), DSL.literal("1"))));
-    assertEquals(missingValue(), eval(
-        DSL.concat_ws(DSL.literal("1"), missingRef, DSL.literal("1"))));
-    assertEquals(nullValue(), eval(
-        DSL.concat_ws(DSL.literal("1"), nullRef, DSL.literal("1"))));
-    assertEquals(missingValue(), eval(
-        DSL.concat_ws(DSL.literal("1"), DSL.literal("1"), missingRef)));
-    assertEquals(nullValue(), eval(
-        DSL.concat_ws(DSL.literal("1"), DSL.literal("1"), nullRef)));
-  }
-
-  @Test
-  void length() {
-    UPPER_LOWER_STRINGS.forEach(this::testLengthString);
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.length(missingRef)));
-    assertEquals(nullValue(), eval(DSL.length(nullRef)));
-  }
-
-  @Test
-  void strcmp() {
-    STRING_PATTERN_PAIRS.forEach(this::testStcmpString);
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.strcmp(missingRef, missingRef)));
-    assertEquals(nullValue(), eval(DSL.strcmp(nullRef, nullRef)));
-    assertEquals(missingValue(), eval(DSL.strcmp(nullRef, missingRef)));
-    assertEquals(missingValue(), eval(DSL.strcmp(missingRef, nullRef)));
+  @ParameterizedTest
+  @MethodSource("getStringsForConcat")
+  void concat_ws(List<String> strings) {
+    testConcatString(strings, ",");
   }
 
   @Test
@@ -307,14 +224,6 @@ public class TextFunctionTest extends ExpressionTestBase {
     expression = DSL.right(DSL.literal(""), DSL.literal(10));
     assertEquals(STRING, expression.type());
     assertEquals("", eval(expression).value());
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(missingValue(), eval(DSL.right(nullRef, missingRef)));
-    assertEquals(nullValue(), eval(DSL.right(nullRef, DSL.literal(new ExprIntegerValue(1)))));
-
-    when(nullRef.type()).thenReturn(INTEGER);
-    assertEquals(nullValue(), eval(DSL.right(DSL.literal(new ExprStringValue("value")), nullRef)));
   }
 
   @Test
@@ -336,14 +245,6 @@ public class TextFunctionTest extends ExpressionTestBase {
     expression = DSL.left(DSL.literal(""), DSL.literal(10));
     assertEquals(STRING, expression.type());
     assertEquals("", eval(expression).value());
-
-    when(nullRef.type()).thenReturn(STRING);
-    when(missingRef.type()).thenReturn(INTEGER);
-    assertEquals(missingValue(), eval(DSL.left(nullRef, missingRef)));
-    assertEquals(nullValue(), eval(DSL.left(nullRef, DSL.literal(new ExprIntegerValue(1)))));
-
-    when(nullRef.type()).thenReturn(INTEGER);
-    assertEquals(nullValue(), eval(DSL.left(DSL.literal(new ExprStringValue("value")), nullRef)));
   }
 
   @Test
@@ -351,11 +252,7 @@ public class TextFunctionTest extends ExpressionTestBase {
     FunctionExpression expression = DSL.ascii(DSL.literal(new ExprStringValue("hello")));
     assertEquals(INTEGER, expression.type());
     assertEquals(104, eval(expression).integerValue());
-
-    when(nullRef.type()).thenReturn(STRING);
-    assertEquals(nullValue(), eval(DSL.ascii(nullRef)));
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.ascii(missingRef)));
+    assertEquals(0, DSL.ascii(DSL.literal("")).valueOf().integerValue());
   }
 
   @Test
@@ -372,14 +269,6 @@ public class TextFunctionTest extends ExpressionTestBase {
         DSL.literal(7));
     assertEquals(INTEGER, expression.type());
     assertEquals(11, eval(expression).integerValue());
-
-    when(nullRef.type()).thenReturn(STRING);
-    assertEquals(nullValue(), eval(DSL.locate(nullRef, DSL.literal("hello"))));
-    assertEquals(nullValue(), eval(DSL.locate(nullRef, DSL.literal("hello"), DSL.literal(1))));
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.locate(missingRef, DSL.literal("hello"))));
-    assertEquals(missingValue(), eval(
-        DSL.locate(missingRef, DSL.literal("hello"), DSL.literal(1))));
   }
 
   @Test
@@ -395,11 +284,6 @@ public class TextFunctionTest extends ExpressionTestBase {
             DSL.literal("hello world"));
     assertEquals(INTEGER, expression.type());
     assertEquals(0, eval(expression).integerValue());
-
-    when(nullRef.type()).thenReturn(STRING);
-    assertEquals(nullValue(), eval(DSL.position(nullRef, DSL.literal("hello"))));
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.position(missingRef, DSL.literal("hello"))));
   }
 
   @Test
@@ -410,11 +294,6 @@ public class TextFunctionTest extends ExpressionTestBase {
         DSL.literal("opensearch"));
     assertEquals(STRING, expression.type());
     assertEquals("helloopensearch", eval(expression).stringValue());
-
-    when(nullRef.type()).thenReturn(STRING);
-    assertEquals(nullValue(), eval(DSL.replace(nullRef, DSL.literal("a"), DSL.literal("b"))));
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.replace(missingRef, DSL.literal("a"), DSL.literal("b"))));
   }
 
   @Test
@@ -422,11 +301,6 @@ public class TextFunctionTest extends ExpressionTestBase {
     FunctionExpression expression = DSL.reverse(DSL.literal("abcde"));
     assertEquals(STRING, expression.type());
     assertEquals("edcba", eval(expression).stringValue());
-
-    when(nullRef.type()).thenReturn(STRING);
-    assertEquals(nullValue(), eval(DSL.reverse(nullRef)));
-    when(missingRef.type()).thenReturn(STRING);
-    assertEquals(missingValue(), eval(DSL.reverse(missingRef)));
   }
 
   void testConcatString(List<String> strings) {
@@ -451,6 +325,8 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(expected, eval(expression).stringValue());
   }
 
+  @ParameterizedTest
+  @MethodSource("getMultipleStringsForConcat")
   void testConcatMultipleString(List<String> strings) {
     String expected = null;
     if (strings.stream().noneMatch(Objects::isNull)) {
@@ -467,13 +343,17 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(expected, eval(expression).stringValue());
   }
 
-  void testLengthString(String str) {
+  @ParameterizedTest
+  @MethodSource("getStringsForUpperAndLower")
+  void length(String str) {
     FunctionExpression expression = DSL.length(DSL.literal(new ExprStringValue(str)));
     assertEquals(INTEGER, expression.type());
     assertEquals(str.getBytes().length, eval(expression).integerValue());
   }
 
-  void testStcmpString(StringPatternPair stringPatternPair) {
+  @ParameterizedTest
+  @MethodSource("getStringsForComparison")
+  void strcmp(StringPatternPair stringPatternPair) {
     FunctionExpression expression = DSL.strcmp(
             DSL.literal(new ExprStringValue(stringPatternPair.getStr())),
             DSL.literal(new ExprStringValue(stringPatternPair.getPatt())));
@@ -481,19 +361,23 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(stringPatternPair.strCmpTest(), eval(expression).integerValue());
   }
 
-  void testLowerString(String str) {
+  @ParameterizedTest
+  @MethodSource("getStringsForUpperAndLower")
+  void lower(String str) {
     FunctionExpression expression = DSL.lower(DSL.literal(new ExprStringValue(str)));
     assertEquals(STRING, expression.type());
     assertEquals(stringValue(str.toLowerCase()), eval(expression));
   }
 
-  void testUpperString(String str) {
+  @ParameterizedTest
+  @MethodSource("getStringsForUpperAndLower")
+  void upper(String str) {
     FunctionExpression expression = DSL.upper(DSL.literal(new ExprStringValue(str)));
     assertEquals(STRING, expression.type());
     assertEquals(stringValue(str.toUpperCase()), eval(expression));
   }
 
   private ExprValue eval(Expression expression) {
-    return expression.valueOf(env);
+    return expression.valueOf();
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
@@ -148,7 +148,6 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(strInfo.getRes(), eval(expr).stringValue());
   }
 
-  /** Test `LTRIM` function. */
   @ParameterizedTest
   @MethodSource("getStringsForTrim")
   void ltrim(String str) {
@@ -157,19 +156,17 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(str.stripLeading(), eval(expression).stringValue());
   }
 
-  /** Test `RTRIM` function. */
   @ParameterizedTest
   @MethodSource("getStringsForTrim")
-  public void rtrim(String str) {
+  void rtrim(String str) {
     FunctionExpression expression = DSL.rtrim(DSL.literal(str));
     assertEquals(STRING, expression.type());
     assertEquals(str.stripTrailing(), eval(expression).stringValue());
   }
 
-  /** Test `TRIM` function. */
   @ParameterizedTest
   @MethodSource("getStringsForTrim")
-  public void trim(String str) {
+  void trim(String str) {
     FunctionExpression expression = DSL.trim(DSL.literal(str));
     assertEquals(STRING, expression.type());
     assertEquals(str.trim(), eval(expression).stringValue());


### PR DESCRIPTION
### Description
Update `ASCII` function (to return 0 for empty string, see [doc](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_ascii))
```
opensearchsql> select ascii('');
TransportError(503, 'StringIndexOutOfBoundsException', {'error': {'reason': 'There was internal problem at backend', 'details': 'Index 0 out of bounds for length 0', 'type': 'StringIndexOutOfBoundsException'}, 'status': 503})
```
Update UT for all text functions (similar to #198):
- remove null/missing tests
- make tests parametrized
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).