### PR TITLE
[Spotless] Fixes license headers in core/src (PR 1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,10 @@ spotless {
             exclude '**/build/**', '**/build-*/**'
         }
         importOrder()
-        licenseHeader("/*\n" +
-                " * Copyright OpenSearch Contributors\n" +
-                " * SPDX-License-Identifier: Apache-2.0\n" +
-                " */\n\n\n")
+//        licenseHeader("/*\n" +
+//                " * Copyright OpenSearch Contributors\n" +
+//                " * SPDX-License-Identifier: Apache-2.0\n" +
+//                " */\n\n\n")
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()

--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,10 @@ spotless {
             exclude '**/build/**', '**/build-*/**'
         }
         importOrder()
-//        licenseHeader("/*\n" +
-//                " * Copyright OpenSearch Contributors\n" +
-//                " * SPDX-License-Identifier: Apache-2.0\n" +
-//                " */\n\n\n")
+        licenseHeader("/*\n" +
+                " * Copyright OpenSearch Contributors\n" +
+                " * SPDX-License-Identifier: Apache-2.0\n" +
+                " */\n\n\n")
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()

--- a/core/src/main/java/org/opensearch/sql/DataSourceSchemaName.java
+++ b/core/src/main/java/org/opensearch/sql/DataSourceSchemaName.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql;
 

--- a/core/src/main/java/org/opensearch/sql/analysis/DataSourceSchemaIdentifierNameResolver.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/DataSourceSchemaIdentifierNameResolver.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.analysis;
 

--- a/core/src/main/java/org/opensearch/sql/analysis/HighlightAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/HighlightAnalyzer.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.analysis;
 
 import lombok.RequiredArgsConstructor;

--- a/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.analysis;
 
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;

--- a/core/src/main/java/org/opensearch/sql/ast/expression/Between.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/Between.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.expression;
 
 import java.util.Arrays;

--- a/core/src/main/java/org/opensearch/sql/ast/expression/HighlightFunction.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/HighlightFunction.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.expression;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/ast/expression/ScoreFunction.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/ScoreFunction.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.expression;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/ast/expression/Span.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/Span.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/ast/statement/Explain.java
+++ b/core/src/main/java/org/opensearch/sql/ast/statement/Explain.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.ast.statement;
 

--- a/core/src/main/java/org/opensearch/sql/ast/statement/Query.java
+++ b/core/src/main/java/org/opensearch/sql/ast/statement/Query.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.ast.statement;
 

--- a/core/src/main/java/org/opensearch/sql/ast/statement/Statement.java
+++ b/core/src/main/java/org/opensearch/sql/ast/statement/Statement.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.ast.statement;
 

--- a/core/src/main/java/org/opensearch/sql/ast/tree/CloseCursor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/CloseCursor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.tree;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/ast/tree/FetchCursor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/FetchCursor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.tree;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Paginate.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Paginate.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.tree;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.data.model;
 
 import java.time.Instant;

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasource;
 
 import java.util.Set;

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSource.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSource.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasource.model;
 

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasource.model;
 
 

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasource.model;
 
 public enum DataSourceType {

--- a/core/src/main/java/org/opensearch/sql/exception/NoCursorException.java
+++ b/core/src/main/java/org/opensearch/sql/exception/NoCursorException.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.exception;
 
 /**

--- a/core/src/main/java/org/opensearch/sql/exception/UnsupportedCursorRequestException.java
+++ b/core/src/main/java/org/opensearch/sql/exception/UnsupportedCursorRequestException.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.exception;
 
 /**

--- a/core/src/main/java/org/opensearch/sql/executor/ExecutionContext.java
+++ b/core/src/main/java/org/opensearch/sql/executor/ExecutionContext.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor;
 
 import java.util.Optional;

--- a/core/src/main/java/org/opensearch/sql/executor/QueryId.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryId.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor;
 

--- a/core/src/main/java/org/opensearch/sql/executor/QueryManager.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryManager.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor;
 

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor;
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/AbstractPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/AbstractPlan.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/CommandPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/CommandPlan.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/ExplainPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/ExplainPlan.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlan.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/StreamingQueryPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/StreamingQueryPlan.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.execution;
 
 import java.time.Duration;

--- a/core/src/main/java/org/opensearch/sql/executor/pagination/CanPaginateVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/executor/pagination/CanPaginateVisitor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.pagination;
 
 import org.opensearch.sql.ast.AbstractNodeVisitor;

--- a/core/src/main/java/org/opensearch/sql/executor/pagination/Cursor.java
+++ b/core/src/main/java/org/opensearch/sql/executor/pagination/Cursor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.pagination;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/org/opensearch/sql/executor/pagination/PlanSerializer.java
+++ b/core/src/main/java/org/opensearch/sql/executor/pagination/PlanSerializer.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.pagination;
 
 import com.google.common.hash.HashCode;

--- a/core/src/main/java/org/opensearch/sql/executor/streaming/Batch.java
+++ b/core/src/main/java/org/opensearch/sql/executor/streaming/Batch.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.streaming;
 
 import lombok.Data;

--- a/core/src/main/java/org/opensearch/sql/executor/streaming/DefaultMetadataLog.java
+++ b/core/src/main/java/org/opensearch/sql/executor/streaming/DefaultMetadataLog.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.streaming;
 

--- a/core/src/main/java/org/opensearch/sql/executor/streaming/MetadataLog.java
+++ b/core/src/main/java/org/opensearch/sql/executor/streaming/MetadataLog.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.streaming;
 

--- a/core/src/main/java/org/opensearch/sql/executor/streaming/MicroBatchStreamingExecution.java
+++ b/core/src/main/java/org/opensearch/sql/executor/streaming/MicroBatchStreamingExecution.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.streaming;
 

--- a/core/src/main/java/org/opensearch/sql/executor/streaming/Offset.java
+++ b/core/src/main/java/org/opensearch/sql/executor/streaming/Offset.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.streaming;
 
 import lombok.Data;

--- a/core/src/main/java/org/opensearch/sql/executor/streaming/StreamingSource.java
+++ b/core/src/main/java/org/opensearch/sql/executor/streaming/StreamingSource.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.streaming;
 
 import java.util.Optional;

--- a/core/src/main/java/org/opensearch/sql/expression/HighlightExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/HighlightExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression;
 
 import java.util.LinkedHashMap;

--- a/core/src/main/java/org/opensearch/sql/expression/NamedArgumentExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/NamedArgumentExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/StdDevAggregator.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/StdDevAggregator.java
@@ -1,15 +1,8 @@
 /*
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.expression.aggregation;
 

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/VarianceAggregator.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/VarianceAggregator.java
@@ -1,15 +1,8 @@
 /*
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.expression.aggregation;
 

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import com.google.common.collect.ImmutableMap;

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import com.google.common.collect.ImmutableMap;

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.ast.expression.Cast.getCastFunctionName;

--- a/core/src/main/java/org/opensearch/sql/expression/function/DefaultFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/DefaultFunctionResolver.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.util.AbstractMap;

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionProperties.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionProperties.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.io.Serializable;

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionResolver.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import org.apache.commons.lang3.tuple.Pair;

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionSignature.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionSignature.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.data.type.ExprCoreType.ARRAY;

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;

--- a/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/expression/function/TableFunctionImplementation.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/TableFunctionImplementation.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.expression.function;
 

--- a/core/src/main/java/org/opensearch/sql/expression/parse/GrokExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/GrokExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.parse;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/expression/parse/ParseExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/ParseExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.parse;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/expression/parse/PatternsExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/PatternsExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.parse;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/expression/parse/RegexExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/RegexExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.parse;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.span;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/org/opensearch/sql/expression/system/SystemFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/system/SystemFunctions.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.system;
 
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;

--- a/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner;
 
 import org.opensearch.sql.executor.pagination.PlanSerializer;

--- a/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner;
 
 import java.util.Optional;

--- a/core/src/main/java/org/opensearch/sql/planner/SerializablePlan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/SerializablePlan.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner;
 
 import java.io.Externalizable;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalAD.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalAD.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalCloseCursor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalCloseCursor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalFetchCursor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalFetchCursor.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalHighlight.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalHighlight.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalML.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalML.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalMLCommons.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalMLCommons.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalNested.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalNested.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPaginate.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPaginate.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalWrite.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalWrite.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/PushDownPageSize.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/PushDownPageSize.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.optimizer;
 
 import com.facebook.presto.matching.Captures;

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/read/CreateTableScanBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/read/CreateTableScanBuilder.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.optimizer.rule.read;
 
 import static org.opensearch.sql.planner.optimizer.pattern.Patterns.table;

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/read/TableScanPushDown.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/read/TableScanPushDown.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.optimizer.rule.read;
 
 import static org.opensearch.sql.planner.optimizer.pattern.Patterns.aggregate;

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/write/CreateTableWriteBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/write/CreateTableWriteBuilder.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.optimizer.rule.write;
 
 import static org.opensearch.sql.planner.optimizer.pattern.Patterns.writeTable;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/CursorCloseOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/CursorCloseOperator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/FilterOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/FilterOperator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/NestedOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/NestedOperator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical;
 
 import static java.util.stream.Collectors.mapping;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/BucketCollector.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/BucketCollector.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical.collector;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/Collector.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/Collector.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical.collector;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/MetricCollector.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/MetricCollector.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical.collector;
 
 import java.util.AbstractMap;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical.collector;
 
 import static org.opensearch.sql.data.type.ExprCoreType.DATE;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTable.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTable.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.planner.physical.datasource;
 

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.planner.physical.datasource;
 

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableSchema.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableSchema.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical.datasource;
 
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/StreamContext.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/StreamContext.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming;
 
 import lombok.Data;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGenerator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGenerator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.watermark;
 
 import lombok.RequiredArgsConstructor;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/WatermarkGenerator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/WatermarkGenerator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.watermark;
 
 /**

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/Window.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/Window.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing;
 
 import lombok.Data;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssigner.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
 import com.google.common.base.Preconditions;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
 import com.google.common.base.Preconditions;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/WindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/WindowAssigner.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
 import java.util.List;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTrigger.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTrigger.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.trigger;
 
 import lombok.RequiredArgsConstructor;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/TriggerResult.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/TriggerResult.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.trigger;
 
 import lombok.Getter;

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/WindowTrigger.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/WindowTrigger.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.trigger;
 
 import org.opensearch.sql.planner.streaming.windowing.Window;

--- a/core/src/main/java/org/opensearch/sql/storage/DataSourceFactory.java
+++ b/core/src/main/java/org/opensearch/sql/storage/DataSourceFactory.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.storage;
 

--- a/core/src/main/java/org/opensearch/sql/storage/read/TableScanBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/storage/read/TableScanBuilder.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.storage.read;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/storage/split/Split.java
+++ b/core/src/main/java/org/opensearch/sql/storage/split/Split.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.storage.split;
 
 import org.opensearch.sql.storage.StorageEngine;

--- a/core/src/main/java/org/opensearch/sql/storage/write/TableWriteBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/storage/write/TableWriteBuilder.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.storage.write;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/storage/write/TableWriteOperator.java
+++ b/core/src/main/java/org/opensearch/sql/storage/write/TableWriteOperator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.storage.write;
 
 import java.util.Collections;

--- a/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.utils;
 
 import java.time.Instant;

--- a/core/src/main/java/org/opensearch/sql/utils/MLCommonsConstants.java
+++ b/core/src/main/java/org/opensearch/sql/utils/MLCommonsConstants.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.utils;
 
 public class MLCommonsConstants {

--- a/core/src/test/java/org/opensearch/sql/analysis/model/DataSourceSchemaIdentifierNameResolverTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/model/DataSourceSchemaIdentifierNameResolverTest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.analysis.model;
 

--- a/core/src/test/java/org/opensearch/sql/ast/tree/RelationTest.java
+++ b/core/src/test/java/org/opensearch/sql/ast/tree/RelationTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ast.tree;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/common/utils/StringUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/common/utils/StringUtilsTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.common.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/data/model/ExprStringValueTest.java
+++ b/core/src/test/java/org/opensearch/sql/data/model/ExprStringValueTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.data.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/executor/QueryIdTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/QueryIdTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor;
 

--- a/core/src/test/java/org/opensearch/sql/executor/QueryManagerTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/QueryManagerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/core/src/test/java/org/opensearch/sql/executor/QueryServiceTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/QueryServiceTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor;
 

--- a/core/src/test/java/org/opensearch/sql/executor/execution/CommandPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/CommandPlanTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/test/java/org/opensearch/sql/executor/execution/ExplainPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/ExplainPlanTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/test/java/org/opensearch/sql/executor/execution/IntervalTriggerExecutionTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/IntervalTriggerExecutionTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.execution;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanFactoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanFactoryTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.execution;
 

--- a/core/src/test/java/org/opensearch/sql/executor/execution/StreamingQueryPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/StreamingQueryPlanTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/executor/pagination/CanPaginateVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/pagination/CanPaginateVisitorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.pagination;
 
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/core/src/test/java/org/opensearch/sql/executor/pagination/CursorTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/pagination/CursorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.pagination;
 
 import org.junit.jupiter.api.Assertions;

--- a/core/src/test/java/org/opensearch/sql/executor/pagination/PlanSerializerTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/pagination/PlanSerializerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.pagination;
 
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/core/src/test/java/org/opensearch/sql/executor/streaming/DefaultMetadataLogTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/streaming/DefaultMetadataLogTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.executor.streaming;
 

--- a/core/src/test/java/org/opensearch/sql/executor/streaming/MicroBatchStreamingExecutionTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/streaming/MicroBatchStreamingExecutionTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor.streaming;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/HighlightExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/HighlightExpressionTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/NamedArgumentExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/NamedArgumentExpressionTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/aggregation/StdDevAggregatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/aggregation/StdDevAggregatorTest.java
@@ -1,15 +1,8 @@
 /*
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.expression.aggregation;
 

--- a/core/src/test/java/org/opensearch/sql/expression/aggregation/VarianceAggregatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/aggregation/VarianceAggregatorTest.java
@@ -1,15 +1,8 @@
 /*
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.expression.aggregation;
 

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/AddTimeAndSubTimeTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/AddTimeAndSubTimeTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateAddAndAddDateTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateAddAndAddDateTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateDiffTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static java.time.temporal.ChronoUnit.DAYS;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateSubAndSubDateTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateSubAndSubDateTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.opensearch.sql.data.model.ExprValueUtils.fromObjectValue;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/FromUnixTimeTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/FromUnixTimeTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/PeriodFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/PeriodFunctionsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeDiffTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimestampTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimestampTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTimeStampTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTimeStampTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.datetime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLDefineTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLDefineTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.util.List;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplFourArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplFourArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplNoArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplNoArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplOneArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplOneArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplTestBase.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplThreeArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplThreeArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplTwoArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplTwoArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesNoArgsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesNoArgsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.util.List;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesOneArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesOneArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesThreeArgsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesThreeArgsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.util.List;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import java.util.List;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesTwoArgsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLnullMissingHandlingTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLnullMissingHandlingTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionPropertiesTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionPropertiesTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/OpenSearchFunctionsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/function/RelevanceFunctionResolverTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/RelevanceFunctionResolverTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/span/SpanExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/span/SpanExpressionTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.span;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/expression/system/SystemFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/system/SystemFunctionsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.expression.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/planner/DefaultImplementorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/DefaultImplementorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner;
 
 import static java.util.Collections.emptyList;

--- a/core/src/test/java/org/opensearch/sql/planner/PlanContextTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/PlanContextTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/core/src/test/java/org/opensearch/sql/planner/SerializablePlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/SerializablePlanTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner;
 
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/core/src/test/java/org/opensearch/sql/planner/physical/CursorCloseOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/CursorCloseOperatorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/planner/physical/NestedOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/NestedOperatorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical;
 
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.physical.collector;
 
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.planner.physical.datasource;
 

--- a/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableTest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.planner.physical.datasource;
 

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGeneratorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGeneratorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.watermark;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/WindowTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/WindowTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssignerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssignerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssignerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssignerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTriggerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTriggerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.planner.streaming.windowing.trigger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.storage;
 

--- a/core/src/test/java/org/opensearch/sql/storage/write/TableWriteOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/storage/write/TableWriteOperatorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.storage.write;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/org/opensearch/sql/utils/TestOperator.java
+++ b/core/src/test/java/org/opensearch/sql/utils/TestOperator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.utils;
 
 import java.io.IOException;

--- a/core/src/testFixtures/java/org/opensearch/sql/executor/DefaultExecutionEngine.java
+++ b/core/src/testFixtures/java/org/opensearch/sql/executor/DefaultExecutionEngine.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor;
 
 import java.util.ArrayList;

--- a/core/src/testFixtures/java/org/opensearch/sql/executor/DefaultQueryManager.java
+++ b/core/src/testFixtures/java/org/opensearch/sql/executor/DefaultQueryManager.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.executor;
 
 import java.util.HashMap;


### PR DESCRIPTION
### Description
Fixes license headers in core/src. 

Converts all header licenses to:
```/*
 * Copyright OpenSearch Contributors
 * SPDX-License-Identifier: Apache-2.0
 */
 ```
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).