### PR TITLE
[Spotless] Fixes license headers in PPL SQL Spark Datasources Integ-tests (PR 2)

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/auth/AuthenticationType.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/auth/AuthenticationType.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.auth;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelper.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelper.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.auth;
 
 import org.opensearch.sql.datasource.model.DataSourceMetadata;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelperImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelperImpl.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.auth;
 
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/encryptor/Encryptor.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/encryptor/Encryptor.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.encryptor;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/encryptor/EncryptorImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/encryptor/EncryptorImpl.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.encryptor;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DataSourceNotFoundException.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DataSourceNotFoundException.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.exceptions;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/CreateDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/CreateDataSourceActionRequest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/CreateDataSourceActionResponse.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/CreateDataSourceActionResponse.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/DeleteDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/DeleteDataSourceActionRequest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/DeleteDataSourceActionResponse.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/DeleteDataSourceActionResponse.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/GetDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/GetDataSourceActionRequest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/GetDataSourceActionResponse.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/GetDataSourceActionResponse.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/UpdateDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/UpdateDataSourceActionRequest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/UpdateDataSourceActionResponse.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/UpdateDataSourceActionResponse.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.model.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.rest;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCache.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCache.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.service;
 
 import org.opensearch.sql.datasource.model.DataSource;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImpl.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.service;
 
 import com.google.common.cache.Cache;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceMetadataStorage.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.service;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.service;
 
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.storage;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceAction.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceAction.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.transport;
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/Scheduler.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/Scheduler.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.utils;
 
 import java.util.Map;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/XContentParserUtils.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/XContentParserUtils.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.utils;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/auth/AuthenticationTypeTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/auth/AuthenticationTypeTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.auth;
 
 

--- a/datasources/src/test/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelperImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelperImplTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.auth;
 
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/encryptor/EncryptorImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/encryptor/EncryptorImplTest.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.datasources.encryptor;
 

--- a/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImplTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.service;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceServiceImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceServiceImplTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.storage;
 
 import static org.opensearch.sql.datasources.storage.OpenSearchDataSourceMetadataStorage.DATASOURCE_INDEX_NAME;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.transport;
 
 import static org.mockito.Mockito.doThrow;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceActionTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.transport;
 
 import static org.mockito.Mockito.doThrow;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceActionTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.transport;
 
 import static org.mockito.Mockito.doThrow;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.transport;
 
 import static org.mockito.Mockito.doThrow;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/SchedulerTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/SchedulerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasources.utils;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/XContentParserUtilsTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/XContentParserUtilsTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.datasources.utils;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasource;
 
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DatasourceClusterSettingsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DatasourceClusterSettingsIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.datasource;
 
 import static org.hamcrest.Matchers.equalTo;

--- a/integ-test/src/test/java/org/opensearch/sql/jdbc/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/jdbc/CursorIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.jdbc;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ConvertTZFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ConvertTZFunctionIT.java
@@ -1,7 +1,8 @@
-  /*
-   * Copyright OpenSearch Contributors
-   * SPDX-License-Identifier: Apache-2.0
-   */
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 
 package org.opensearch.sql.ppl;
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeComparisonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeComparisonIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.ppl;
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/LegacyAPICompatibilityIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/LegacyAPICompatibilityIT.java
@@ -2,6 +2,8 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.plugin.rest.RestPPLQueryAction.LEGACY_EXPLAIN_API_ENDPOINT;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/MatchBoolPrefixIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/MatchBoolPrefixIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PHRASE;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/MatchPhrasePrefixIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/MatchPhrasePrefixIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/NowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/NowLikeFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PositionFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PositionFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.ppl;
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/QueryStringIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/RelevanceFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/RelevanceFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
@@ -1,9 +1,8 @@
 /*
- *
- *  * Copyright OpenSearch Contributors
- *  * SPDX-License-Identifier: Apache-2.0
- *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 
 package org.opensearch.sql.ppl;
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SimpleQueryStringIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SystemFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SystemFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_NONNUMERIC;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/VisualizationFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/VisualizationFormatIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/ConvertTZFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ConvertTZFunctionIT.java
@@ -1,7 +1,8 @@
-  /*
-   * Copyright OpenSearch Contributors
-   * SPDX-License-Identifier: Apache-2.0
-   */
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 
 package org.opensearch.sql.sql;
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeComparisonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeComparisonIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeImplementationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeImplementationIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.util.MatcherUtils.rows;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/HighlightFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/HighlightFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.util.MatcherUtils.rows;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/LegacyAPICompatibilityIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/LegacyAPICompatibilityIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.hamcrest.Matchers.equalTo;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchBoolPrefixIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchBoolPrefixIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PHRASE;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.hamcrest.Matchers.containsString;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MultiMatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MultiMatchIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_MULTI_NESTED_TYPE;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NowLikeFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.junit.Assert.assertEquals;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationWindowIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationWindowIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PHRASE;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PositionFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PositionFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.util.MatcherUtils.rows;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RelevanceFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RelevanceFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/ScoreQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ScoreQueryIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.hamcrest.Matchers.containsString;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/StandalonePaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/StandalonePaginationIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.datasource.model.DataSourceMetadata.defaultOpenSearchDataSourceMetadata;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SystemFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SystemFunctionIT.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC;

--- a/integ-test/src/test/java/org/opensearch/sql/util/ExecuteOnCallerThreadQueryManager.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/ExecuteOnCallerThreadQueryManager.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.util;
 
 import org.opensearch.sql.executor.QueryId;

--- a/integ-test/src/test/java/org/opensearch/sql/util/InternalRestHighLevelClient.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/InternalRestHighLevelClient.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.util;
 
 import java.util.Collections;

--- a/integ-test/src/test/java/org/opensearch/sql/util/StandaloneModule.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/StandaloneModule.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.util;
 
 import lombok.RequiredArgsConstructor;

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstStatementBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstStatementBuilder.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.ppl.parser;
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserMatchBoolPrefixSamplesTests.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserMatchBoolPrefixSamplesTests.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl.antlr;
 
 import static org.junit.Assert.assertNotEquals;

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserMatchPhraseSamplesTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserMatchPhraseSamplesTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.ppl.antlr;
 
 import static org.junit.Assert.assertNotEquals;

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstStatementBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstStatementBuilderTest.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.ppl.parser;
 

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatter.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.protocol.response.format;
 
 import lombok.Getter;

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatter.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.protocol.response.format;
 
 import com.google.common.collect.ImmutableList;

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/ErrorFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/ErrorFormatterTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatterTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EmrClientImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EmrClientImpl.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.client;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.SPARK_INDEX_NAME;

--- a/spark/src/main/java/org/opensearch/sql/spark/client/SparkClient.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/SparkClient.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.client;
 
 import java.io.IOException;

--- a/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.data.constants;
 
 public class SparkConstants {

--- a/spark/src/main/java/org/opensearch/sql/spark/functions/implementation/SparkSqlFunctionImplementation.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/functions/implementation/SparkSqlFunctionImplementation.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions.implementation;
 
 import static org.opensearch.sql.spark.functions.resolver.SparkSqlTableFunctionResolver.QUERY;

--- a/spark/src/main/java/org/opensearch/sql/spark/functions/resolver/SparkSqlTableFunctionResolver.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/functions/resolver/SparkSqlTableFunctionResolver.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions.resolver;
 
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;

--- a/spark/src/main/java/org/opensearch/sql/spark/functions/response/DefaultSparkSqlFunctionResponseHandle.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/functions/response/DefaultSparkSqlFunctionResponseHandle.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions.response;
 
 import java.util.ArrayList;

--- a/spark/src/main/java/org/opensearch/sql/spark/functions/response/SparkSqlFunctionResponseHandle.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/functions/response/SparkSqlFunctionResponseHandle.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions.response;
 
 import org.opensearch.sql.data.model.ExprValue;

--- a/spark/src/main/java/org/opensearch/sql/spark/functions/scan/SparkSqlFunctionTableScanBuilder.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/functions/scan/SparkSqlFunctionTableScanBuilder.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions.scan;
 
 import lombok.AllArgsConstructor;

--- a/spark/src/main/java/org/opensearch/sql/spark/functions/scan/SparkSqlFunctionTableScanOperator.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/functions/scan/SparkSqlFunctionTableScanOperator.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions.scan;
 
 import java.io.IOException;

--- a/spark/src/main/java/org/opensearch/sql/spark/helper/FlintHelper.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/helper/FlintHelper.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.helper;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_DEFAULT_AUTH;

--- a/spark/src/main/java/org/opensearch/sql/spark/request/SparkQueryRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/request/SparkQueryRequest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.request;
 
 import lombok.Data;

--- a/spark/src/main/java/org/opensearch/sql/spark/response/SparkResponse.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/response/SparkResponse.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.response;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.SPARK_INDEX_NAME;

--- a/spark/src/main/java/org/opensearch/sql/spark/storage/SparkScan.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/storage/SparkScan.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import lombok.EqualsAndHashCode;

--- a/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageEngine.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageEngine.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import java.util.Collection;

--- a/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageFactory.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageFactory.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.EMR;

--- a/spark/src/main/java/org/opensearch/sql/spark/storage/SparkTable.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/storage/SparkTable.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import java.util.HashMap;

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrClientImplTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.client;
 
 import static org.mockito.Mockito.any;

--- a/spark/src/test/java/org/opensearch/sql/spark/constants/TestConstants.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/constants/TestConstants.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.constants;
 
 public class TestConstants {

--- a/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlFunctionImplementationTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlFunctionImplementationTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlFunctionTableScanBuilderTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlFunctionTableScanBuilderTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions;
 
 import static org.opensearch.sql.spark.constants.TestConstants.QUERY;

--- a/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlFunctionTableScanOperatorTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlFunctionTableScanOperatorTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlTableFunctionResolverTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/functions/SparkSqlTableFunctionResolverTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/test/java/org/opensearch/sql/spark/response/SparkResponseTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/response/SparkResponseTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.response;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/spark/src/test/java/org/opensearch/sql/spark/storage/SparkScanTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/storage/SparkScanTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageEngineTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageEngineTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageFactoryTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageFactoryTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import static org.opensearch.sql.spark.constants.TestConstants.EMR_CLUSTER_ID;

--- a/spark/src/test/java/org/opensearch/sql/spark/storage/SparkTableTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/storage/SparkTableTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spark/src/test/java/org/opensearch/sql/spark/utils/TestUtils.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/utils/TestUtils.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.spark.utils;
 
 import java.io.IOException;

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstStatementBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstStatementBuilder.java
@@ -1,10 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
+
 
 package org.opensearch.sql.sql.parser;
 

--- a/sql/src/test/java/org/opensearch/sql/common/antlr/SyntaxParserTestBase.java
+++ b/sql/src/test/java/org/opensearch/sql/common/antlr/SyntaxParserTestBase.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.common.antlr;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/HighlightTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/HighlightTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql.antlr;
 
 import org.junit.jupiter.api.Test;

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/MatchBoolPrefixParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/MatchBoolPrefixParserTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql.antlr;
 
 import java.util.stream.Stream;

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLParserTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.sql.antlr;
 
 import org.opensearch.sql.common.antlr.SyntaxParserTestBase;

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTestBase.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTestBase.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql.parser;
 
 import org.antlr.v4.runtime.tree.ParseTree;

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstNowLikeFunctionTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstNowLikeFunctionTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 package org.opensearch.sql.sql.parser;
 
 import static java.util.Collections.emptyList;


### PR DESCRIPTION
### Description
Fixes license headers 

Converts all header licenses to:
```/*
 * Copyright OpenSearch Contributors
 * SPDX-License-Identifier: Apache-2.0
 */
 ```
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).