### PR TITLE
Add new setting to ignore pagination where it is unsupported in V2.

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
@@ -32,6 +32,7 @@ public abstract class Settings {
     QUERY_SIZE_LIMIT("plugins.query.size_limit"),
     ENCYRPTION_MASTER_KEY("plugins.query.datasources.encryption.masterkey"),
     DATASOURCES_URI_ALLOWHOSTS("plugins.query.datasources.uri.allowhosts"),
+    IGNORE_UNSUPPORTED_PAGINATION("plugins.query.ignore_unsupported_pagination"),
 
     METRICS_ROLLING_WINDOW("plugins.query.metrics.rolling_window"),
     METRICS_ROLLING_INTERVAL("plugins.query.metrics.rolling_interval"),

--- a/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
@@ -122,10 +122,7 @@ public class QueryPlanFactory
       } else if (settings.getSettingValue(Settings.Key.IGNORE_UNSUPPORTED_PAGINATION)) {
         LOG.warn("[{}] Query executed without pagination.", QueryContext.getRequestId());
         return new QueryPlan(
-            QueryId.queryId(),
-            node.getPlan(),
-            queryService,
-            context.getLeft().get());
+            QueryId.queryId(), node.getPlan(), queryService, context.getLeft().get());
       } else {
         // This should be picked up by the legacy engine.
         throw new UnsupportedCursorRequestException();

--- a/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
@@ -13,6 +13,8 @@ import com.google.common.base.Preconditions;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.statement.Explain;
 import org.opensearch.sql.ast.statement.Query;
@@ -21,6 +23,8 @@ import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.common.utils.QueryContext;
 import org.opensearch.sql.exception.UnsupportedCursorRequestException;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.QueryId;
@@ -38,6 +42,10 @@ public class QueryPlanFactory
 
   /** Query Service. */
   private final QueryService queryService;
+
+  private final Settings settings;
+
+  private static final Logger LOG = LogManager.getLogger(QueryPlanFactory.class);
 
   /**
    * NO_CONSUMER_RESPONSE_LISTENER should never be called. It is only used as constructor parameter
@@ -109,6 +117,13 @@ public class QueryPlanFactory
             QueryId.queryId(),
             node.getPlan(),
             node.getFetchSize(),
+            queryService,
+            context.getLeft().get());
+      } else if (settings.getSettingValue(Settings.Key.IGNORE_UNSUPPORTED_PAGINATION)) {
+        LOG.warn("[{}] Query executed without pagination.", QueryContext.getRequestId());
+        return new QueryPlan(
+            QueryId.queryId(),
+            node.getPlan(),
             queryService,
             context.getLeft().get());
       } else {

--- a/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanFactoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanFactoryTest.java
@@ -10,6 +10,7 @@ package org.opensearch.sql.executor.execution;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,6 +33,7 @@ import org.opensearch.sql.ast.statement.Statement;
 import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.exception.UnsupportedCursorRequestException;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.QueryService;
@@ -51,11 +53,14 @@ class QueryPlanFactoryTest {
 
   @Mock private ExecutionEngine.QueryResponse queryResponse;
 
+  @Mock
+  private Settings settings;
+
   private QueryPlanFactory factory;
 
   @BeforeEach
   void init() {
-    factory = new QueryPlanFactory(queryService);
+    factory = new QueryPlanFactory(queryService, settings);
   }
 
   @Test
@@ -125,17 +130,19 @@ class QueryPlanFactoryTest {
   @Test
   public void create_query_with_fetch_size_which_can_be_paged() {
     when(plan.accept(any(CanPaginateVisitor.class), any())).thenReturn(Boolean.TRUE);
-    factory = new QueryPlanFactory(queryService);
+    factory = new QueryPlanFactory(queryService, settings);
     Statement query = new Query(plan, 10);
     AbstractPlan queryExecution =
         factory.create(query, Optional.of(queryListener), Optional.empty());
     assertTrue(queryExecution instanceof QueryPlan);
+    assertEquals(10, ((QueryPlan) queryExecution).pageSize.get());
   }
 
   @Test
-  public void create_query_with_fetch_size_which_cannot_be_paged() {
+  public void create_query_with_fetch_size_which_cannot_be_paged_with_legacy_fallback() {
     when(plan.accept(any(CanPaginateVisitor.class), any())).thenReturn(Boolean.FALSE);
-    factory = new QueryPlanFactory(queryService);
+    when(settings.getSettingValue(Settings.Key.IGNORE_UNSUPPORTED_PAGINATION)).thenReturn(false);
+    factory = new QueryPlanFactory(queryService, settings);
     Statement query = new Query(plan, 10);
     assertThrows(
         UnsupportedCursorRequestException.class,
@@ -143,8 +150,20 @@ class QueryPlanFactoryTest {
   }
 
   @Test
+  public void create_query_with_fetch_size_which_cannot_be_paged_with_ignoring_paging() {
+    when(plan.accept(any(CanPaginateVisitor.class), any())).thenReturn(Boolean.FALSE);
+    when(settings.getSettingValue(Settings.Key.IGNORE_UNSUPPORTED_PAGINATION)).thenReturn(true);
+    factory = new QueryPlanFactory(queryService, settings);
+    Statement query = new Query(plan, 10);
+    AbstractPlan queryExecution =
+        factory.create(query, Optional.of(queryListener), Optional.empty());
+    assertTrue(queryExecution instanceof QueryPlan);
+    assertFalse(((QueryPlan) queryExecution).pageSize.isPresent());
+  }
+
+  @Test
   public void create_close_cursor() {
-    factory = new QueryPlanFactory(queryService);
+    factory = new QueryPlanFactory(queryService, settings);
     var plan = factory.createCloseCursor("pewpew", queryListener);
     assertTrue(plan instanceof CommandPlan);
     plan.execute();

--- a/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanFactoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/QueryPlanFactoryTest.java
@@ -53,8 +53,7 @@ class QueryPlanFactoryTest {
 
   @Mock private ExecutionEngine.QueryResponse queryResponse;
 
-  @Mock
-  private Settings settings;
+  @Mock private Settings settings;
 
   private QueryPlanFactory factory;
 

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -36,7 +36,7 @@ The opendistro.sql.query.analysis.semantic.threshold setting is deprecated and w
 
 opendistro.sql.query.response.format
 ------------------------------------
-The opendistro.sql.query.response.format setting is deprecated and will be removed then. From OpenSearch 1.0, the query response format is default to JDBC format. `You can change the format by using query parameters<../interfaces/protocol.rst>`_.
+The opendistro.sql.query.response.format setting is deprecated and will be removed then. From OpenSearch 1.0, the query response format is default to JDBC format. `You can change the format by using query parameters <../interfaces/protocol.rst>`_.
 
 opendistro.sql.cursor.enabled
 -----------------------------
@@ -47,7 +47,7 @@ opendistro.sql.cursor.fetch_size
 The opendistro.sql.cursor.fetch_size setting is deprecated and will be removed then. From OpenSearch 1.0, the fetch_size in query body will decide whether create the cursor context. No cursor will be created if the fetch_size = 0.
 
 plugins.sql.enabled
-======================
+===================
 
 Description
 -----------
@@ -64,7 +64,7 @@ Example 1
 
 You can update the setting with a new value like this.
 
-SQL query::
+Configuration request::
 
 	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
 	  "transient" : {
@@ -72,7 +72,7 @@ SQL query::
 	  }
 	}'
 
-Result set::
+Response::
 
 	{
 	  "acknowledged" : true,
@@ -99,7 +99,7 @@ SQL query::
 	  "query" : "SELECT * FROM accounts"
 	}'
 
-Result set::
+Response::
 
 	{
 	  "error" : {
@@ -111,7 +111,7 @@ Result set::
 	}
 
 plugins.sql.slowlog
-============================
+===================
 
 Description
 -----------
@@ -128,7 +128,7 @@ Example
 
 You can update the setting with a new value like this.
 
-SQL query::
+Configuration request::
 
 	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
 	  "transient" : {
@@ -136,7 +136,7 @@ SQL query::
 	  }
 	}'
 
-Result set::
+Response::
 
 	{
 	  "acknowledged" : true,
@@ -153,7 +153,7 @@ Result set::
 Note: the legacy settings of ``opendistro.sql.slowlog`` is deprecated, it will fallback to the new settings if you request an update with the legacy name.
 
 plugins.sql.cursor.keep_alive
-================================
+=============================
 
 Description
 -----------
@@ -170,7 +170,7 @@ Example
 
 You can update the setting with a new value like this.
 
-SQL query::
+Configuration request::
 
 	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
 	  "transient" : {
@@ -178,7 +178,7 @@ SQL query::
 	  }
 	}'
 
-Result set::
+Response::
 
 	{
 	  "acknowledged" : true,
@@ -197,7 +197,7 @@ Result set::
 Note: the legacy settings of ``opendistro.sql.cursor.keep_alive`` is deprecated, it will fallback to the new settings if you request an update with the legacy name.
 
 plugins.query.size_limit
-===========================
+========================
 
 Description
 -----------
@@ -210,7 +210,7 @@ The new engine fetches a default size of index from OpenSearch set by this setti
 	  }
 	}'
 
-Result set::
+Response::
 
     {
       "acknowledged" : true,
@@ -240,25 +240,25 @@ You can set heap memory usage limit for the query engine. When query running, it
 	  }
 	}'
 
-Result set::
+Response::
 
     {
       "acknowledged": true,
-      "persistent": {
+      "persistent": { },
+      "transient": {
         "plugins": {
           "query": {
             "memory_limit": "80%"
           }
         }
-      },
-      "transient": {}
+      }
     }
 
 Note: the legacy settings of ``opendistro.ppl.query.memory_limit`` is deprecated, it will fallback to the new settings if you request an update with the legacy name.
 
 
 plugins.sql.delete.enabled
-======================
+==========================
 
 Description
 -----------
@@ -275,10 +275,10 @@ Example 1
 
 You can update the setting with a new value like this.
 
-SQL query::
+Configuration request::
 
     sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings \
-    ... -d '{"transient":{"plugins.sql.delete.enabled":"false"}}'
+    ... -d '{ "transient" : { "plugins.sql.delete.enabled" : false } }'
     {
       "acknowledged": true,
       "persistent": {},
@@ -311,3 +311,38 @@ SQL query::
       "status": 400
     }
 
+plugins.query.ignore_unsupported_pagination
+===========================================
+
+Description
+-----------
+
+This boolean settings defines how SQL plugin handles pagination requests with features which are not supported or not compatible with pagination in V2 engine.
+
+Please, refer to `V1/V2 limitations <https://opensearch.org/docs/latest/search-plugins/sql/limitation/#query-processing-engines>`_ and `pagination request <../interfaces/endpoint.rst#cursor>`_ info sections.
+
+1. This setting is set to ``true`` by default.
+2. When it is set to ``true``, such requests are performed without pagination.
+3. When it is set to ``false``, such requests are performed by V1 engine.
+
+Configuration request::
+
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
+	  "transient" : {
+	    "plugins.query.ignore_unsupported_pagination" : false
+	  }
+	}'
+
+Response::
+
+    {
+      "acknowledged": true,
+      "persistent": { },
+      "transient": {
+        "plugins": {
+          "query": {
+            "ignore_unsupported_pagination": "false"
+          }
+        }
+      }
+    }

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -3,7 +3,7 @@
 OpenSearch SQL Reference Manual
 ===============================
 
-OpenSearch SQL enables you to extract insights out of OpenSearch using the familiar SQL query syntax. Please refer to the `technical documentation <https://docs-beta.opensearch.org/>`_ for detailed information on installing and configuring opendistro-elasticsearch-sql plugin. In this user reference manual, you can find many information for your reference. In each part, we try to make it clear by adding work example along with detailed description. Here is table of contents of the documentation:
+OpenSearch SQL enables you to extract insights out of OpenSearch using the familiar SQL query syntax. Please refer to the `technical documentation <https://opensearch.org/docs/latest/install-and-configure/plugins/>`_ for detailed information on installing and configuring SQL plugin. In this user reference manual, you can find many information for your reference. In each part, we try to make it clear by adding work example along with detailed description. Here is table of contents of the documentation:
 
 * **Interfaces**
 

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/runner/connection/JDBCConnection.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/runner/connection/JDBCConnection.java
@@ -108,7 +108,9 @@ public class JDBCConnection implements DBConnection {
 
   @Override
   public DBResult select(String query) {
-    try (Statement stmt = connection.createStatement()) {
+    try (Statement stmt =
+        connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
+      stmt.setFetchSize(5);
       ResultSet resultSet = stmt.executeQuery(query);
       DBResult result =
           isOrderByQuery(query)

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
@@ -39,6 +39,8 @@ public class CursorIT extends SQLIntegTestCase {
   @Override
   protected void init() throws Exception {
     loadIndex(Index.ACCOUNT);
+    updateClusterSettings(
+        new ClusterSetting(PERSISTENT, Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), "false"));
   }
 
   /**

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
@@ -40,7 +40,8 @@ public class CursorIT extends SQLIntegTestCase {
   protected void init() throws Exception {
     loadIndex(Index.ACCOUNT);
     updateClusterSettings(
-        new ClusterSetting(PERSISTENT, Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), "false"));
+        new ClusterSetting(
+            PERSISTENT, Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), "false"));
   }
 
   /**

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -392,7 +392,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return new JSONObject(executeRequest(request, client));
   }
 
-  protected static JSONObject updateClusterSettings(ClusterSetting setting) throws IOException {
+  public static JSONObject updateClusterSettings(ClusterSetting setting) throws IOException {
     return updateClusterSettings(setting, client());
   }
 
@@ -404,7 +404,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return new JSONObject(executeRequest(request));
   }
 
-  protected static class ClusterSetting {
+  public static class ClusterSetting {
     private final String type;
     private final String name;
     private final String value;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
@@ -235,12 +235,11 @@ public class StandaloneIT extends PPLIntegTestCase {
 
     @Provides
     public QueryPlanFactory queryPlanFactory(ExecutionEngine executionEngine) {
-      Analyzer analyzer =
-          new Analyzer(
-              new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
+      Analyzer analyzer = new Analyzer(
+          new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
       Planner planner = new Planner(LogicalPlanOptimizer.create());
       QueryService queryService = new QueryService(analyzer, executionEngine, planner);
-      return new QueryPlanFactory(queryService);
+      return new QueryPlanFactory(queryService, settings);
     }
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
@@ -235,8 +235,9 @@ public class StandaloneIT extends PPLIntegTestCase {
 
     @Provides
     public QueryPlanFactory queryPlanFactory(ExecutionEngine executionEngine) {
-      Analyzer analyzer = new Analyzer(
-          new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
+      Analyzer analyzer =
+          new Analyzer(
+              new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
       Planner planner = new Planner(LogicalPlanOptimizer.create());
       QueryService queryService = new QueryService(analyzer, executionEngine, planner);
       return new QueryPlanFactory(queryService, settings);

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
@@ -6,20 +6,28 @@
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
 import static org.opensearch.sql.util.TestUtils.verifyIsV1Cursor;
 import static org.opensearch.sql.util.TestUtils.verifyIsV2Cursor;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.junit.Test;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.util.TestUtils;
+import lombok.SneakyThrows;
 
 public class PaginationFallbackIT extends SQLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.PHRASE);
     loadIndex(Index.ONLINE);
+    loadIndex(Index.BANK);
+    updateClusterSettings(
+        new ClusterSetting(PERSISTENT, Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), "false"));
   }
 
   @Test
@@ -119,5 +127,48 @@ public class PaginationFallbackIT extends SQLIntegTestCase {
   public void testOrderBy() throws IOException {
     var response = executeQueryTemplate("SELECT * FROM %s ORDER By `107`", TEST_INDEX_ONLINE);
     verifyIsV2Cursor(response);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testFallbackSwitch() {
+    var log = Paths.get(System.getProperty("project.root"),
+        "build", "testclusters", "integTest-0", "logs", "integTest.log");
+    // By default, the switch set to true - don't paginate if unsupported
+    // Unset custom setting and check the default value
+    updateClusterSettings(new ClusterSetting(PERSISTENT,
+        Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), null));
+    var clusterSettings = getAllClusterSettings();
+    assertEquals("true", clusterSettings.getJSONObject("defaults")
+        .getString(Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue()));
+
+    var logSize = Files.readAllLines(log).size();
+    // Query should be executed on V2 (aggregation is not supported with paging there) without cursor
+    var response = executeQueryTemplate("SELECT state, count(*) as `count` FROM %s GROUP BY state",
+        TEST_INDEX_BANK);
+    assertFalse(response.has("cursor"));
+    assertEquals(7, response.getInt("total"));
+    // Check logs
+    var lines = Files.readAllLines(log);
+    assertTrue(lines.stream().skip(logSize)
+        .anyMatch(l -> l.endsWith("Query executed without pagination.")));
+    assertFalse(lines.stream().skip(logSize)
+        .anyMatch(l -> l.endsWith("Request is not supported and falling back to old SQL engine")));
+    logSize = lines.size();
+
+    updateClusterSettings(new ClusterSetting(PERSISTENT,
+        Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), "false"));
+
+    // V1 fails to execute such query
+    response = executeQueryTemplate("SELECT state, count(*) as `count` FROM %s GROUP BY state",
+        TEST_INDEX_BANK);
+    assertEquals(response.getJSONObject("error").getString("reason"),
+        "There was internal problem at backend");
+    // Check logs
+    lines = Files.readAllLines(log);
+    assertFalse(lines.stream().skip(logSize)
+        .anyMatch(l -> l.endsWith("Query executed without pagination.")));
+    assertTrue(lines.stream().skip(logSize)
+        .anyMatch(l -> l.endsWith("Request is not supported and falling back to old SQL engine")));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SQLCorrectnessIT.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.legacy.SQLIntegTestCase.PERSISTENT;
+import static org.opensearch.sql.legacy.SQLIntegTestCase.updateClusterSettings;
+
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -12,6 +15,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
 import org.junit.Test;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 /** SQL integration test automated by comparison test framework. */
 public class SQLCorrectnessIT extends CorrectnessTestBase {
@@ -23,6 +28,11 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
   @Override
   protected void init() throws Exception {
     super.init();
+    updateClusterSettings(
+        new SQLIntegTestCase.ClusterSetting(
+            PERSISTENT,
+            Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(),
+            "true"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SQLCorrectnessIT.java
@@ -30,9 +30,7 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
     super.init();
     updateClusterSettings(
         new SQLIntegTestCase.ClusterSetting(
-            PERSISTENT,
-            Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(),
-            "true"));
+            PERSISTENT, Settings.Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(), "true"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/util/StandaloneModule.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/StandaloneModule.java
@@ -105,7 +105,7 @@ public class StandaloneModule extends AbstractModule {
   @Provides
   public QueryPlanFactory queryPlanFactory(QueryService qs) {
 
-    return new QueryPlanFactory(qs);
+    return new QueryPlanFactory(qs, settings);
   }
 
   @Provides

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -155,8 +155,8 @@ public class RestSqlAction extends BaseRestHandler {
                             if (newSqlRequest.isExplainRequest()) {
                                 LOG.info("Request is falling back to old SQL engine due to: " + exception.getMessage());
                             }
-                            LOG.info("[{}] Request {} is not supported and falling back to old SQL engine",
-                                QueryContext.getRequestId(), newSqlRequest);
+                            LOG.info("[{}] Request is not supported and falling back to old SQL engine",
+                                QueryContext.getRequestId());
                             LOG.info("Request Query: {}", QueryDataAnonymizer.anonymizeData(sqlRequest.getSql()));
                             QueryAction queryAction = explainRequest(client, sqlRequest, format);
                             executeSqlRequest(request, queryAction, client, restChannel);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -88,6 +88,12 @@ public class OpenSearchSettings extends Settings {
       Setting.Property.NodeScope,
       Setting.Property.Dynamic);
 
+  public static final Setting<?> IGNORE_UNSUPPORTED_PAGINATION_SETTING = Setting.boolSetting(
+      Key.IGNORE_UNSUPPORTED_PAGINATION.getKeyValue(),
+      true,
+      Setting.Property.NodeScope,
+      Setting.Property.Dynamic);
+
   public static final Setting<?> METRICS_ROLLING_WINDOW_SETTING = Setting.longSetting(
       Key.METRICS_ROLLING_WINDOW.getKeyValue(),
       LegacyOpenDistroSettings.METRICS_ROLLING_WINDOW_SETTING,
@@ -142,6 +148,8 @@ public class OpenSearchSettings extends Settings {
         QUERY_MEMORY_LIMIT_SETTING, new Updater(Key.QUERY_MEMORY_LIMIT));
     register(settingBuilder, clusterSettings, Key.QUERY_SIZE_LIMIT,
         QUERY_SIZE_LIMIT_SETTING, new Updater(Key.QUERY_SIZE_LIMIT));
+    register(settingBuilder, clusterSettings, Key.IGNORE_UNSUPPORTED_PAGINATION,
+        IGNORE_UNSUPPORTED_PAGINATION_SETTING, new Updater(Key.IGNORE_UNSUPPORTED_PAGINATION));
     register(settingBuilder, clusterSettings, Key.METRICS_ROLLING_WINDOW,
         METRICS_ROLLING_WINDOW_SETTING, new Updater(Key.METRICS_ROLLING_WINDOW));
     register(settingBuilder, clusterSettings, Key.METRICS_ROLLING_INTERVAL,
@@ -214,6 +222,7 @@ public class OpenSearchSettings extends Settings {
         .add(PPL_ENABLED_SETTING)
         .add(QUERY_MEMORY_LIMIT_SETTING)
         .add(QUERY_SIZE_LIMIT_SETTING)
+        .add(IGNORE_UNSUPPORTED_PAGINATION_SETTING)
         .add(METRICS_ROLLING_WINDOW_SETTING)
         .add(METRICS_ROLLING_INTERVAL_SETTING)
         .add(DATASOURCE_URI_ALLOW_HOSTS)

--- a/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
@@ -97,12 +97,12 @@ public class OpenSearchPluginModule extends AbstractModule {
   /** {@link QueryPlanFactory}. */
   @Provides
   public QueryPlanFactory queryPlanFactory(
-      DataSourceService dataSourceService, ExecutionEngine executionEngine) {
+      DataSourceService dataSourceService, ExecutionEngine executionEngine, Settings settings) {
     Analyzer analyzer =
         new Analyzer(
             new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
     Planner planner = new Planner(LogicalPlanOptimizer.create());
     QueryService queryService = new QueryService(analyzer, executionEngine, planner);
-    return new QueryPlanFactory(queryService);
+    return new QueryPlanFactory(queryService, settings);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.executor.DefaultQueryManager;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
@@ -44,13 +45,16 @@ public class PPLServiceTest {
 
   @Mock private ExecutionEngine.Schema schema;
 
+  @Mock private Settings settings;
+
   /** Setup the test context. */
   @Before
   public void setUp() {
     queryManager = DefaultQueryManager.defaultQueryManager();
 
     pplService =
-        new PPLService(new PPLSyntaxParser(), queryManager, new QueryPlanFactory(queryService));
+        new PPLService(
+            new PPLSyntaxParser(), queryManager, new QueryPlanFactory(queryService, settings));
   }
 
   @After

--- a/sql/src/main/java/org/opensearch/sql/sql/antlr/SQLSyntaxParser.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/antlr/SQLSyntaxParser.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
 import org.opensearch.sql.common.antlr.Parser;
 import org.opensearch.sql.common.antlr.SyntaxAnalysisErrorListener;
+import org.opensearch.sql.common.utils.QueryContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLLexer;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
 
@@ -35,7 +36,8 @@ public class SQLSyntaxParser implements Parser {
     parser.addParseListener(anonymizer);
 
     ParseTree parseTree = parser.root();
-    LOG.info("New Engine Request Query: {}", anonymizer.getAnonymizedQueryString());
+    LOG.info("[{}] New Engine Request Query: {}",
+        QueryContext.getRequestId(), anonymizer.getAnonymizedQueryString());
 
     return parseTree;
   }

--- a/sql/src/main/java/org/opensearch/sql/sql/antlr/SQLSyntaxParser.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/antlr/SQLSyntaxParser.java
@@ -36,8 +36,10 @@ public class SQLSyntaxParser implements Parser {
     parser.addParseListener(anonymizer);
 
     ParseTree parseTree = parser.root();
-    LOG.info("[{}] New Engine Request Query: {}",
-        QueryContext.getRequestId(), anonymizer.getAnonymizedQueryString());
+    LOG.info(
+        "[{}] New Engine Request Query: {}",
+        QueryContext.getRequestId(),
+        anonymizer.getAnonymizedQueryString());
 
     return parseTree;
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.executor.DefaultQueryManager;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponseNode;
@@ -46,11 +47,14 @@ class SQLServiceTest {
 
   @Mock private QueryService queryService;
 
+  @Mock private Settings settings;
+
   @BeforeEach
   public void setUp() {
     queryManager = DefaultQueryManager.defaultQueryManager();
     sqlService =
-        new SQLService(new SQLSyntaxParser(), queryManager, new QueryPlanFactory(queryService));
+        new SQLService(
+            new SQLSyntaxParser(), queryManager, new QueryPlanFactory(queryService, settings));
   }
 
   @AfterEach


### PR DESCRIPTION
### Description
Changes how pagination requests with unsupported/incompatible [with pagination] queries are handled.
Adds new setting `plugins.query.ignore_unsupported_pagination`:
1. `true` by default
2. when `true` such requests are performed without pagination
3. when `false` such requests fall back to legacy engine

Misc changes:
1. Minor logging improvements
2. Minor doc grooming
3. Use pagination in correctness test


```
curl -X PUT localhost:9200/_cluster/settings?pretty -H "Content-Type: application/json" -d '{ "transient": { "plugins.query.ignore_unsupported_pagination": true } }'
```
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1765, https://github.com/opensearch-project/sql/issues/78
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).