### PR TITLE
1713: add multi-cluster IT testing class for Cross-Cluster support

### DIFF
--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -64,8 +64,9 @@ jobs:
         ./gradlew :core:jacocoTestCoverageVerification                   || echo "* Jacoco failed for core" >> report.log
         ./gradlew :protocol:jacocoTestCoverageVerification               || echo "* Jacoco failed for protocol" >> report.log
         ./gradlew :opensearch-sql-plugin:jacocoTestCoverageVerification  || echo "* Jacoco failed for plugin" >> report.log
-        # Misc tests
+        # Misc/Additional Integration tests
         ./gradlew :integ-test:integTest                   || echo "* Integration test failed" >> report.log
+        ./gradlew :integ-test:multiClusterSearch          || echo "* Multi-Cluster Search tests failed" >> report.log
         ./gradlew :doctest:doctest                        || echo "* Doctest failed" >> report.log
         ./scripts/bwctest.sh                              || echo "* Backward compatibility test failed" >> report.log
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -285,6 +285,9 @@ integTest {
     exclude 'org/opensearch/sql/doctest/**/*IT.class'
     exclude 'org/opensearch/sql/correctness/**'
 
+    // Skip to run these IT tests on a different cluster
+    exclude 'org/opensearch/sql/multiClusterSearch/**'
+
     // Explain IT is dependent on internal implementation of old engine so it's not necessary
     // to run these with new engine and not necessary to make this consistent with old engine.
     exclude 'org/opensearch/sql/legacy/ExplainIT.class'
@@ -301,7 +304,7 @@ integTest {
     exclude 'org/opensearch/sql/jdbc/**'
 
     // Exclude this IT until running IT with security plugin enabled is ready
-    exclude 'org/opensearch/sql/ppl/CrossClusterSearchIT.class'
+    // exclude 'org/opensearch/sql/ppl/CrossClusterSearchIT.class'
 }
 
 
@@ -479,6 +482,76 @@ task bwcTestSuite(type: StandaloneRestIntegTestTask) {
     dependsOn tasks.named("${baseName}#mixedClusterTask")
     dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
     dependsOn tasks.named("${baseName}#fullRestartClusterTask")
+}
+
+testClusters {
+    multiClusterSearch {
+        testDistribution = "ARCHIVE"
+        numberOfNodes = 3
+        plugin ":opensearch-sql-plugin"
+    }
+}
+
+testClusters {
+    multiClusterSearchRemote {
+        testDistribution = "ARCHIVE"
+        plugin ":opensearch-sql-plugin"
+    }
+}
+
+task multiClusterSearch(type: RestIntegTestTask) {
+
+    useCluster testClusters.multiClusterSearch
+    useCluster testClusters.multiClusterSearchRemote
+
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+
+    // Set properties for connection to clusters and between clusters
+    doFirst {
+        getClusters().forEach { cluster ->
+            String allTransportSocketURI = cluster.nodes.stream().flatMap { node ->
+                node.getAllTransportPortURI().stream()
+            }.collect(Collectors.joining(","))
+            String allHttpSocketURI = cluster.nodes.stream().flatMap { node ->
+                node.getAllHttpSocketURI().stream()
+            }.collect(Collectors.joining(","))
+
+            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> allHttpSocketURI}"
+            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> allTransportSocketURI}"
+        }
+    }
+
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Set default query size limit
+    systemProperty 'defaultQuerySizeLimit', '10000'
+
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst {
+        if (System.getProperty("debug-jvm") != null) {
+            setDebug(true);
+        }
+        systemProperty 'cluster.debug', getDebug()
+    }
+
+
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006'
+    }
+
+    filter {
+        includeTestsMatching "org.opensearch.sql.multiClusterSearch.*IT"
+    }
 }
 
 def opensearch_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -105,10 +105,10 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
   }
 
   // Modified from initClient in OpenSearchRestTestCase
-  public void initRemoteClient() throws IOException {
+  public void initRemoteClient(String clusterName) throws IOException {
     if (remoteClient == null) {
       assert remoteAdminClient == null;
-      String cluster = getTestRestCluster(REMOTE_CLUSTER);
+      String cluster = getTestRestCluster(clusterName);
       String[] stringUrls = cluster.split(",");
       List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
       for (String stringUrl : stringUrls) {
@@ -252,14 +252,14 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
    * Initialize rest client to remote cluster,
    * and create a connection to it from the coordinating cluster.
    */
-  public void configureMultiClusters() throws IOException {
-    initRemoteClient();
+  public void configureMultiClusters(String clusterName) throws IOException {
+    initRemoteClient(clusterName);
 
     Request connectionRequest = new Request("PUT", "_cluster/settings");
     String connectionSetting = "{\"persistent\": {\"cluster\": {\"remote\": {\""
-        + REMOTE_CLUSTER
+        + clusterName
         + "\": {\"seeds\": [\""
-        + getTestTransportCluster(REMOTE_CLUSTER).split(",")[0]
+        + getTestTransportCluster(clusterName).split(",")[0]
         + "\"]}}}}}";
     connectionRequest.setJsonEntity(connectionSetting);
     adminClient().performRequest(connectionRequest);

--- a/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/CrossClusterSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/multiClusterSearch/CrossClusterSearchIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.multiClusterSearch;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
+import static org.opensearch.sql.util.MatcherUtils.columnName;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.client.ResponseException;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+public class CrossClusterSearchIT extends PPLIntegTestCase {
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  public static final String REMOTE_CLUSTER = "multiClusterSearchRemote";
+
+  private final static String TEST_INDEX_BANK_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_BANK;
+  private final static String TEST_INDEX_DOG_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
+  private final static String TEST_INDEX_DOG_MATCH_ALL_REMOTE = MATCH_ALL_REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
+  private final static String TEST_INDEX_ACCOUNT_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_ACCOUNT;
+
+  @Override
+  public void init() throws IOException {
+    configureMultiClusters(REMOTE_CLUSTER);
+    loadIndex(Index.BANK);
+    loadIndex(Index.BANK, remoteClient());
+    loadIndex(Index.DOG);
+    loadIndex(Index.DOG, remoteClient());
+    loadIndex(Index.ACCOUNT, remoteClient());
+  }
+
+  @Test
+  public void testCrossClusterSearchAllFields() throws IOException {
+    JSONObject result = executeQuery(String.format("search source=%s", TEST_INDEX_DOG_REMOTE));
+    verifyColumn(result, columnName("dog_name"), columnName("holdersName"), columnName("age"));
+  }
+
+  @Test
+  public void testMatchAllCrossClusterSearchAllFields() throws IOException {
+    JSONObject result = executeQuery(String.format("search source=%s", TEST_INDEX_DOG_MATCH_ALL_REMOTE));
+    verifyColumn(result, columnName("dog_name"), columnName("holdersName"), columnName("age"));
+  }
+
+  @Test
+  public void testCrossClusterSearchWithoutLocalFieldMappingShouldFail() throws IOException {
+    exceptionRule.expect(ResponseException.class);
+    exceptionRule.expectMessage("400 Bad Request");
+    exceptionRule.expectMessage("IndexNotFoundException");
+
+    executeQuery(String.format("search source=%s", TEST_INDEX_ACCOUNT_REMOTE));
+  }
+
+  @Test
+  public void testCrossClusterSearchCommandWithLogicalExpression() throws IOException {
+    JSONObject result = executeQuery(String.format(
+        "search source=%s firstname='Hattie' | fields firstname", TEST_INDEX_BANK_REMOTE));
+    verifyDataRows(result, rows("Hattie"));
+  }
+
+  @Test
+  public void testCrossClusterSearchMultiClusters() throws IOException {
+    JSONObject result = executeQuery(String.format(
+        "search source=%s,%s firstname='Hattie' | fields firstname", TEST_INDEX_BANK_REMOTE, TEST_INDEX_BANK));
+    verifyDataRows(result,
+        rows("Hattie"),
+        rows("Hattie"));
+  }
+
+  @Test
+  public void testCrossClusterDescribeAllFields() throws IOException {
+    JSONObject result = executeQuery(String.format("describe %s", TEST_INDEX_DOG_REMOTE));
+    verifyColumn(
+        result,
+        columnName("TABLE_CAT"),
+        columnName("TABLE_SCHEM"),
+        columnName("TABLE_NAME"),
+        columnName("COLUMN_NAME"),
+        columnName("DATA_TYPE"),
+        columnName("TYPE_NAME"),
+        columnName("COLUMN_SIZE"),
+        columnName("BUFFER_LENGTH"),
+        columnName("DECIMAL_DIGITS"),
+        columnName("NUM_PREC_RADIX"),
+        columnName("NULLABLE"),
+        columnName("REMARKS"),
+        columnName("COLUMN_DEF"),
+        columnName("SQL_DATA_TYPE"),
+        columnName("SQL_DATETIME_SUB"),
+        columnName("CHAR_OCTET_LENGTH"),
+        columnName("ORDINAL_POSITION"),
+        columnName("IS_NULLABLE"),
+        columnName("SCOPE_CATALOG"),
+        columnName("SCOPE_SCHEMA"),
+        columnName("SCOPE_TABLE"),
+        columnName("SOURCE_DATA_TYPE"),
+        columnName("IS_AUTOINCREMENT"),
+        columnName("IS_GENERATEDCOLUMN")
+    );
+  }
+
+  @Test
+  public void testMatchAllCrossClusterDescribeAllFields() throws IOException {
+    JSONObject result = executeQuery(String.format("describe %s", TEST_INDEX_DOG_MATCH_ALL_REMOTE));
+    verifyColumn(
+        result,
+        columnName("TABLE_CAT"),
+        columnName("TABLE_SCHEM"),
+        columnName("TABLE_NAME"),
+        columnName("COLUMN_NAME"),
+        columnName("DATA_TYPE"),
+        columnName("TYPE_NAME"),
+        columnName("COLUMN_SIZE"),
+        columnName("BUFFER_LENGTH"),
+        columnName("DECIMAL_DIGITS"),
+        columnName("NUM_PREC_RADIX"),
+        columnName("NULLABLE"),
+        columnName("REMARKS"),
+        columnName("COLUMN_DEF"),
+        columnName("SQL_DATA_TYPE"),
+        columnName("SQL_DATETIME_SUB"),
+        columnName("CHAR_OCTET_LENGTH"),
+        columnName("ORDINAL_POSITION"),
+        columnName("IS_NULLABLE"),
+        columnName("SCOPE_CATALOG"),
+        columnName("SCOPE_SCHEMA"),
+        columnName("SCOPE_TABLE"),
+        columnName("SOURCE_DATA_TYPE"),
+        columnName("IS_AUTOINCREMENT"),
+        columnName("IS_GENERATEDCOLUMN")
+    );
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/CrossClusterSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/CrossClusterSearchIT.java
@@ -33,7 +33,7 @@ public class CrossClusterSearchIT extends PPLIntegTestCase {
 
   @Override
   public void init() throws IOException {
-    configureMultiClusters();
+    configureMultiClusters(REMOTE_CLUSTER);
     loadIndex(Index.BANK);
     loadIndex(Index.BANK, remoteClient());
     loadIndex(Index.DOG);


### PR DESCRIPTION
### Description
Adds multiClusterSearch IT test task that creates a 3-node cluster and additional cross-cluster for CrossClusterSearchIT testing, with the Security plugin enabled. 

This will bring IT test infrastructure more in-step with the release workflow to avoid security-plugin issues in the future. 
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1713
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).