### PR TITLE
Set target routing shard by partition key

### DIFF
--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -64,8 +64,9 @@ jobs:
         ./gradlew :core:jacocoTestCoverageVerification                   || echo "* Jacoco failed for core" >> report.log
         ./gradlew :protocol:jacocoTestCoverageVerification               || echo "* Jacoco failed for protocol" >> report.log
         ./gradlew :opensearch-sql-plugin:jacocoTestCoverageVerification  || echo "* Jacoco failed for plugin" >> report.log
-        # Misc tests
+        # Misc Integration tests
         ./gradlew :integ-test:integTest                   || echo "* Integration test failed" >> report.log
+        ./gradlew :integ-test:multiClusterSearch          || echo "* Multi-Cluster Search tests failed" >> report.log
         ./gradlew :doctest:doctest                        || echo "* Doctest failed" >> report.log
         ./scripts/bwctest.sh                              || echo "* Backward compatibility test failed" >> report.log
 

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -64,7 +64,7 @@ jobs:
         ./gradlew :core:jacocoTestCoverageVerification                   || echo "* Jacoco failed for core" >> report.log
         ./gradlew :protocol:jacocoTestCoverageVerification               || echo "* Jacoco failed for protocol" >> report.log
         ./gradlew :opensearch-sql-plugin:jacocoTestCoverageVerification  || echo "* Jacoco failed for plugin" >> report.log
-        # Misc Integration tests
+        # Misc/Additional Integration tests
         ./gradlew :integ-test:integTest                   || echo "* Integration test failed" >> report.log
         ./gradlew :integ-test:multiClusterSearch          || echo "* Multi-Cluster Search tests failed" >> report.log
         ./gradlew :doctest:doctest                        || echo "* Doctest failed" >> report.log

--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -143,6 +143,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitRelation(Relation node, AnalysisContext context) {
     QualifiedName qualifiedName = node.getTableQualifiedName();
+    String partitionName = node.getTablePartitionKeys();
     DataSourceSchemaIdentifierNameResolver dataSourceSchemaIdentifierNameResolver
         = new DataSourceSchemaIdentifierNameResolver(dataSourceService, qualifiedName.getParts());
     String tableName = dataSourceSchemaIdentifierNameResolver.getIdentifierName();
@@ -156,9 +157,11 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
           .getDataSource(dataSourceSchemaIdentifierNameResolver.getDataSourceName())
           .getStorageEngine()
           .getTable(new DataSourceSchemaName(
-              dataSourceSchemaIdentifierNameResolver.getDataSourceName(),
-              dataSourceSchemaIdentifierNameResolver.getSchemaName()),
-              dataSourceSchemaIdentifierNameResolver.getIdentifierName());
+                dataSourceSchemaIdentifierNameResolver.getDataSourceName(),
+                dataSourceSchemaIdentifierNameResolver.getSchemaName()
+              ),
+              dataSourceSchemaIdentifierNameResolver.getIdentifierName(),
+              partitionName);
     }
     table.getFieldTypes().forEach((k, v) -> curEnv.define(new Symbol(Namespace.FIELD_NAME, k), v));
     table.getReservedFieldTypes().forEach(

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -90,6 +90,10 @@ public class AstDSL {
     return new Relation(qualifiedName(tableName), alias);
   }
 
+  public UnresolvedPlan relation(String tableName, String alias, List<String> partitionKeys) {
+    return new Relation(qualifiedName(tableName), alias, partitionKeys);
+  }
+
   public UnresolvedPlan tableFunction(List<String> functionName, UnresolvedExpression... args) {
     return new TableFunction(new QualifiedName(functionName), Arrays.asList(args));
   }

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -102,10 +102,10 @@ public class Relation extends UnresolvedPlan {
   /**
    * Retrieve the partition keys associated with the table/relation
    *
-   * @return TablePartitionKeys.
+   * @return TablePartitionKeys | null
    */
   public String getTablePartitionKeys() {
-    return String.join(COMMA, partitionKeys);
+    return partitionKeys == null ? null : String.join(COMMA, partitionKeys);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -35,14 +35,25 @@ public class Relation extends UnresolvedPlan {
   }
 
   public Relation(UnresolvedExpression tableName, String alias) {
+    this(tableName, alias, null);
+  }
+
+  public Relation(UnresolvedExpression tableName, String alias, List<String> partitionKeys) {
     this.tableName = Arrays.asList(tableName);
     this.alias = alias;
+    this.partitionKeys = partitionKeys;
   }
 
   /**
    * Optional alias name for the relation.
    */
   private String alias;
+
+
+  /**
+   * Optional partition key(s) for the relation.
+   */
+  private List<String> partitionKeys;
 
   /**
    * Return table name.
@@ -86,6 +97,15 @@ public class Relation extends UnresolvedPlan {
           .map(UnresolvedExpression::toString)
           .collect(Collectors.joining(COMMA)));
     }
+  }
+
+  /**
+   * Retrieve the partition keys associated with the table/relation
+   *
+   * @return TablePartitionKeys.
+   */
+  public String getTablePartitionKeys() {
+    return String.join(COMMA, partitionKeys);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -38,6 +38,13 @@ public class Relation extends UnresolvedPlan {
     this(tableName, alias, null);
   }
 
+  /**
+   * Constructor with Partition Keys for the relation.
+   *
+   * @param tableName - name of the name relation
+   * @param alias - alias name for the relation
+   * @param partitionKeys - partition or routing keys for the relation shard
+   */
   public Relation(UnresolvedExpression tableName, String alias, List<String> partitionKeys) {
     this.tableName = Arrays.asList(tableName);
     this.alias = alias;
@@ -100,13 +107,13 @@ public class Relation extends UnresolvedPlan {
   }
 
   /**
-   * Retrieve the partition keys associated with the table/relation
+   * Retrieve the partition keys associated with the table/relation.
    *
    * @return TablePartitionKeys | null
    */
   public String getTablePartitionKeys() {
-    return partitionKeys == null ?
-        null : String.join(COMMA, partitionKeys);
+    return partitionKeys == null
+        ? null : String.join(COMMA, partitionKeys);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -105,7 +105,8 @@ public class Relation extends UnresolvedPlan {
    * @return TablePartitionKeys | null
    */
   public String getTablePartitionKeys() {
-    return partitionKeys == null ? null : String.join(COMMA, partitionKeys);
+    return partitionKeys == null ?
+        null : String.join(COMMA, partitionKeys);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
+++ b/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.storage;
 
 import java.util.Collection;
 import java.util.Collections;
+import javax.annotation.Nullable;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.expression.function.FunctionResolver;
 
@@ -19,7 +20,7 @@ public interface StorageEngine {
   /**
    * Get {@link Table} from storage engine.
    */
-  Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName);
+  Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, @Nullable String partition);
 
   /**
    * Get list of datasource related functions.

--- a/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
+++ b/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
@@ -20,7 +20,10 @@ public interface StorageEngine {
   /**
    * Get {@link Table} from storage engine.
    */
-  Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, @Nullable String partition);
+  Table getTable(
+      DataSourceSchemaName dataSourceSchemaName,
+      String tableName,
+      @Nullable String partition);
 
   /**
    * Get list of datasource related functions.

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.analysis.symbol.Namespace;
@@ -55,7 +56,7 @@ public class AnalyzerTestBase {
   }
 
   protected StorageEngine storageEngine() {
-    return (dataSourceSchemaName, tableName) -> table;
+    return (dataSourceSchemaName, tableName, partition) -> table;
   }
 
   protected StorageEngine prometheusStorageEngine() {
@@ -85,7 +86,7 @@ public class AnalyzerTestBase {
       }
 
       @Override
-      public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName) {
+      public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, @Nullable String partition) {
         return table;
       }
     };

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -86,7 +86,9 @@ public class AnalyzerTestBase {
       }
 
       @Override
-      public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, @Nullable String partition) {
+      public Table getTable(DataSourceSchemaName dataSourceSchemaName,
+                            String tableName,
+                            @Nullable String partition) {
         return table;
       }
     };

--- a/core/src/test/java/org/opensearch/sql/config/TestConfig.java
+++ b/core/src/test/java/org/opensearch/sql/config/TestConfig.java
@@ -67,7 +67,9 @@ public class TestConfig {
   protected StorageEngine storageEngine() {
     return new StorageEngine() {
       @Override
-      public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name, @Nullable String partition) {
+      public Table getTable(DataSourceSchemaName dataSourceSchemaName,
+                            String name,
+                            @Nullable String partition) {
         return new Table() {
           @Override
           public boolean exists() {

--- a/core/src/test/java/org/opensearch/sql/config/TestConfig.java
+++ b/core/src/test/java/org/opensearch/sql/config/TestConfig.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.config;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.analysis.symbol.Namespace;
 import org.opensearch.sql.analysis.symbol.Symbol;
@@ -66,7 +67,7 @@ public class TestConfig {
   protected StorageEngine storageEngine() {
     return new StorageEngine() {
       @Override
-      public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name) {
+      public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name, @Nullable String partition) {
         return new Table() {
           @Override
           public boolean exists() {

--- a/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
@@ -58,7 +58,7 @@ public class PlannerTest extends PhysicalPlanTestBase {
 
   @BeforeEach
   public void setUp() {
-    when(storageEngine.getTable(any(), any())).thenReturn(new MockTable());
+    when(storageEngine.getTable(any(), any(), any())).thenReturn(new MockTable());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class PlannerTest extends PhysicalPlanTestBase {
                     LogicalPlanDSL.relation("schema",
                         storageEngine.getTable(
                             new DataSourceSchemaName(DEFAULT_DATASOURCE_NAME, "default"),
-                        "schema")),
+                        "schema", "partition")),
                     DSL.equal(DSL.ref("response", INTEGER), DSL.literal(10))
                 ),
                 ImmutableList.of(DSL.named("avg(response)", DSL.avg(DSL.ref("response", INTEGER)))),

--- a/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
@@ -15,7 +15,7 @@ public class StorageEngineTest {
 
   @Test
   void testFunctionsMethod() {
-    StorageEngine k = (dataSourceSchemaName, tableName) -> null;
+    StorageEngine k = (dataSourceSchemaName, tableName, partition) -> null;
     Assertions.assertEquals(Collections.emptyList(), k.getFunctions());
   }
 }

--- a/docs/user/dql/basics.rst
+++ b/docs/user/dql/basics.rst
@@ -363,6 +363,17 @@ SQL query::
 	{
 	  "query" : "SELECT account_number FROM accounts/account"
 	}
+Example 4: Selecting From Index using Partition Shard
+-----------------------------------------------------------
+
+You can also specify a specific shard or partition to target using a routing hash key in ``PARTITION``.  You can target multiple shards by providing a list separated by commas.
+
+SQL query::
+
+	POST /_plugins/_sql
+	{
+	  "query" : "SELECT account_number FROM account PARTITION(shard1, shard2)"
+	}
 
 WHERE
 =====

--- a/docs/user/optimization/optimization.rst
+++ b/docs/user/optimization/optimization.rst
@@ -44,7 +44,7 @@ The consecutive Filter operator will be merged as one Filter operator::
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\":{\"age\":{\"from\":null,\"to\":20,\"include_lower\":true,\"include_upper\":false,\"boost\":1.0}}},{\"range\":{\"age\":{\"from\":10,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\":{\"age\":{\"from\":null,\"to\":20,\"include_lower\":true,\"include_upper\":false,\"boost\":1.0}}},{\"range\":{\"age\":{\"from\":10,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -71,7 +71,7 @@ The Filter operator should be push down under Sort operator::
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":null,\"to\":20,\"include_lower\":true,\"include_upper\":false,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":null,\"to\":20,\"include_lower\":true,\"include_upper\":false,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -102,7 +102,7 @@ The Project list will push down to Query DSL to `filter the source <https://www.
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -128,7 +128,7 @@ The Filter operator will merge into OpenSearch Query DSL::
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -154,7 +154,7 @@ The Sort operator will merge into OpenSearch Query DSL::
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -188,7 +188,7 @@ Because the OpenSearch Script Based Sorting can't handle NULL/MISSING value, the
               {
                 "name": "OpenSearchIndexScan",
                 "description": {
-                  "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\"}, searchDone=false)"
+                  "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\"}, searchDone=false, routingId=null)"
                 },
                 "children": []
               }
@@ -216,7 +216,7 @@ The Limit operator will merge in OpenSearch Query DSL::
               {
                 "name": "OpenSearchIndexScan",
                 "description": {
-                  "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":5,\"size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, searchDone=false)"
+                  "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":5,\"size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, searchDone=false, routingId=null)"
                 },
                 "children": []
               }
@@ -257,7 +257,7 @@ If sort that includes expression, which cannot be merged into query DSL, also ex
                       {
                         "name": "OpenSearchIndexScan",
                         "description": {
-                          "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\"}, searchDone=false)"
+                          "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\"}, searchDone=false, routingId=null)"
                         },
                         "children": []
                       }
@@ -287,7 +287,7 @@ The Aggregation operator will merge into OpenSearch Aggregation::
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"gender\":{\"terms\":{\"field\":\"gender.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"gender\":{\"terms\":{\"field\":\"gender.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -313,7 +313,7 @@ The Sort operator will merge into OpenSearch Aggregation.::
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"gender\":{\"terms\":{\"field\":\"gender.keyword\",\"missing_bucket\":true,\"missing_order\":\"last\",\"order\":\"desc\"}}}]},\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"gender\":{\"terms\":{\"field\":\"gender.keyword\",\"missing_bucket\":true,\"missing_order\":\"last\",\"order\":\"desc\"}}}]},\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone=false, routingId=null)"
             },
             "children": []
           }
@@ -348,7 +348,7 @@ Because the OpenSearch Composite Aggregation doesn't support order by metrics fi
               {
                 "name": "OpenSearchIndexScan",
                 "description": {
-                  "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"gender\":{\"terms\":{\"field\":\"gender.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone=false)"
+                  "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"gender\":{\"terms\":{\"field\":\"gender.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone=false, routingId=null)"
                 },
                 "children": []
               }

--- a/docs/user/ppl/interfaces/endpoint.rst
+++ b/docs/user/ppl/interfaces/endpoint.rst
@@ -91,7 +91,7 @@ The following PPL query demonstrated that where and stats command were pushed do
           {
             "name": "OpenSearchIndexScan",
             "description": {
-              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":10,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}],\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}, searchDone=false)"
+              "request": "OpenSearchQueryRequest(indexName=accounts, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":10,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}],\"aggregations\":{\"avg(age)\":{\"avg\":{\"field\":\"age\"}}}}, searchDone=false, routingId=null)"
             },
             "children": []
           }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -481,6 +481,68 @@ task bwcTestSuite(type: StandaloneRestIntegTestTask) {
     dependsOn tasks.named("${baseName}#fullRestartClusterTask")
 }
 
+testClusters {
+    multiClusterSearch {
+        testDistribution = "ARCHIVE"
+        numberOfNodes = 3
+        plugin ":opensearch-sql-plugin"
+    }
+}
+
+task multiClusterSearch(type: RestIntegTestTask) {
+    useCluster testClusters.multiClusterSearch
+
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+
+    // Set properties for connection to clusters and between clusters
+    doFirst {
+        getClusters().forEach { cluster ->
+            String allTransportSocketURI = cluster.nodes.stream().flatMap { node ->
+                node.getAllTransportPortURI().stream()
+            }.collect(Collectors.joining(","))
+            String allHttpSocketURI = cluster.nodes.stream().flatMap { node ->
+                node.getAllHttpSocketURI().stream()
+            }.collect(Collectors.joining(","))
+
+            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> allHttpSocketURI}"
+            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> allTransportSocketURI}"
+        }
+    }
+
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Set default query size limit
+    systemProperty 'defaultQuerySizeLimit', '10000'
+
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst {
+        if (System.getProperty("debug-jvm") != null) {
+            setDebug(true);
+        }
+        systemProperty 'cluster.debug', getDebug()
+    }
+
+
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006'
+    }
+
+    filter {
+        includeTestsMatching "org.opensearch.sql.multiClusterSearch.*IT"
+    }
+}
+
+
 def opensearch_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -285,6 +285,9 @@ integTest {
     exclude 'org/opensearch/sql/doctest/**/*IT.class'
     exclude 'org/opensearch/sql/correctness/**'
 
+    // Skip to run these IT tests on a different cluster
+    exclude 'org/opensearch/sql/multiClusterSearch/**'
+
     // Explain IT is dependent on internal implementation of old engine so it's not necessary
     // to run these with new engine and not necessary to make this consistent with old engine.
     exclude 'org/opensearch/sql/legacy/ExplainIT.class'

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -50,6 +50,8 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
 
   private static final Logger LOG = LogManager.getLogger();
   public static final String REMOTE_CLUSTER = "remoteCluster";
+
+  public static final String MULTI_REMOTE_CLUSTER = "multiClusterSearch";
   public static final String MATCH_ALL_REMOTE_CLUSTER = "*";
 
   private static RestClient remoteClient;
@@ -105,10 +107,10 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
   }
 
   // Modified from initClient in OpenSearchRestTestCase
-  public void initRemoteClient() throws IOException {
+  public void initRemoteClient(String clusterName) throws IOException {
     if (remoteClient == null) {
       assert remoteAdminClient == null;
-      String cluster = getTestRestCluster(REMOTE_CLUSTER);
+      String cluster = getTestRestCluster(clusterName);
       String[] stringUrls = cluster.split(",");
       List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
       for (String stringUrl : stringUrls) {
@@ -252,14 +254,14 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
    * Initialize rest client to remote cluster,
    * and create a connection to it from the coordinating cluster.
    */
-  public void configureMultiClusters() throws IOException {
-    initRemoteClient();
+  public void configureMultiClusters(String clusterName) throws IOException {
+    initRemoteClient(clusterName);
 
     Request connectionRequest = new Request("PUT", "_cluster/settings");
     String connectionSetting = "{\"persistent\": {\"cluster\": {\"remote\": {\""
-        + REMOTE_CLUSTER
+        + clusterName
         + "\": {\"seeds\": [\""
-        + getTestTransportCluster(REMOTE_CLUSTER).split(",")[0]
+        + getTestTransportCluster(clusterName).split(",")[0]
         + "\"]}}}}}";
     connectionRequest.setJsonEntity(connectionSetting);
     adminClient().performRequest(connectionRequest);

--- a/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/CrossClusterSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/CrossClusterSearchIT.java
@@ -27,10 +27,10 @@ public class CrossClusterSearchIT extends PPLIntegTestCase {
   @Rule
   public ExpectedException exceptionRule = ExpectedException.none();
 
-  private final static String TEST_INDEX_BANK_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_BANK;
-  private final static String TEST_INDEX_DOG_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
+  private final static String TEST_INDEX_BANK_REMOTE = MULTI_REMOTE_CLUSTER + ":" + TEST_INDEX_BANK;
+  private final static String TEST_INDEX_DOG_REMOTE = MULTI_REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
   private final static String TEST_INDEX_DOG_MATCH_ALL_REMOTE = MATCH_ALL_REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
-  private final static String TEST_INDEX_ACCOUNT_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_ACCOUNT;
+  private final static String TEST_INDEX_ACCOUNT_REMOTE = MULTI_REMOTE_CLUSTER + ":" + TEST_INDEX_ACCOUNT;
 
   @Override
   public void init() throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/CrossClusterSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/CrossClusterSearchIT.java
@@ -4,7 +4,7 @@
  */
 
 
-package org.opensearch.sql.ppl;
+package org.opensearch.sql.multiClusterSearch;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
@@ -20,6 +20,7 @@ import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.ResponseException;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class CrossClusterSearchIT extends PPLIntegTestCase {
 
@@ -33,7 +34,7 @@ public class CrossClusterSearchIT extends PPLIntegTestCase {
 
   @Override
   public void init() throws IOException {
-    configureMultiClusters(REMOTE_CLUSTER);
+    configureMultiClusters(MULTI_REMOTE_CLUSTER);
     loadIndex(Index.BANK);
     loadIndex(Index.BANK, remoteClient());
     loadIndex(Index.DOG);

--- a/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/ShardingSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/ShardingSearchIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.multiClusterSearch;
+
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+import static org.opensearch.sql.util.TestUtils.createHiddenIndexByRestClient;
+import static org.opensearch.sql.util.TestUtils.performRequest;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.client.Request;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+public class ShardingSearchIT extends SQLIntegTestCase {
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  private final static String MAPPING = "{ " +
+      "\"settings\": {" +
+      "  \"number_of_shards\": 3" +
+      "}," +
+      "\"mappings\" : {" +
+      "  \"_routing\": { \"required\": true }," +
+      "  \"properties\" : { " +
+      "    \"age\" : { \"type\" : \"long\" } } } }";
+
+  @Override
+  public void init() throws IOException {
+    configureMultiClusters(MULTI_REMOTE_CLUSTER);
+  }
+
+  @Test
+  public void testMetafieldIdentifierRoutingTest() throws IOException {
+    // create an index, but the contents doesn't really matter
+    String index = "test.routing_partition";
+    new Index(index, MAPPING)
+        .addDocWithShardId("{\"age\": 31}", "test0", "test0")
+        .addDocWithShardId("{\"age\": 31}", "test1", "test1")
+        .addDocWithShardId("{\"age\": 32}", "test2", "test2")
+        .addDocWithShardId("{\"age\": 33}", "test3", "test3")
+        .addDocWithShardId("{\"age\": 34}", "test4", "test4")
+        .addDocWithShardId("{\"age\": 35}", "test5", "test5");
+
+    // Execute using field metadata values filtering on the routing shard hash id
+    String query = "SELECT age, _id, _index, _routing "
+        + "FROM " + index + " partition(test4)";
+    final JSONObject result = new JSONObject(executeQuery(query, "jdbc"));
+
+    // Verify that the metadata values are returned when requested
+    verifySchema(result,
+        schema("age", null, "long"),
+        schema("_id", null, "keyword"),
+        schema("_index", null, "keyword"),
+        schema("_routing", null, "keyword"));
+    assertTrue(result.getJSONArray("schema").length() == 4);
+
+    // expect AT LEAST one result as we're requested all data on a single shard,
+    // but multiple _routing hashes can point to the same shard
+    var datarows = result.getJSONArray("datarows");
+    assertTrue(datarows.length() > 0);
+  }
+
+  @Test
+  public void testMetafieldIdentifierRoutingWhereTest() throws IOException {
+    // create an index, but the contents doesn't really matter
+    String index = "test.routing_where";
+    new Index(index, MAPPING)
+        .addDocWithShardId("{\"age\": 31}", "test0", "test0")
+        .addDocWithShardId("{\"age\": 31}", "test1", "test1")
+        .addDocWithShardId("{\"age\": 32}", "test2", "test2")
+        .addDocWithShardId("{\"age\": 33}", "test3", "test3")
+        .addDocWithShardId("{\"age\": 34}", "test4", "test4")
+        .addDocWithShardId("{\"age\": 35}", "test5", "test5");
+
+    // Execute using field metadata values filtering on the routing shard hash id
+    String query = "SELECT age, _id, _index, _routing "
+        + "FROM " + index + " partition(test4) "
+        + "WHERE _routing='test4'";
+    final JSONObject result = new JSONObject(executeQuery(query, "jdbc"));
+
+    // Verify that the metadata values are returned when requested
+    verifySchema(result,
+        schema("age", null, "long"),
+        schema("_id", null, "keyword"),
+        schema("_index", null, "keyword"),
+        schema("_routing", null, "keyword"));
+    assertTrue(result.getJSONArray("schema").length() == 4);
+
+    // expect exactly one result as we're filtering on the _routing shard
+    var datarows = result.getJSONArray("datarows");
+    assertEquals(1, datarows.length());
+
+    assertEquals("test4", datarows.getJSONArray(0).getString(1));
+    assertEquals(index, datarows.getJSONArray(0).getString(2));
+    assertEquals("test4", datarows.getJSONArray(0).getString(3));
+  }
+
+  @Test
+  public void testMetafieldIdentifierRoutingWithoutPartitionTest() throws IOException {
+    // create an index with 3 shards
+    String index = "test.routing_empty";
+    new Index(index, MAPPING)
+        .addDocWithShardId("{\"age\": 31}", "test0", "test0")
+        .addDocWithShardId("{\"age\": 31}", "test1", "test1")
+        .addDocWithShardId("{\"age\": 32}", "test2", "test2")
+        .addDocWithShardId("{\"age\": 33}", "test3", "test3")
+        .addDocWithShardId("{\"age\": 34}", "test4", "test4")
+        .addDocWithShardId("{\"age\": 35}", "test5", "test5");
+
+    // Execute using field metadata values filtering on the routing shard hash id
+    String query = "SELECT age, _id, _index, _routing "
+        + "FROM " + index;
+    final JSONObject result = new JSONObject(executeQuery(query, "jdbc"));
+
+    // Verify that the metadata values are returned when requested
+    verifySchema(result,
+        schema("age", null, "long"),
+        schema("_id", null, "keyword"),
+        schema("_index", null, "keyword"),
+        schema("_routing", null, "keyword"));
+    assertTrue(result.getJSONArray("schema").length() == 4);
+
+    // expect that when partition/shard is not specified, all data is returned
+    var datarows = result.getJSONArray("datarows");
+    assertEquals(6, datarows.length());
+  }
+
+  @Test
+  public void testWithoutRoutingThrowsTest() throws IOException {
+    Index index = new Index("test.routing_error", MAPPING);
+
+    // routing is required when pushing data
+    final IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> index.addDoc("{\"age\": 31}", "test0"));
+  }
+
+  /**
+   * Index abstraction for test code readability.
+   */
+  private static class Index {
+
+    private final String indexName;
+
+    Index(String indexName) throws IOException {
+      this.indexName = indexName;
+
+      if (indexName.startsWith(".")) {
+        createHiddenIndexByRestClient(client(), indexName, "");
+      } else {
+        executeRequest(new Request("PUT", "/" + indexName));
+      }
+    }
+
+    Index(String indexName, String mapping) throws IOException {
+      this.indexName = indexName;
+
+      Request createIndex = new Request("PUT", "/" + indexName);
+      createIndex.setJsonEntity(mapping);
+      executeRequest(createIndex);
+    }
+
+    void addDoc(String doc) {
+      Request indexDoc = new Request("POST", String.format("/%s/_doc?refresh=true", indexName));
+      indexDoc.setJsonEntity(doc);
+      performRequest(client(), indexDoc);
+    }
+
+    public Index addDoc(String doc, String id) {
+      Request indexDoc = new Request("POST", String.format("/%s/_doc/%s?refresh=true", indexName, id));
+      indexDoc.setJsonEntity(doc);
+      performRequest(client(), indexDoc);
+      return this;
+    }
+
+    public Index addDocWithShardId(String doc, String id, String routing) {
+      Request indexDoc = new Request("POST", String.format("/%s/_doc/%s?refresh=true&routing=%s", indexName, id, routing));
+      indexDoc.setJsonEntity(doc);
+      performRequest(client(), indexDoc);
+      return this;
+    }
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/sql/IdentifierIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/IdentifierIT.java
@@ -140,48 +140,7 @@ public class IdentifierIT extends SQLIntegTestCase {
     for (int i = 0; i < 6; i++) {
       assertEquals("test" + i, datarows.getJSONArray(i).getString(1));
       assertEquals(index, datarows.getJSONArray(i).getString(2));
-      assertTrue(datarows.getJSONArray(i).getString(3).contains("[" + index + "]"));
-    }
-  }
-
-  @Test
-  public void testMetafieldIdentifierRoutingPartitionTest() throws IOException {
-    // create an index with routing required
-    String index = "test.routing_partition";
-    final String mapping = "{ " +
-        "\"mappings\" : {" +
-        "  \"_routing\": { \"required\": true }," +
-        "  \"properties\" : { " +
-        "    \"age\" : { \"type\" : \"long\" } } } }";
-    new Index(index, mapping)
-        .addDocWithShardId("{\"age\": 31}", "test0", "test0")
-        .addDocWithShardId("{\"age\": 31}", "test1", "test1")
-        .addDocWithShardId("{\"age\": 32}", "test2", "test2")
-        .addDocWithShardId("{\"age\": 33}", "test3", "test3")
-        .addDocWithShardId("{\"age\": 34}", "test4", "test4")
-        .addDocWithShardId("{\"age\": 35}", "test5", "test5");
-
-    // Execute using field metadata values filtering on the routing shard hash id
-    String query = "SELECT age, _id, _index, _routing "
-        + "FROM " + index + " PARTITION(test4,test5)";
-    final JSONObject result = new JSONObject(executeQuery(query, "jdbc"));
-
-    // Verify that the metadata values are returned when requested
-    verifySchema(result,
-        schema("age", null, "long"),
-        schema("_id", null, "keyword"),
-        schema("_index", null, "keyword"),
-        schema("_routing", null, "keyword"));
-    assertTrue(result.getJSONArray("schema").length() == 4);
-
-    var datarows = result.getJSONArray("datarows");
-    assertEquals(2, datarows.length());
-
-    // note that _routing in the SELECT clause returns the shard
-    for (int i = 0; i < 2; i++) {
-      assertEquals("test" + i, datarows.getJSONArray(i).getString(1));
-      assertEquals(index, datarows.getJSONArray(i).getString(2));
-      assertTrue(datarows.getJSONArray(i).getString(3).contains("[" + index + "]"));
+      assertEquals("test" + i, datarows.getJSONArray(i).getString(3));
     }
   }
 
@@ -220,9 +179,7 @@ public class IdentifierIT extends SQLIntegTestCase {
     assertEquals(1, datarows.length());
 
     assertEquals("test4", datarows.getJSONArray(0).getString(0));
-    // note that _routing in the SELECT clause returns the shard, not the routing hash id
-    assertTrue(datarows.getJSONArray(0).getString(2).contains("[" + index + "]"));
-
+    assertEquals("test4", datarows.getJSONArray(0).getString(2));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/StandalonePaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/StandalonePaginationIT.java
@@ -112,7 +112,7 @@ public class StandalonePaginationIT extends SQLIntegTestCase {
     }
 
     // act 1, asserts in firstResponder
-    var t = new OpenSearchIndex(client, defaultSettings(), "test");
+    var t = new OpenSearchIndex(client, defaultSettings(), "test", "routingId");
     LogicalPlan p = new LogicalPaginate(1, List.of(
         new LogicalProject(
           new LogicalRelation("test", t), List.of(

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_agg_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_agg_push.json
@@ -8,7 +8,7 @@
       {
         "name": "OpenSearchIndexScan",
         "description": {
-          "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}],\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"state\":{\"terms\":{\"field\":\"state.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}},{\"city\":{\"terms\":{\"field\":\"city.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg_age\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone\u003dfalse)"
+          "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}],\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"state\":{\"terms\":{\"field\":\"state.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}},{\"city\":{\"terms\":{\"field\":\"city.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg_age\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone\u003dfalse, routingId\u003dnull)"
         },
         "children": []
       }

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push.json
@@ -8,7 +8,7 @@
       {
         "name": "OpenSearchIndexScan",
         "description": {
-          "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"bool\":{\"filter\":[{\"range\":{\"balance\":{\"from\":10000,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},{\"range\":{\"age\":{\"from\":null,\"to\":40,\"include_lower\":true,\"include_upper\":false,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, searchDone\u003dfalse)"
+          "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"bool\":{\"filter\":[{\"range\":{\"balance\":{\"from\":10000,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},{\"range\":{\"age\":{\"from\":null,\"to\":40,\"include_lower\":true,\"include_upper\":false,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, searchDone\u003dfalse, routingId\u003dnull)"
         },
         "children": []
       }

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_output.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_output.json
@@ -31,7 +31,7 @@
                   {
                     "name": "OpenSearchIndexScan",
                     "description": {
-                      "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}],\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"state\":{\"terms\":{\"field\":\"state.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}},{\"city\":{\"terms\":{\"field\":\"city.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg_age\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone\u003dfalse)"
+                      "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}],\"aggregations\":{\"composite_buckets\":{\"composite\":{\"size\":1000,\"sources\":[{\"state\":{\"terms\":{\"field\":\"state.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}},{\"city\":{\"terms\":{\"field\":\"city.keyword\",\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg_age\":{\"avg\":{\"field\":\"age\"}}}}}}, searchDone\u003dfalse, routingId\u003dnull)"
                     },
                     "children": []
                   }

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_push.json
@@ -8,7 +8,7 @@
       {
         "name": "OpenSearchIndexScan",
         "description": {
-          "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone\u003dfalse)"
+          "request": "OpenSearchQueryRequest(indexName\u003dopensearch-sql_test_index_account, sourceBuilder\u003d{\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone\u003dfalse, routingId\u003dnull)"
         },
         "children": []
       }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -148,7 +148,7 @@ public class RestSqlAction extends BaseRestHandler {
 
             // Route request to new query engine if it's supported already
             SQLQueryRequest newSqlRequest = new SQLQueryRequest(sqlRequest.getJsonContent(),
-                sqlRequest.getSql(), request.path(), request.params(), sqlRequest.cursor());
+                sqlRequest.getSql(), request.path(), request.params(), sqlRequest.cursor(), sqlRequest.routingIds());
             return newSqlQueryHandler.prepareRequest(newSqlRequest,
                     (restChannel, exception) -> {
                         try{

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -148,7 +148,7 @@ public class RestSqlAction extends BaseRestHandler {
 
             // Route request to new query engine if it's supported already
             SQLQueryRequest newSqlRequest = new SQLQueryRequest(sqlRequest.getJsonContent(),
-                sqlRequest.getSql(), request.path(), request.params(), sqlRequest.cursor(), sqlRequest.routingIds());
+                sqlRequest.getSql(), request.path(), request.params(), sqlRequest.cursor());
             return newSqlQueryHandler.prepareRequest(newSqlRequest,
                     (restChannel, exception) -> {
                         try{

--- a/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequest.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequest.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.legacy.request;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.opensearch.common.settings.Settings;
@@ -28,6 +29,7 @@ public class SqlRequest {
     JSONObject jsonContent;
     String cursor;
     Integer fetchSize;
+    private List<String> routingIds;
 
     public SqlRequest(final String sql, final JSONObject jsonContent) {
         this.sql = sql;
@@ -38,10 +40,12 @@ public class SqlRequest {
         this.cursor = cursor;
     }
 
-    public SqlRequest(final String sql, final Integer fetchSize, final JSONObject jsonContent) {
+    public SqlRequest(final String sql, final Integer fetchSize, final JSONObject jsonContent,
+                      final List<String> routingIds) {
         this.sql = sql;
         this.fetchSize = fetchSize;
         this.jsonContent = jsonContent;
+        this.routingIds = routingIds;
     }
 
     private static boolean isValidJson(String json) {
@@ -64,6 +68,8 @@ public class SqlRequest {
     public Integer fetchSize() {
         return this.fetchSize;
     }
+
+    public List<String> routingIds() { return this.routingIds; }
 
     public JSONObject getJsonContent() {
         return this.jsonContent;

--- a/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequest.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequest.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.legacy.request;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.opensearch.common.settings.Settings;
@@ -29,7 +28,6 @@ public class SqlRequest {
     JSONObject jsonContent;
     String cursor;
     Integer fetchSize;
-    private List<String> routingIds;
 
     public SqlRequest(final String sql, final JSONObject jsonContent) {
         this.sql = sql;
@@ -40,12 +38,10 @@ public class SqlRequest {
         this.cursor = cursor;
     }
 
-    public SqlRequest(final String sql, final Integer fetchSize, final JSONObject jsonContent,
-                      final List<String> routingIds) {
+    public SqlRequest(final String sql, final Integer fetchSize, final JSONObject jsonContent) {
         this.sql = sql;
         this.fetchSize = fetchSize;
         this.jsonContent = jsonContent;
-        this.routingIds = routingIds;
     }
 
     private static boolean isValidJson(String json) {
@@ -68,8 +64,6 @@ public class SqlRequest {
     public Integer fetchSize() {
         return this.fetchSize;
     }
-
-    public List<String> routingIds() { return this.routingIds; }
 
     public JSONObject getJsonContent() {
         return this.jsonContent;

--- a/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestFactory.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestFactory.java
@@ -24,6 +24,7 @@ public class SqlRequestFactory {
 
     public static final String SQL_CURSOR_FIELD_NAME = "cursor";
     public static final String SQL_FETCH_FIELD_NAME = "fetch_size";
+    public static final String ROUTING_FIELD_NAME = "routing";
 
     public static SqlRequest getSqlRequest(RestRequest request) {
         switch (request.method()) {
@@ -63,7 +64,22 @@ public class SqlRequestFactory {
             List<PreparedStatementRequest.PreparedStatementParameter> parameters = parseParameters(paramArray);
             return new PreparedStatementRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent, parameters);
         }
-        return new SqlRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent);
+
+        List<String> routingIds = List.of();
+        if (jsonContent.has(ROUTING_FIELD_NAME)) {
+            try {
+                routingIds = List.of(jsonContent.getString(ROUTING_FIELD_NAME));
+            } catch (JSONException ignored) {
+                try {
+                    JSONArray routingIdArray = jsonContent.getJSONArray(ROUTING_FIELD_NAME);
+                    routingIds = parseRoutingIds(routingIdArray);
+                } catch (JSONException jsonException) {
+                    throw new IllegalArgumentException(ROUTING_FIELD_NAME + " parameter must be defined as a string or array value", jsonException);
+                }
+            }
+        }
+
+        return new SqlRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent, routingIds);
     }
 
 
@@ -80,6 +96,14 @@ public class SqlRequestFactory {
             throw new IllegalArgumentException("Failed to parse field [" + SQL_FETCH_FIELD_NAME +"]", e);
         }
         return fetchSize.orElse(0);
+    }
+
+    private static List<String> parseRoutingIds(JSONArray array) {
+        List<String> routingIds = List.of();
+        for (int i = 0; i < array.length(); i++) {
+            routingIds.add(array.getString(i));
+        }
+        return routingIds;
     }
 
     private static List<PreparedStatementRequest.PreparedStatementParameter> parseParameters(

--- a/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestFactory.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestFactory.java
@@ -24,7 +24,6 @@ public class SqlRequestFactory {
 
     public static final String SQL_CURSOR_FIELD_NAME = "cursor";
     public static final String SQL_FETCH_FIELD_NAME = "fetch_size";
-    public static final String ROUTING_FIELD_NAME = "routing";
 
     public static SqlRequest getSqlRequest(RestRequest request) {
         switch (request.method()) {
@@ -65,21 +64,7 @@ public class SqlRequestFactory {
             return new PreparedStatementRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent, parameters);
         }
 
-        List<String> routingIds = List.of();
-        if (jsonContent.has(ROUTING_FIELD_NAME)) {
-            try {
-                routingIds = List.of(jsonContent.getString(ROUTING_FIELD_NAME));
-            } catch (JSONException ignored) {
-                try {
-                    JSONArray routingIdArray = jsonContent.getJSONArray(ROUTING_FIELD_NAME);
-                    routingIds = parseRoutingIds(routingIdArray);
-                } catch (JSONException jsonException) {
-                    throw new IllegalArgumentException(ROUTING_FIELD_NAME + " parameter must be defined as a string or array value", jsonException);
-                }
-            }
-        }
-
-        return new SqlRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent, routingIds);
+        return new SqlRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent);
     }
 
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestFactory.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestFactory.java
@@ -63,7 +63,6 @@ public class SqlRequestFactory {
             List<PreparedStatementRequest.PreparedStatementParameter> parameters = parseParameters(paramArray);
             return new PreparedStatementRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent, parameters);
         }
-
         return new SqlRequest(sql, validateAndGetFetchSize(jsonContent), jsonContent);
     }
 
@@ -81,14 +80,6 @@ public class SqlRequestFactory {
             throw new IllegalArgumentException("Failed to parse field [" + SQL_FETCH_FIELD_NAME +"]", e);
         }
         return fetchSize.orElse(0);
-    }
-
-    private static List<String> parseRoutingIds(JSONArray array) {
-        List<String> routingIds = List.of();
-        for (int i = 0; i < array.length(); i++) {
-            routingIds.add(array.getString(i));
-        }
-        return routingIds;
     }
 
     private static List<PreparedStatementRequest.PreparedStatementParameter> parseParameters(

--- a/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.fail;
 import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -98,8 +99,9 @@ public class RestSQLQueryActionCursorFallbackTest extends BaseRestHandler {
     builder.endObject();
     JSONObject jsonContent = new JSONObject(Strings.toString(builder));
 
+    // TODO pass through
     return  new SQLQueryRequest(jsonContent, query, QUERY_API_ENDPOINT,
-        Map.of("format", "jdbc"), cursorId.orElse(""));
+        Map.of("format", "jdbc"), cursorId.orElse(""), List.of());
   }
 
   boolean doesQueryFallback(SQLQueryRequest request) throws Exception {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
@@ -101,7 +101,7 @@ public class RestSQLQueryActionCursorFallbackTest extends BaseRestHandler {
 
     // TODO pass through
     return  new SQLQueryRequest(jsonContent, query, QUERY_API_ENDPOINT,
-        Map.of("format", "jdbc"), cursorId.orElse(""), List.of());
+        Map.of("format", "jdbc"), cursorId.orElse(""));
   }
 
   boolean doesQueryFallback(SQLQueryRequest request) throws Exception {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/plugin/RestSQLQueryActionCursorFallbackTest.java
@@ -99,7 +99,6 @@ public class RestSQLQueryActionCursorFallbackTest extends BaseRestHandler {
     builder.endObject();
     JSONObject jsonContent = new JSONObject(Strings.toString(builder));
 
-    // TODO pass through
     return  new SQLQueryRequest(jsonContent, query, QUERY_API_ENDPOINT,
         Map.of("format", "jdbc"), cursorId.orElse(""));
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java
@@ -58,34 +58,47 @@ public class OpenSearchQueryRequest implements OpenSearchRequest {
   private boolean searchDone = false;
 
   /**
+   *
+   */
+  private final IndexName routingId;
+
+  /**
    * Constructor of OpenSearchQueryRequest.
    */
-  public OpenSearchQueryRequest(String indexName, int size,
+  public OpenSearchQueryRequest(String indexName,
+                                String routingId,
+                                int size,
                                 OpenSearchExprValueFactory factory) {
-    this(new IndexName(indexName), size, factory);
+    this(new IndexName(indexName), new IndexName(routingId), size, factory);
   }
 
   /**
    * Constructor of OpenSearchQueryRequest.
    */
-  public OpenSearchQueryRequest(IndexName indexName, int size,
-      OpenSearchExprValueFactory factory) {
+  public OpenSearchQueryRequest(IndexName indexName,
+                                IndexName routingId,
+                                int size,
+                                OpenSearchExprValueFactory factory) {
     this.indexName = indexName;
     this.sourceBuilder = new SearchSourceBuilder();
     sourceBuilder.from(0);
     sourceBuilder.size(size);
     sourceBuilder.timeout(DEFAULT_QUERY_TIMEOUT);
     this.exprValueFactory = factory;
+    this.routingId = routingId;
   }
 
   /**
    * Constructor of OpenSearchQueryRequest.
    */
-  public OpenSearchQueryRequest(IndexName indexName, SearchSourceBuilder sourceBuilder,
+  public OpenSearchQueryRequest(IndexName indexName,
+                                IndexName routingId,
+                                SearchSourceBuilder sourceBuilder,
                                 OpenSearchExprValueFactory factory) {
     this.indexName = indexName;
     this.sourceBuilder = sourceBuilder;
     this.exprValueFactory = factory;
+    this.routingId = routingId;
   }
 
   @Override
@@ -101,8 +114,9 @@ public class OpenSearchQueryRequest implements OpenSearchRequest {
       searchDone = true;
       return new OpenSearchResponse(
           searchAction.apply(new SearchRequest()
-            .indices(indexName.getIndexNames())
-            .source(sourceBuilder)), exprValueFactory, includes);
+              .indices(indexName.getIndexNames())
+              .source(sourceBuilder)
+              .routing(getRoutingId().getIndexNames())), exprValueFactory, includes);
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java
@@ -112,11 +112,14 @@ public class OpenSearchQueryRequest implements OpenSearchRequest {
       return new OpenSearchResponse(SearchHits.empty(), exprValueFactory, includes);
     } else {
       searchDone = true;
+      SearchRequest searchRequest = new SearchRequest()
+          .indices(indexName.getIndexNames())
+          .source(sourceBuilder);
+      if (getRoutingId() != null) {
+        searchRequest.routing(getRoutingId().getIndexNames());
+      }
       return new OpenSearchResponse(
-          searchAction.apply(new SearchRequest()
-              .indices(indexName.getIndexNames())
-              .source(sourceBuilder)
-              .routing(getRoutingId().getIndexNames())), exprValueFactory, includes);
+          searchAction.apply(searchRequest), exprValueFactory, includes);
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java
@@ -58,7 +58,7 @@ public class OpenSearchQueryRequest implements OpenSearchRequest {
   private boolean searchDone = false;
 
   /**
-   *
+   * Sharding or Routing ID for the OpenSearch request.
    */
   private final IndexName routingId;
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
@@ -96,24 +96,25 @@ public class OpenSearchRequestBuilder {
    * @return query request or scroll request
    */
   public OpenSearchRequest build(OpenSearchRequest.IndexName indexName,
+                                 OpenSearchRequest.IndexName routingId,
                                  int maxResultWindow, TimeValue scrollTimeout) {
     int size = requestedTotalSize;
     if (pageSize == null) {
       if (startFrom + size > maxResultWindow) {
         sourceBuilder.size(maxResultWindow - startFrom);
         return new OpenSearchScrollRequest(
-            indexName, scrollTimeout, sourceBuilder, exprValueFactory);
+            indexName, routingId, scrollTimeout, sourceBuilder, exprValueFactory);
       } else {
         sourceBuilder.from(startFrom);
         sourceBuilder.size(requestedTotalSize);
-        return new OpenSearchQueryRequest(indexName, sourceBuilder, exprValueFactory);
+        return new OpenSearchQueryRequest(indexName, routingId, sourceBuilder, exprValueFactory);
       }
     } else {
       if (startFrom != 0) {
         throw new UnsupportedOperationException("Non-zero offset is not supported with pagination");
       }
       sourceBuilder.size(pageSize);
-      return new OpenSearchScrollRequest(indexName, scrollTimeout,
+      return new OpenSearchScrollRequest(indexName, routingId, scrollTimeout,
           sourceBuilder, exprValueFactory);
     }
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
@@ -52,6 +52,12 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
    */
   private final IndexName indexName;
 
+  /**
+   * Routing Ids used for the request
+   * {@link OpenSearchRequest.IndexName}.
+   */
+  private final IndexName routingId;
+
   /** Index name. */
   @EqualsAndHashCode.Exclude
   @ToString.Exclude
@@ -75,14 +81,17 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
 
   /** Constructor. */
   public OpenSearchScrollRequest(IndexName indexName,
+                                 IndexName routingId,
                                  TimeValue scrollTimeout,
                                  SearchSourceBuilder sourceBuilder,
                                  OpenSearchExprValueFactory exprValueFactory) {
     this.indexName = indexName;
+    this.routingId = routingId;
     this.scrollTimeout = scrollTimeout;
     this.exprValueFactory = exprValueFactory;
     this.initialSearchRequest = new SearchRequest()
         .indices(indexName.getIndexNames())
+        .routing(routingId.getIndexNames())
         .scroll(scrollTimeout)
         .source(sourceBuilder);
 
@@ -168,6 +177,7 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
     out.writeString(scrollId);
     out.writeStringCollection(includes);
     indexName.writeTo(out);
+    routingId.writeTo(out);
   }
 
   /**
@@ -183,7 +193,11 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
     scrollId = in.readString();
     includes = in.readStringList();
     indexName = new IndexName(in);
-    OpenSearchIndex index = (OpenSearchIndex) engine.getTable(null, indexName.toString());
+    routingId = new IndexName(in);
+    OpenSearchIndex index = (OpenSearchIndex) engine.getTable(
+        null,
+        indexName.toString(),
+        routingId.toString());
     exprValueFactory = new OpenSearchExprValueFactory(index.getFieldOpenSearchTypes());
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
@@ -91,9 +91,11 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
     this.exprValueFactory = exprValueFactory;
     this.initialSearchRequest = new SearchRequest()
         .indices(indexName.getIndexNames())
-        .routing(routingId.getIndexNames())
         .scroll(scrollTimeout)
         .source(sourceBuilder);
+    if (routingId != null) {
+      this.initialSearchRequest.routing(routingId.getIndexNames());
+    }
 
     includes = sourceBuilder.fetchSource() == null
         ? List.of()

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
@@ -179,7 +179,9 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
     out.writeString(scrollId);
     out.writeStringCollection(includes);
     indexName.writeTo(out);
-    routingId.writeTo(out);
+    if (routingId != null) {
+      routingId.writeTo(out);
+    }
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
@@ -189,7 +189,10 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
       } else if (metaDataField.equals(METADATA_FIELD_SORT)) {
         builder.put(METADATA_FIELD_SORT, new ExprLongValue(hit.getSeqNo()));
       } else { // if (metaDataField.equals(METADATA_FIELD_ROUTING)){
-        builder.put(METADATA_FIELD_ROUTING, new ExprStringValue(hit.getShard().toString()));
+        var routing = hit.getFields().getOrDefault("_routing", null);
+        if (routing != null) {
+          builder.put(METADATA_FIELD_ROUTING, new ExprStringValue(routing.getValue()));
+        }
       }
     });
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
@@ -29,6 +29,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.sql.data.model.ExprFloatValue;
 import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -94,7 +94,7 @@ public class OpenSearchIndex implements Table {
     this.client = client;
     this.settings = settings;
     this.indexName = new OpenSearchRequest.IndexName(indexName);
-    this.routingId = new OpenSearchRequest.IndexName(routingId);
+    this.routingId = routingId == null ? null : new OpenSearchRequest.IndexName(routingId);
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -67,6 +67,12 @@ public class OpenSearchIndex implements Table {
   private final OpenSearchRequest.IndexName indexName;
 
   /**
+   * Stores the routing id for the request
+   * {@link OpenSearchRequest.IndexName}.
+   */
+  private final OpenSearchRequest.IndexName routingId;
+
+  /**
    * The cached mapping of field and type in index.
    */
   private Map<String, OpenSearchDataType> cachedFieldOpenSearchTypes = null;
@@ -84,10 +90,11 @@ public class OpenSearchIndex implements Table {
   /**
    * Constructor.
    */
-  public OpenSearchIndex(OpenSearchClient client, Settings settings, String indexName) {
+  public OpenSearchIndex(OpenSearchClient client, Settings settings, String indexName, String routingId) {
     this.client = client;
     this.settings = settings;
     this.indexName = new OpenSearchRequest.IndexName(indexName);
+    this.routingId = new OpenSearchRequest.IndexName(routingId);
   }
 
   @Override
@@ -180,7 +187,7 @@ public class OpenSearchIndex implements Table {
         createExprValueFactory());
     Function<OpenSearchRequestBuilder, OpenSearchIndexScan> createScanOperator =
         requestBuilder -> new OpenSearchIndexScan(client, requestBuilder.getMaxResponseSize(),
-        requestBuilder.build(indexName, getMaxResultWindow(), cursorKeepAlive));
+        requestBuilder.build(indexName, routingId, getMaxResultWindow(), cursorKeepAlive));
     return new OpenSearchIndexScanBuilder(builder, createScanOperator);
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -90,7 +90,10 @@ public class OpenSearchIndex implements Table {
   /**
    * Constructor.
    */
-  public OpenSearchIndex(OpenSearchClient client, Settings settings, String indexName, String routingId) {
+  public OpenSearchIndex(OpenSearchClient client,
+                         Settings settings,
+                         String indexName,
+                         String routingId) {
     this.client = client;
     this.settings = settings;
     this.indexName = new OpenSearchRequest.IndexName(indexName);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.opensearch.storage;
 
 import static org.opensearch.sql.utils.SystemIndexUtils.isSystemIndex;
 
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.DataSourceSchemaName;
@@ -28,11 +29,12 @@ public class OpenSearchStorageEngine implements StorageEngine {
   private final Settings settings;
 
   @Override
-  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name) {
+  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name, @Nullable String routingId) {
     if (isSystemIndex(name)) {
+      // TODO: handle routingId on system tables too?
       return new OpenSearchSystemIndex(client, name);
     } else {
-      return new OpenSearchIndex(client, settings, name);
+      return new OpenSearchIndex(client, settings, name, routingId == null ? "" : routingId);
     }
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
@@ -34,7 +34,7 @@ public class OpenSearchStorageEngine implements StorageEngine {
       // TODO: handle routingId on system tables too?
       return new OpenSearchSystemIndex(client, name);
     } else {
-      return new OpenSearchIndex(client, settings, name, routingId == null ? "" : routingId);
+      return new OpenSearchIndex(client, settings, name, routingId);
     }
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
@@ -29,7 +29,9 @@ public class OpenSearchStorageEngine implements StorageEngine {
   private final Settings settings;
 
   @Override
-  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name, @Nullable String routingId) {
+  public Table getTable(DataSourceSchemaName dataSourceSchemaName,
+                        String name,
+                        @Nullable String routingId) {
     if (isSystemIndex(name)) {
       // TODO: handle routingId on system tables too?
       return new OpenSearchSystemIndex(client, name);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -87,6 +87,11 @@ class OpenSearchNodeClientTest {
   private static final String TEST_MAPPING_FILE = "mappings/accounts.json";
   private static final String TEST_MAPPING_SETTINGS_FILE = "mappings/accounts2.json";
 
+  private static final OpenSearchRequest.IndexName INDEX_NAME =
+      new OpenSearchRequest.IndexName("test");
+  private static final OpenSearchRequest.IndexName ROUTING_ID =
+      new OpenSearchRequest.IndexName("shard");
+
   @Mock(answer = RETURNS_DEEP_STUBS)
   private NodeClient nodeClient;
 
@@ -322,7 +327,7 @@ class OpenSearchNodeClientTest {
 
     // Verify response for first scroll request
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     OpenSearchResponse response1 = client.search(request);
     assertFalse(response1.isEmpty());
@@ -357,7 +362,7 @@ class OpenSearchNodeClientTest {
     when(requestBuilder.get()).thenReturn(null);
 
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     request.setScrollId("scroll123");
     // Enforce cleaning by setting a private field.
@@ -374,7 +379,7 @@ class OpenSearchNodeClientTest {
   @Test
   void cleanup_without_scrollId() {
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     client.cleanup(request);
     verify(nodeClient, never()).prepareClearScroll();
@@ -386,7 +391,7 @@ class OpenSearchNodeClientTest {
     when(nodeClient.prepareClearScroll()).thenThrow(new RuntimeException());
 
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     request.setScrollId("scroll123");
     // Enforce cleaning by setting a private field.

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
@@ -81,6 +81,11 @@ import org.opensearch.sql.opensearch.response.OpenSearchResponse;
 class OpenSearchRestClientTest {
 
   private static final String TEST_MAPPING_FILE = "mappings/accounts.json";
+
+  private static final OpenSearchRequest.IndexName INDEX_NAME =
+      new OpenSearchRequest.IndexName("test");
+  private static final OpenSearchRequest.IndexName ROUTING_ID =
+      new OpenSearchRequest.IndexName("shard");
   @Mock(answer = RETURNS_DEEP_STUBS)
   private RestHighLevelClient restClient;
 
@@ -313,7 +318,7 @@ class OpenSearchRestClientTest {
 
     // Verify response for first scroll request
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     OpenSearchResponse response1 = client.search(request);
     assertFalse(response1.isEmpty());
@@ -335,7 +340,7 @@ class OpenSearchRestClientTest {
     assertThrows(
         IllegalStateException.class,
         () -> client.search(new OpenSearchScrollRequest(
-            new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+            INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
             new SearchSourceBuilder(), factory)));
   }
 
@@ -357,7 +362,7 @@ class OpenSearchRestClientTest {
 
     // First request run successfully
     OpenSearchScrollRequest scrollRequest = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     client.search(scrollRequest);
     assertThrows(
@@ -376,7 +381,7 @@ class OpenSearchRestClientTest {
   @SneakyThrows
   void cleanup() {
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     // Enforce cleaning by setting a private field.
     FieldUtils.writeField(request, "needClean", true, true);
@@ -389,7 +394,7 @@ class OpenSearchRestClientTest {
   @Test
   void cleanup_without_scrollId() throws IOException {
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     client.cleanup(request);
     verify(restClient, never()).clearScroll(any(), any());
@@ -401,7 +406,7 @@ class OpenSearchRestClientTest {
     when(restClient.clearScroll(any(), any())).thenThrow(new IOException());
 
     OpenSearchScrollRequest request = new OpenSearchScrollRequest(
-        new OpenSearchRequest.IndexName("test"), TimeValue.timeValueMinutes(1),
+        INDEX_NAME, ROUTING_ID, TimeValue.timeValueMinutes(1),
         new SearchSourceBuilder(), factory);
     // Enforce cleaning by setting a private field.
     FieldUtils.writeField(request, "needClean", true, true);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngineTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngineTest.java
@@ -183,7 +183,7 @@ class OpenSearchExecutionEngineTest {
     final int maxResultWindow = 10000;
     final var requestBuilder = new OpenSearchRequestBuilder(defaultQuerySize, exprValueFactory);
     PhysicalPlan plan = new OpenSearchIndexScan(mock(OpenSearchClient.class),
-        maxResultWindow, requestBuilder.build(name, maxResultWindow,
+        maxResultWindow, requestBuilder.build(name, null, maxResultWindow,
         settings.getSettingValue(SQL_CURSOR_KEEP_ALIVE)));
 
     AtomicReference<ExplainResponse> result = new AtomicReference<>();

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -119,7 +119,7 @@ class OpenSearchExecutionProtectorTest {
 
     final var name = new OpenSearchRequest.IndexName(indexName);
     final var request = new OpenSearchRequestBuilder(querySizeLimit, exprValueFactory)
-        .build(name, maxResultWindow,
+        .build(name, null, maxResultWindow,
             settings.getSettingValue(Settings.Key.SQL_CURSOR_KEEP_ALIVE));
     assertEquals(
         PhysicalPlanDSL.project(

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequestTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequestTest.java
@@ -68,15 +68,16 @@ public class OpenSearchQueryRequestTest {
   private OpenSearchExprValueFactory factory;
 
   private final OpenSearchQueryRequest request =
-      new OpenSearchQueryRequest("test", 200, factory);
+      new OpenSearchQueryRequest("test", "key", 200, factory);
 
   private final OpenSearchQueryRequest remoteRequest =
-      new OpenSearchQueryRequest("ccs:test", 200, factory);
+      new OpenSearchQueryRequest("ccs:test", "ccs:key", 200, factory);
 
   @Test
   void search() {
     OpenSearchQueryRequest request = new OpenSearchQueryRequest(
         new OpenSearchRequest.IndexName("test"),
+        new OpenSearchRequest.IndexName("key"),
         sourceBuilder,
         factory
     );
@@ -99,6 +100,7 @@ public class OpenSearchQueryRequestTest {
   void search_withoutContext() {
     OpenSearchQueryRequest request = new OpenSearchQueryRequest(
         new OpenSearchRequest.IndexName("test"),
+        new OpenSearchRequest.IndexName("key"),
         sourceBuilder,
         factory
     );
@@ -117,6 +119,7 @@ public class OpenSearchQueryRequestTest {
   void search_withIncludes() {
     OpenSearchQueryRequest request = new OpenSearchQueryRequest(
         new OpenSearchRequest.IndexName("test"),
+        new OpenSearchRequest.IndexName("key"),
         sourceBuilder,
         factory
     );
@@ -150,6 +153,7 @@ public class OpenSearchQueryRequestTest {
 
     assertSearchRequest(new SearchRequest()
         .indices("test")
+        .routing("key")
         .source(new SearchSourceBuilder()
           .timeout(DEFAULT_QUERY_TIMEOUT)
           .from(0)
@@ -165,6 +169,7 @@ public class OpenSearchQueryRequestTest {
     assertSearchRequest(
         new SearchRequest()
             .indices("ccs:test")
+            .routing("key")
             .source(new SearchSourceBuilder()
                 .timeout(DEFAULT_QUERY_TIMEOUT)
                 .from(0)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequestTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequestTest.java
@@ -100,7 +100,7 @@ public class OpenSearchQueryRequestTest {
   void search_withoutContext() {
     OpenSearchQueryRequest request = new OpenSearchQueryRequest(
         new OpenSearchRequest.IndexName("test"),
-        new OpenSearchRequest.IndexName("key"),
+        null,
         sourceBuilder,
         factory
     );
@@ -124,7 +124,7 @@ public class OpenSearchQueryRequestTest {
         factory
     );
 
-    String[] includes = {"_id", "_index"};
+    String[] includes = {"_id", "_index", "_routing"};
     when(sourceBuilder.fetchSource()).thenReturn(fetchSourceContext);
     when(fetchSourceContext.includes()).thenReturn(includes);
     when(searchAction.apply(any())).thenReturn(searchResponse);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequestTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequestTest.java
@@ -169,7 +169,7 @@ public class OpenSearchQueryRequestTest {
     assertSearchRequest(
         new SearchRequest()
             .indices("ccs:test")
-            .routing("key")
+            .routing("ccs:key")
             .source(new SearchSourceBuilder()
                 .timeout(DEFAULT_QUERY_TIMEOUT)
                 .from(0)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequestTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequestTest.java
@@ -89,7 +89,7 @@ class OpenSearchScrollRequestTest {
   @Test
   void constructor2() {
     searchSourceBuilder.fetchSource(new String[]{"test"}, null);
-    var request = new OpenSearchScrollRequest(INDEX_NAME, ROUTING_ID, SCROLL_TIMEOUT, searchSourceBuilder,
+    var request = new OpenSearchScrollRequest(INDEX_NAME, null, SCROLL_TIMEOUT, searchSourceBuilder,
         factory);
     assertNotEquals(List.of(), request.getIncludes());
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchResponseTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchResponseTest.java
@@ -15,8 +15,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
@@ -30,12 +28,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.document.DocumentField;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.text.Text;
-import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
-import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.fetch.subphase.highlight.HighlightField;
 import org.opensearch.sql.data.model.ExprFloatValue;
@@ -150,13 +147,12 @@ class OpenSearchResponseTest {
                 new TotalHits(1L, TotalHits.Relation.EQUAL_TO),
                 3.75F));
 
-    ShardId shardId = new ShardId("index", "indexUUID", 42);
-    SearchShardTarget shardTarget = new SearchShardTarget("node", shardId, null, null);
+    DocumentField routingField = new DocumentField("_routing", List.of("testShard"));
 
     when(searchHit1.getSourceAsString()).thenReturn("{\"id1\", 1}");
     when(searchHit1.getId()).thenReturn("testId");
     when(searchHit1.getIndex()).thenReturn("testIndex");
-    when(searchHit1.getShard()).thenReturn(shardTarget);
+    when(searchHit1.getFields()).thenReturn(Map.of("_routing", routingField));
     when(searchHit1.getScore()).thenReturn(3.75F);
     when(searchHit1.getSeqNo()).thenReturn(123456L);
 
@@ -166,7 +162,7 @@ class OpenSearchResponseTest {
         "id1", new ExprIntegerValue(1),
         "_index", new ExprStringValue("testIndex"),
         "_id", new ExprStringValue("testId"),
-        "_routing", new ExprStringValue(shardTarget.toString()),
+        "_routing", new ExprStringValue("testShard"),
         "_sort", new ExprLongValue(123456L),
         "_score", new ExprFloatValue(3.75F),
         "_maxscore", new ExprFloatValue(3.75F)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchResponseTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchResponseTest.java
@@ -38,6 +38,7 @@ import org.opensearch.search.fetch.subphase.highlight.HighlightField;
 import org.opensearch.sql.data.model.ExprFloatValue;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
@@ -213,7 +214,7 @@ class OpenSearchResponseTest {
   }
 
   @Test
-  void iterator_metafields_scoreNaN() {
+  void iterator_metafields_nullNaN() {
 
     ExprTupleValue exprTupleHit = ExprTupleValue.fromExprValueMap(ImmutableMap.of(
         "id1", new ExprIntegerValue(1)
@@ -234,7 +235,7 @@ class OpenSearchResponseTest {
 
     when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleHit);
 
-    List includes = List.of("id1", "_index", "_id", "_sort", "_score", "_maxscore");
+    List includes = List.of("id1", "_index", "_id", "_routing", "_sort", "_score", "_maxscore");
     ExprTupleValue exprTupleResponse = ExprTupleValue.fromExprValueMap(ImmutableMap.of(
         "id1", new ExprIntegerValue(1),
         "_index", new ExprStringValue("testIndex"),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
@@ -85,7 +85,9 @@ class OpenSearchIndexTest {
 
   @BeforeEach
   void setUp() {
-    this.index = new OpenSearchIndex(client, settings, "test", "routing");
+    this.index = new OpenSearchIndex(client, settings,
+        INDEX_NAME.getIndexNames()[0],
+        PARTITION_KEY.getIndexNames()[0]);
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
@@ -167,7 +167,7 @@ class OpenSearchIndexTest {
     when(client.getIndexMappings("test")).thenReturn(
         ImmutableMap.of("test", mapping));
 
-    OpenSearchIndex index = new OpenSearchIndex(client, settings, "test", "routing");
+    OpenSearchIndex index = new OpenSearchIndex(client, settings, "test", null);
     assertThat(index.getFieldTypes(), allOf(
         aMapWithSize(1),
         hasEntry("name", STRING)));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngineTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngineTest.java
@@ -35,7 +35,7 @@ class OpenSearchStorageEngineTest {
   public void getTable() {
     OpenSearchStorageEngine engine = new OpenSearchStorageEngine(client, settings);
     Table table = engine.getTable(new DataSourceSchemaName(DEFAULT_DATASOURCE_NAME, "default"),
-        "test");
+        "test", "shard_test");
     assertAll(
         () -> assertNotNull(table),
         () -> assertTrue(table instanceof OpenSearchIndex)
@@ -46,7 +46,7 @@ class OpenSearchStorageEngineTest {
   public void getSystemTable() {
     OpenSearchStorageEngine engine = new OpenSearchStorageEngine(client, settings);
     Table table = engine.getTable(new DataSourceSchemaName(DEFAULT_DATASOURCE_NAME, "default"),
-        TABLE_INFO);
+        TABLE_INFO, "shard_test");
     assertAll(
         () -> assertNotNull(table),
         () -> assertTrue(table instanceof OpenSearchSystemIndex)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanPaginationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanPaginationTest.java
@@ -46,6 +46,8 @@ public class OpenSearchIndexScanPaginationTest {
 
   public static final OpenSearchRequest.IndexName INDEX_NAME
       = new OpenSearchRequest.IndexName("test");
+  public static final OpenSearchRequest.IndexName ROUTING_ID
+      = new OpenSearchRequest.IndexName("shard");
   public static final int MAX_RESULT_WINDOW = 3;
   public static final TimeValue SCROLL_TIMEOUT = TimeValue.timeValueMinutes(4);
   @Mock
@@ -71,7 +73,7 @@ public class OpenSearchIndexScanPaginationTest {
     mockResponse(client);
     var builder = new OpenSearchRequestBuilder(QUERY_SIZE, exprValueFactory);
     try (var indexScan = new OpenSearchIndexScan(client, MAX_RESULT_WINDOW,
-          builder.build(INDEX_NAME, MAX_RESULT_WINDOW, SCROLL_TIMEOUT))) {
+          builder.build(INDEX_NAME, ROUTING_ID, MAX_RESULT_WINDOW, SCROLL_TIMEOUT))) {
       indexScan.open();
       assertFalse(indexScan.hasNext());
     }
@@ -90,11 +92,11 @@ public class OpenSearchIndexScanPaginationTest {
     OpenSearchRequestBuilder builder = mock();
     OpenSearchRequest request = mock();
     OpenSearchResponse response = mock();
-    when(builder.build(any(), anyInt(), any())).thenReturn(request);
+    when(builder.build(any(), any(), anyInt(), any())).thenReturn(request);
     when(client.search(any())).thenReturn(response);
     try (var indexScan
         = new OpenSearchIndexScan(client, MAX_RESULT_WINDOW,
-          builder.build(INDEX_NAME, MAX_RESULT_WINDOW, SCROLL_TIMEOUT))) {
+          builder.build(INDEX_NAME, ROUTING_ID, MAX_RESULT_WINDOW, SCROLL_TIMEOUT))) {
       indexScan.open();
 
       when(request.hasAnotherBatch()).thenReturn(false);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -183,12 +182,6 @@ class OpenSearchIndexScanTest {
     }
     verify(client).cleanup(any());
   }
-
-  static final OpenSearchRequest.IndexName EMPLOYEES_INDEX
-      = new OpenSearchRequest.IndexName("employees");
-
-  static final OpenSearchRequest.IndexName EMPLOYEES_PARTITION_KEY
-      = new OpenSearchRequest.IndexName("employkeys");
 
   @Test
   void query_all_results_with_scroll() {
@@ -387,11 +380,11 @@ class OpenSearchIndexScanTest {
           .highlighter(highlight)
           .sort(DOC_FIELD_NAME, ASC);
       OpenSearchRequest request =
-          new OpenSearchQueryRequest(EMPLOYEES_INDEX, EMPLOYEES_PARTITION_KEY, sourceBuilder, factory);
+          new OpenSearchQueryRequest(INDEX_NAME, ROUTING_ID, sourceBuilder, factory);
 
       when(client.search(request)).thenReturn(response);
       var indexScan = new OpenSearchIndexScan(client,
-          QUERY_SIZE, requestBuilder.build(EMPLOYEES_INDEX, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
+          QUERY_SIZE, requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
       indexScan.open();
       return this;
     }
@@ -403,10 +396,10 @@ class OpenSearchIndexScanTest {
           .size(QUERY_SIZE)
           .timeout(CURSOR_KEEP_ALIVE)
           .sort(DOC_FIELD_NAME, ASC);
-      OpenSearchRequest request = new OpenSearchQueryRequest(EMPLOYEES_INDEX, EMPLOYEES_PARTITION_KEY, builder, factory);
+      OpenSearchRequest request = new OpenSearchQueryRequest(INDEX_NAME, ROUTING_ID, builder, factory);
       when(client.search(request)).thenReturn(response);
       var indexScan = new OpenSearchIndexScan(client,
-          10000, requestBuilder.build(EMPLOYEES_INDEX, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
+          10000, requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
       indexScan.open();
       return this;
     }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanTest.java
@@ -68,6 +68,9 @@ class OpenSearchIndexScanTest {
   public static final int QUERY_SIZE = 200;
   public static final OpenSearchRequest.IndexName INDEX_NAME
       = new OpenSearchRequest.IndexName("employees");
+
+  public static final OpenSearchRequest.IndexName ROUTING_ID
+      = new OpenSearchRequest.IndexName("test_shard");
   public static final int MAX_RESULT_WINDOW = 10000;
   public static final TimeValue CURSOR_KEEP_ALIVE = TimeValue.timeValueMinutes(1);
   @Mock
@@ -111,9 +114,9 @@ class OpenSearchIndexScanTest {
     var engine = mock(OpenSearchStorageEngine.class);
     var index = mock(OpenSearchIndex.class);
     when(engine.getClient()).thenReturn(client);
-    when(engine.getTable(any(), any())).thenReturn(index);
+    when(engine.getTable(any(), any(), any())).thenReturn(index);
     var request = new OpenSearchScrollRequest(
-        INDEX_NAME, CURSOR_KEEP_ALIVE, searchSourceBuilder, factory);
+        INDEX_NAME, ROUTING_ID, CURSOR_KEEP_ALIVE, searchSourceBuilder, factory);
     request.setScrollId("valid-id");
     // make a response, so OpenSearchResponse::isEmpty would return true and unset needClean
     var response = mock(SearchResponse.class);
@@ -146,7 +149,7 @@ class OpenSearchIndexScanTest {
     final var name = new OpenSearchRequest.IndexName("test");
     final var requestBuilder = new OpenSearchRequestBuilder(QUERY_SIZE, exprValueFactory);
     try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        QUERY_SIZE, requestBuilder.build(name, MAX_RESULT_WINDOW, CURSOR_KEEP_ALIVE))) {
+        QUERY_SIZE, requestBuilder.build(name, ROUTING_ID, MAX_RESULT_WINDOW, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
       assertFalse(indexScan.hasNext());
     }
@@ -162,7 +165,7 @@ class OpenSearchIndexScanTest {
 
     final var requestBuilder = new OpenSearchRequestBuilder(QUERY_SIZE, exprValueFactory);
     try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        10, requestBuilder.build(INDEX_NAME, 10000, CURSOR_KEEP_ALIVE))) {
+        10, requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
 
       assertAll(
@@ -184,6 +187,9 @@ class OpenSearchIndexScanTest {
   static final OpenSearchRequest.IndexName EMPLOYEES_INDEX
       = new OpenSearchRequest.IndexName("employees");
 
+  static final OpenSearchRequest.IndexName EMPLOYEES_PARTITION_KEY
+      = new OpenSearchRequest.IndexName("employkeys");
+
   @Test
   void query_all_results_with_scroll() {
     mockResponse(client,
@@ -192,7 +198,7 @@ class OpenSearchIndexScanTest {
 
     final var requestBuilder = new OpenSearchRequestBuilder(QUERY_SIZE, exprValueFactory);
     try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        10, requestBuilder.build(INDEX_NAME, 10000, CURSOR_KEEP_ALIVE))) {
+        10, requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
 
       assertAll(
@@ -222,7 +228,7 @@ class OpenSearchIndexScanTest {
     final int limit = 3;
     OpenSearchRequestBuilder builder = new OpenSearchRequestBuilder(0, exprValueFactory);
     try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        limit, builder.build(INDEX_NAME, MAX_RESULT_WINDOW, CURSOR_KEEP_ALIVE))) {
+        limit, builder.build(INDEX_NAME, ROUTING_ID, MAX_RESULT_WINDOW, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
 
       assertAll(
@@ -246,7 +252,7 @@ class OpenSearchIndexScanTest {
     mockTwoPageResponse(client);
     final var requestuilder = new OpenSearchRequestBuilder(10, exprValueFactory);
     try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        3, requestuilder.build(INDEX_NAME, MAX_RESULT_WINDOW, CURSOR_KEEP_ALIVE))) {
+        3, requestuilder.build(INDEX_NAME, ROUTING_ID, MAX_RESULT_WINDOW, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
 
       assertAll(
@@ -282,7 +288,7 @@ class OpenSearchIndexScanTest {
     final int defaultQuerySize = 2;
     final var requestBuilder = new OpenSearchRequestBuilder(defaultQuerySize, exprValueFactory);
     try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        defaultQuerySize, requestBuilder.build(INDEX_NAME, QUERY_SIZE, CURSOR_KEEP_ALIVE))) {
+        defaultQuerySize, requestBuilder.build(INDEX_NAME, ROUTING_ID, QUERY_SIZE, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
 
       assertAll(
@@ -381,11 +387,11 @@ class OpenSearchIndexScanTest {
           .highlighter(highlight)
           .sort(DOC_FIELD_NAME, ASC);
       OpenSearchRequest request =
-          new OpenSearchQueryRequest(EMPLOYEES_INDEX, sourceBuilder, factory);
+          new OpenSearchQueryRequest(EMPLOYEES_INDEX, EMPLOYEES_PARTITION_KEY, sourceBuilder, factory);
 
       when(client.search(request)).thenReturn(response);
       var indexScan = new OpenSearchIndexScan(client,
-          QUERY_SIZE, requestBuilder.build(EMPLOYEES_INDEX, 10000, CURSOR_KEEP_ALIVE));
+          QUERY_SIZE, requestBuilder.build(EMPLOYEES_INDEX, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
       indexScan.open();
       return this;
     }
@@ -397,10 +403,10 @@ class OpenSearchIndexScanTest {
           .size(QUERY_SIZE)
           .timeout(CURSOR_KEEP_ALIVE)
           .sort(DOC_FIELD_NAME, ASC);
-      OpenSearchRequest request = new OpenSearchQueryRequest(EMPLOYEES_INDEX, builder, factory);
+      OpenSearchRequest request = new OpenSearchQueryRequest(EMPLOYEES_INDEX, EMPLOYEES_PARTITION_KEY, builder, factory);
       when(client.search(request)).thenReturn(response);
       var indexScan = new OpenSearchIndexScan(client,
-          10000, requestBuilder.build(EMPLOYEES_INDEX, 10000, CURSOR_KEEP_ALIVE));
+          10000, requestBuilder.build(EMPLOYEES_INDEX, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
       indexScan.open();
       return this;
     }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanTest.java
@@ -280,8 +280,9 @@ class OpenSearchIndexScanTest {
 
     final int defaultQuerySize = 2;
     final var requestBuilder = new OpenSearchRequestBuilder(defaultQuerySize, exprValueFactory);
-    try (OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client,
-        defaultQuerySize, requestBuilder.build(INDEX_NAME, ROUTING_ID, QUERY_SIZE, CURSOR_KEEP_ALIVE))) {
+    try (OpenSearchIndexScan indexScan =
+             new OpenSearchIndexScan(client, defaultQuerySize,
+                 requestBuilder.build(INDEX_NAME, ROUTING_ID, QUERY_SIZE, CURSOR_KEEP_ALIVE))) {
       indexScan.open();
 
       assertAll(
@@ -383,8 +384,8 @@ class OpenSearchIndexScanTest {
           new OpenSearchQueryRequest(INDEX_NAME, ROUTING_ID, sourceBuilder, factory);
 
       when(client.search(request)).thenReturn(response);
-      var indexScan = new OpenSearchIndexScan(client,
-          QUERY_SIZE, requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
+      var indexScan = new OpenSearchIndexScan(client, QUERY_SIZE,
+          requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
       indexScan.open();
       return this;
     }
@@ -396,10 +397,12 @@ class OpenSearchIndexScanTest {
           .size(QUERY_SIZE)
           .timeout(CURSOR_KEEP_ALIVE)
           .sort(DOC_FIELD_NAME, ASC);
-      OpenSearchRequest request = new OpenSearchQueryRequest(INDEX_NAME, ROUTING_ID, builder, factory);
+      OpenSearchRequest request = new OpenSearchQueryRequest(
+          INDEX_NAME, ROUTING_ID, builder, factory);
       when(client.search(request)).thenReturn(response);
       var indexScan = new OpenSearchIndexScan(client,
-          10000, requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
+          10000,
+          requestBuilder.build(INDEX_NAME, ROUTING_ID, 10000, CURSOR_KEEP_ALIVE));
       indexScan.open();
       return this;
     }

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.utils.SystemIndexUtils.isSystemIndex;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -43,7 +44,7 @@ public class PrometheusStorageEngine implements StorageEngine {
   }
 
   @Override
-  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName) {
+  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, @Nullable String ignored) {
     if (isSystemIndex(tableName)) {
       return new PrometheusSystemTable(prometheusClient, dataSourceSchemaName, tableName);
     } else if (INFORMATION_SCHEMA_NAME.equals(dataSourceSchemaName.getSchemaName())) {

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
@@ -44,7 +44,9 @@ public class PrometheusStorageEngine implements StorageEngine {
   }
 
   @Override
-  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, @Nullable String ignored) {
+  public Table getTable(DataSourceSchemaName dataSourceSchemaName,
+                        String tableName,
+                        @Nullable String ignored) {
     if (isSystemIndex(tableName)) {
       return new PrometheusSystemTable(prometheusClient, dataSourceSchemaName, tableName);
     } else if (INFORMATION_SCHEMA_NAME.equals(dataSourceSchemaName.getSchemaName())) {

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
@@ -57,7 +57,10 @@ class PrometheusStorageEngineTest {
   @Test
   public void getSystemTable() {
     PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
-    Table table = engine.getTable(new DataSourceSchemaName("prometheus", "default"), TABLE_INFO, "ignored");
+    Table table = engine.getTable(
+        new DataSourceSchemaName("prometheus", "default"),
+        TABLE_INFO,
+        "ignored");
     assertNotNull(table);
     assertTrue(table instanceof PrometheusSystemTable);
   }
@@ -66,7 +69,10 @@ class PrometheusStorageEngineTest {
   public void getSystemTableForAllTablesInfo() {
     PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
     Table table
-        = engine.getTable(new DataSourceSchemaName("prometheus", "information_schema"), "tables", "ignored");
+        = engine.getTable(
+            new DataSourceSchemaName("prometheus", "information_schema"),
+        "tables",
+        "ignored");
     assertNotNull(table);
     assertTrue(table instanceof PrometheusSystemTable);
   }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
@@ -35,7 +35,7 @@ class PrometheusStorageEngineTest {
   @Test
   public void getTable() {
     PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
-    Table table = engine.getTable(new DataSourceSchemaName("prometheus", "default"), "test");
+    Table table = engine.getTable(new DataSourceSchemaName("prometheus", "default"), "test", null);
     assertNotNull(table);
     assertTrue(table instanceof PrometheusMetricTable);
   }
@@ -57,7 +57,7 @@ class PrometheusStorageEngineTest {
   @Test
   public void getSystemTable() {
     PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
-    Table table = engine.getTable(new DataSourceSchemaName("prometheus", "default"), TABLE_INFO);
+    Table table = engine.getTable(new DataSourceSchemaName("prometheus", "default"), TABLE_INFO, "ignored");
     assertNotNull(table);
     assertTrue(table instanceof PrometheusSystemTable);
   }
@@ -66,7 +66,7 @@ class PrometheusStorageEngineTest {
   public void getSystemTableForAllTablesInfo() {
     PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
     Table table
-        = engine.getTable(new DataSourceSchemaName("prometheus", "information_schema"), "tables");
+        = engine.getTable(new DataSourceSchemaName("prometheus", "information_schema"), "tables", "ignored");
     assertNotNull(table);
     assertTrue(table instanceof PrometheusSystemTable);
   }
@@ -76,7 +76,7 @@ class PrometheusStorageEngineTest {
     PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
     SemanticCheckException exception = assertThrows(SemanticCheckException.class,
         () -> engine.getTable(new DataSourceSchemaName("prometheus", "information_schema"),
-            "test"));
+            "test", "ignored"));
     assertEquals("Information Schema doesn't contain test table", exception.getMessage());
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageEngine.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageEngine.java
@@ -29,7 +29,7 @@ public class SparkStorageEngine implements StorageEngine {
   }
 
   @Override
-  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName) {
+  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, String parition) {
     throw new RuntimeException("Unable to get table from storage engine.");
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageEngine.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/storage/SparkStorageEngine.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.storage;
 
 import java.util.Collection;
 import java.util.Collections;
+import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.expression.function.FunctionResolver;
@@ -29,7 +30,9 @@ public class SparkStorageEngine implements StorageEngine {
   }
 
   @Override
-  public Table getTable(DataSourceSchemaName dataSourceSchemaName, String tableName, String parition) {
+  public Table getTable(DataSourceSchemaName dataSourceSchemaName,
+                        String tableName,
+                        @Nullable String ignored) {
     throw new RuntimeException("Unable to get table from storage engine.");
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageEngineTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageEngineTest.java
@@ -40,7 +40,7 @@ public class SparkStorageEngineTest {
   public void getTable() {
     SparkStorageEngine engine = new SparkStorageEngine(client);
     RuntimeException exception = assertThrows(RuntimeException.class,
-        () -> engine.getTable(new DataSourceSchemaName("spark", "default"), ""));
+        () -> engine.getTable(new DataSourceSchemaName("spark", "default"), "", null));
     assertEquals("Unable to get table from storage engine.", exception.getMessage());
   }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -115,8 +115,12 @@ fromClause
     ;
 
 relation
-    : tableName (AS? alias)?                                                #tableAsRelation
+    : tableName (AS? alias)? (partitionRelationClause)?                     #tableAsRelation
     | LR_BRACKET subquery=querySpecification RR_BRACKET AS? alias           #subqueryAsRelation
+    ;
+
+partitionRelationClause
+    : PARTITION LR_BRACKET functionArgs RR_BRACKET
     ;
 
 whereClause

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.sql.domain;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -28,8 +29,9 @@ import org.opensearch.sql.protocol.response.format.Format;
 @RequiredArgsConstructor
 public class SQLQueryRequest {
   private static final String QUERY_FIELD_CURSOR = "cursor";
+  private static final String QUERY_FIELD_ROUTING = "routing";
   private static final Set<String> SUPPORTED_FIELDS = Set.of(
-      "query", "fetch_size", "parameters", QUERY_FIELD_CURSOR);
+      "query", "fetch_size", "parameters", QUERY_FIELD_CURSOR, QUERY_FIELD_ROUTING);
   private static final String QUERY_PARAMS_FORMAT = "format";
   private static final String QUERY_PARAMS_SANITIZE = "sanitize";
 
@@ -65,11 +67,13 @@ public class SQLQueryRequest {
 
   private String cursor;
 
+  private List<String> routingIds;
+
   /**
    * Constructor of SQLQueryRequest that passes request params.
    */
   public SQLQueryRequest(JSONObject jsonContent, String query, String path,
-                         Map<String, String> params, String cursor) {
+                         Map<String, String> params, String cursor, List<String> routingIds) {
     this.jsonContent = jsonContent;
     this.query = query;
     this.path = path;
@@ -77,6 +81,7 @@ public class SQLQueryRequest {
     this.format = getFormat(params);
     this.sanitize = shouldSanitize(params);
     this.cursor = cursor;
+    this.routingIds = routingIds;
   }
 
   /**

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -29,9 +29,8 @@ import org.opensearch.sql.protocol.response.format.Format;
 @RequiredArgsConstructor
 public class SQLQueryRequest {
   private static final String QUERY_FIELD_CURSOR = "cursor";
-  private static final String QUERY_FIELD_ROUTING = "routing";
   private static final Set<String> SUPPORTED_FIELDS = Set.of(
-      "query", "fetch_size", "parameters", QUERY_FIELD_CURSOR, QUERY_FIELD_ROUTING);
+      "query", "fetch_size", "parameters", QUERY_FIELD_CURSOR);
   private static final String QUERY_PARAMS_FORMAT = "format";
   private static final String QUERY_PARAMS_SANITIZE = "sanitize";
 
@@ -67,13 +66,12 @@ public class SQLQueryRequest {
 
   private String cursor;
 
-  private List<String> routingIds;
 
   /**
    * Constructor of SQLQueryRequest that passes request params.
    */
   public SQLQueryRequest(JSONObject jsonContent, String query, String path,
-                         Map<String, String> params, String cursor, List<String> routingIds) {
+                         Map<String, String> params, String cursor) {
     this.jsonContent = jsonContent;
     this.query = query;
     this.path = path;
@@ -81,7 +79,6 @@ public class SQLQueryRequest {
     this.format = getFormat(params);
     this.sanitize = shouldSanitize(params);
     this.cursor = cursor;
-    this.routingIds = routingIds;
   }
 
   /**

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -191,7 +191,7 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
   public UnresolvedPlan visitTableAsRelation(TableAsRelationContext ctx) {
     String tableAlias = (ctx.alias() == null) ? null
         : StringUtils.unquoteIdentifier(ctx.alias().getText());
-    if(ctx.partitionRelationClause() == null) {
+    if (ctx.partitionRelationClause() == null) {
       return new Relation(visitAstExpression(ctx.tableName()), tableAlias);
     }
     return new Relation(

--- a/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
@@ -80,7 +81,7 @@ class SQLServiceTest {
   @Test
   public void can_execute_cursor_query() {
     sqlService.execute(
-        new SQLQueryRequest(new JSONObject(), null, QUERY, Map.of("format", "jdbc"), "n:cursor"),
+        new SQLQueryRequest(new JSONObject(), null, QUERY, Map.of("format", "jdbc"), "n:cursor", List.of()),
         new ResponseListener<>() {
           @Override
           public void onResponse(QueryResponse response) {
@@ -98,7 +99,7 @@ class SQLServiceTest {
   public void can_execute_close_cursor_query() {
     sqlService.execute(
         new SQLQueryRequest(new JSONObject(), null, QUERY + "/close",
-            Map.of("format", "jdbc"), "n:cursor"),
+            Map.of("format", "jdbc"), "n:cursor", List.of()),
         new ResponseListener<>() {
           @Override
           public void onResponse(QueryResponse response) {
@@ -154,7 +155,7 @@ class SQLServiceTest {
   @Test
   public void cannot_explain_cursor_query() {
     sqlService.explain(new SQLQueryRequest(new JSONObject(), null, EXPLAIN,
-            Map.of("format", "jdbc"), "n:cursor"),
+            Map.of("format", "jdbc"), "n:cursor", List.of()),
         new ResponseListener<ExplainResponse>() {
           @Override
           public void onResponse(ExplainResponse response) {

--- a/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
@@ -81,7 +81,7 @@ class SQLServiceTest {
   @Test
   public void can_execute_cursor_query() {
     sqlService.execute(
-        new SQLQueryRequest(new JSONObject(), null, QUERY, Map.of("format", "jdbc"), "n:cursor", List.of()),
+        new SQLQueryRequest(new JSONObject(), null, QUERY, Map.of("format", "jdbc"), "n:cursor"),
         new ResponseListener<>() {
           @Override
           public void onResponse(QueryResponse response) {
@@ -99,7 +99,7 @@ class SQLServiceTest {
   public void can_execute_close_cursor_query() {
     sqlService.execute(
         new SQLQueryRequest(new JSONObject(), null, QUERY + "/close",
-            Map.of("format", "jdbc"), "n:cursor", List.of()),
+            Map.of("format", "jdbc"), "n:cursor"),
         new ResponseListener<>() {
           @Override
           public void onResponse(QueryResponse response) {
@@ -155,7 +155,7 @@ class SQLServiceTest {
   @Test
   public void cannot_explain_cursor_query() {
     sqlService.explain(new SQLQueryRequest(new JSONObject(), null, EXPLAIN,
-            Map.of("format", "jdbc"), "n:cursor", List.of()),
+            Map.of("format", "jdbc"), "n:cursor"),
         new ResponseListener<ExplainResponse>() {
           @Override
           public void onResponse(ExplainResponse response) {

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -289,6 +290,7 @@ public class SQLQueryRequestTest {
     private String format;
     private String cursor;
     private Map<String, String> params = new HashMap<>();
+    private List<String> routingIds = List.of();
 
     static SQLQueryRequestBuilder request(String query) {
       SQLQueryRequestBuilder builder = new SQLQueryRequestBuilder();
@@ -326,7 +328,7 @@ public class SQLQueryRequestTest {
         params.put("format", format);
       }
       return new SQLQueryRequest(jsonContent == null ? null : new JSONObject(jsonContent),
-          query, path, params, cursor);
+          query, path, params, cursor, routingIds);
     }
   }
 

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -290,7 +289,6 @@ public class SQLQueryRequestTest {
     private String format;
     private String cursor;
     private Map<String, String> params = new HashMap<>();
-    private List<String> routingIds = List.of();
 
     static SQLQueryRequestBuilder request(String query) {
       SQLQueryRequestBuilder builder = new SQLQueryRequestBuilder();
@@ -328,7 +326,7 @@ public class SQLQueryRequestTest {
         params.put("format", format);
       }
       return new SQLQueryRequest(jsonContent == null ? null : new JSONObject(jsonContent),
-          query, path, params, cursor, routingIds);
+          query, path, params, cursor);
     }
   }
 

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -33,6 +33,7 @@ import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ast.dsl.AstDSL;
@@ -121,6 +122,39 @@ class AstBuilderTest extends AstBuilderTestBase {
             alias("age", qualifiedName("age"))
         ),
         buildAST("SELECT age FROM test")
+    );
+  }
+
+  @Test
+  public void can_build_select_fields_from_index_with_partition() {
+    assertEquals(
+        project(
+            relation("test", null, List.of("key")),
+            alias("age", qualifiedName("age"))
+        ),
+        buildAST("SELECT age FROM test PARTITION(key)")
+    );
+  }
+
+  @Test
+  public void can_build_select_fields_from_index_with_multiple_partitions() {
+    assertEquals(
+        project(
+            relation("test", null, List.of("key1", "key2", "key3")),
+            alias("age", qualifiedName("age"))
+        ),
+        buildAST("SELECT age FROM test PARTITION(key1, key2, key3)")
+    );
+  }
+
+  @Test
+  public void can_build_select_fields_from_index_with_quoted_partitions() {
+    assertEquals(
+        project(
+            relation("test", null, List.of("'key1'", "\"key2\"", "`key3`")),
+            alias("age", qualifiedName("age"))
+        ),
+        buildAST("SELECT age FROM test PARTITION('key1', \"key2\", `key3`)")
     );
   }
 


### PR DESCRIPTION
### Description
Allows user to set routing shard via the relation partition keys. For example: 
```
select _id, _index, _routing, int0 from calcs_routing PARTITION(KEY1, KEY2) where _routing = 'KEY1' or _routing = 'KEY2'
```

Note that multiple keys can be send to OpenSearch storage by using comma-delimited list. 

#### IT tests

New IT tests running against a multi-node cluster have been added to the build.  These can be run using `./gradlew :integ-test:multiClusterSearch` and will be automatically run against CI. 

#### TODO

- [x] Remove quotes/backticks from around the routingId before sending
- [x] Rebase
- [ ] Propose PPL syntax

### Issues Resolved
* resolves https://github.com/opensearch-project/sql/issues/1478 for SQL

Note (out of scope): PPL syntax is still TBD
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).