### PR TITLE
[Spotless] Applying Google Code Format for integ-tests #9

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -53,6 +53,11 @@ repositories {
     }
 }
 
+// Being ignored as a temporary measure before being removed in favour of
+// spotless https://github.com/opensearch-project/sql/issues/1101
+checkstyleTest.ignoreFailures = true
+checkstyleMain.ignoreFailures = true
+
 ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.TXT')

--- a/integ-test/src/test/java/org/opensearch/sql/bwc/SQLBackwardsCompatibilityIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/bwc/SQLBackwardsCompatibilityIT.java
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.bwc;
-
 
 import static org.opensearch.sql.legacy.TestUtils.createIndexByRestClient;
 import static org.opensearch.sql.legacy.TestUtils.isIndexExist;

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/runner/connection/OpenSearchConnection.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/runner/connection/OpenSearchConnection.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.correctness.runner.connection;
 
 import java.io.IOException;
@@ -16,18 +15,15 @@ import org.opensearch.client.RestClient;
 import org.opensearch.sql.correctness.runner.resultset.DBResult;
 
 /**
- * OpenSearch database connection for insertion. This class wraps JDBCConnection to delegate query method.
+ * OpenSearch database connection for insertion. This class wraps JDBCConnection to delegate query
+ * method.
  */
 public class OpenSearchConnection implements DBConnection {
 
-  /**
-   * Connection via our OpenSearch JDBC driver
-   */
+  /** Connection via our OpenSearch JDBC driver */
   private final DBConnection connection;
 
-  /**
-   * Native OpenSearch REST client for operation unsupported by driver such as CREATE/INSERT
-   */
+  /** Native OpenSearch REST client for operation unsupported by driver such as CREATE/INSERT */
   private final RestClient client;
 
   public OpenSearchConnection(String connectionUrl, RestClient client) {
@@ -112,10 +108,8 @@ public class OpenSearchConnection implements DBConnection {
         }
       }
 
-      body.append("{\"index\":{}}\n").
-          append(json).append("\n");
+      body.append("{\"index\":{}}\n").append(json).append("\n");
     }
     return body.toString();
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/runner/resultset/Row.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/runner/resultset/Row.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.correctness.runner.resultset;
 
 import java.math.BigDecimal;
@@ -15,9 +14,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-/**
- * Row in result set.
- */
+/** Row in result set. */
 @EqualsAndHashCode
 @ToString
 @Getter
@@ -77,5 +74,4 @@ public class Row implements Comparable<Row> {
     }
     return 0;
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/tests/OpenSearchConnectionTest.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/tests/OpenSearchConnectionTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.correctness.tests;
 
 import static org.junit.Assert.assertEquals;
@@ -30,14 +29,11 @@ import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
 import org.opensearch.sql.correctness.runner.connection.OpenSearchConnection;
 
-/**
- * Tests for {@link OpenSearchConnection}
- */
+/** Tests for {@link OpenSearchConnection} */
 @RunWith(MockitoJUnitRunner.class)
 public class OpenSearchConnectionTest {
 
-  @Mock
-  private RestClient client;
+  @Mock private RestClient client;
 
   private OpenSearchConnection conn;
 
@@ -63,36 +59,30 @@ public class OpenSearchConnectionTest {
 
   @Test
   public void testInsertData() throws IOException {
-    conn.insert("test", new String[] {"name"},
-        Arrays.asList(new String[] {"John"}, new String[] {"Hank"}));
+    conn.insert(
+        "test", new String[] {"name"}, Arrays.asList(new String[] {"John"}, new String[] {"Hank"}));
 
     Request actual = captureActualArg();
     assertEquals("POST", actual.getMethod());
     assertEquals("/test/_bulk?refresh=true", actual.getEndpoint());
     assertEquals(
-        "{\"index\":{}}\n"
-            + "{\"name\":\"John\"}\n"
-            + "{\"index\":{}}\n"
-            + "{\"name\":\"Hank\"}\n",
-        getBody(actual)
-    );
+        "{\"index\":{}}\n" + "{\"name\":\"John\"}\n" + "{\"index\":{}}\n" + "{\"name\":\"Hank\"}\n",
+        getBody(actual));
   }
 
   @Test
   public void testInsertNullData() throws IOException {
-    conn.insert("test", new String[] {"name", "age"},
+    conn.insert(
+        "test",
+        new String[] {"name", "age"},
         Arrays.asList(new Object[] {null, 30}, new Object[] {"Hank", null}));
 
     Request actual = captureActualArg();
     assertEquals("POST", actual.getMethod());
     assertEquals("/test/_bulk?refresh=true", actual.getEndpoint());
     assertEquals(
-        "{\"index\":{}}\n"
-            + "{\"age\":30}\n"
-            + "{\"index\":{}}\n"
-            + "{\"name\":\"Hank\"}\n",
-        getBody(actual)
-    );
+        "{\"index\":{}}\n" + "{\"age\":30}\n" + "{\"index\":{}}\n" + "{\"name\":\"Hank\"}\n",
+        getBody(actual));
   }
 
   @Test
@@ -114,5 +104,4 @@ public class OpenSearchConnectionTest {
     InputStream inputStream = request.getEntity().getContent();
     return CharStreams.toString(new InputStreamReader(inputStream));
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/tests/RowTest.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/tests/RowTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.correctness.tests;
 
 import static org.junit.Assert.assertEquals;
@@ -12,9 +11,7 @@ import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
 import org.opensearch.sql.correctness.runner.resultset.Row;
 
-/**
- * Unit test {@link Row}
- */
+/** Unit test {@link Row} */
 public class RowTest {
 
   @Test
@@ -47,5 +44,4 @@ public class RowTest {
     row2.add("world");
     assertEquals(1, row1.compareTo(row2));
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/NestedFieldQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/NestedFieldQueryIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.allOf;
@@ -40,6 +39,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchHit;
 
 /**
+ * <pre>
  * Integration test cases for both rewriting and projection logic.
  * <p>
  * Test result:
@@ -56,12 +56,12 @@ import org.opensearch.search.SearchHit;
  * 4) Subquery
  * 5) HAVING
  * 6) Verification for conditions mixed with regular and nested fields
+ * </pre>
  */
 public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   private static final String FROM =
       "FROM " + TestsConstants.TEST_INDEX_NESTED_TYPE + " n, n.message m";
-
 
   @Override
   protected void init() throws Exception {
@@ -83,188 +83,71 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     assertThat(
         query(sql),
         hits(
-            hit(
-                myNum(1),
-                someField("b"),
-                innerHits("message",
-                    hit(
-                        author("e"),
-                        info("a")
-                    )
-                )
-            ),
-            hit(
-                myNum(2),
-                someField("a"),
-                innerHits("message",
-                    hit(
-                        author("f"),
-                        info("b")
-                    )
-                )
-            ),
-            hit(
-                myNum(3),
-                someField("a"),
-                innerHits("message",
-                    hit(
-                        author("g"),
-                        info("c")
-                    )
-                )
-            ),
+            hit(myNum(1), someField("b"), innerHits("message", hit(author("e"), info("a")))),
+            hit(myNum(2), someField("a"), innerHits("message", hit(author("f"), info("b")))),
+            hit(myNum(3), someField("a"), innerHits("message", hit(author("g"), info("c")))),
             hit(
                 myNum(4),
                 someField("b"),
-                innerHits("message",
-                    hit(
-                        author("h"),
-                        info("c")
-                    ),
-                    hit(
-                        author("i"),
-                        info("a")
-                    )
-                )
-            ),
+                innerHits("message", hit(author("h"), info("c")), hit(author("i"), info("a")))),
             hit(
                 myNum(new int[] {3, 4}),
                 someField("a"),
-                innerHits("message",
-                    hit(
-                        author("zz"),
-                        info("zz")
-                    )
-                )
-            )
-        )
-    );
+                innerHits("message", hit(author("zz"), info("zz"))))));
   }
 
   @Test
   public void singleCondition() throws IOException {
     assertThat(
-        query(
-            "SELECT myNum, m.author, m.info",
-            "WHERE m.info = 'c'"
-        ),
+        query("SELECT myNum, m.author, m.info", "WHERE m.info = 'c'"),
         hits(
-            hit(
-                myNum(3),
-                innerHits("message",
-                    hit(
-                        author("g"),
-                        info("c")
-                    )
-                )
-            ),
-            hit(
-                myNum(4),
-                innerHits("message",
-                    hit(
-                        author("h"),
-                        info("c")
-                    )
-                )
-            )
-        )
-    );
+            hit(myNum(3), innerHits("message", hit(author("g"), info("c")))),
+            hit(myNum(4), innerHits("message", hit(author("h"), info("c"))))));
   }
 
   @Test
   public void multipleConditionsOfNestedField() throws IOException {
     assertThat(
-        query(
-            "SELECT someField, m.author, m.info",
-            "WHERE m.info = 'c' AND m.author = 'h'"
-        ),
-        hits(
-            hit(
-                someField("b"),
-                innerHits("message",
-                    hit(
-                        author("h"),
-                        info("c")
-                    )
-                )
-            )
-        )
-    );
+        query("SELECT someField, m.author, m.info", "WHERE m.info = 'c' AND m.author = 'h'"),
+        hits(hit(someField("b"), innerHits("message", hit(author("h"), info("c"))))));
   }
 
   @Test
   public void multipleConditionsOfNestedFieldNoMatch() throws IOException {
     assertThat(
-        query(
-            "SELECT someField, m.author, m.info",
-            "WHERE m.info = 'c' AND m.author = 'i'"
-        ),
-        hits()
-    );
+        query("SELECT someField, m.author, m.info", "WHERE m.info = 'c' AND m.author = 'i'"),
+        hits());
   }
 
   @Test
   public void multipleConditionsOfRegularAndNestedField() throws IOException {
     assertThat(
-        query(
-            "SELECT myNum, m.author, m.info",
-            "WHERE myNum = 3 AND m.info = 'c'"
-        ),
-        hits(
-            hit(
-                myNum(3),
-                innerHits("message",
-                    hit(
-                        author("g"),
-                        info("c")
-                    )
-                )
-            )
-        )
-    );
+        query("SELECT myNum, m.author, m.info", "WHERE myNum = 3 AND m.info = 'c'"),
+        hits(hit(myNum(3), innerHits("message", hit(author("g"), info("c"))))));
   }
 
   @Test
   public void multipleConditionsOfRegularOrNestedField() throws IOException {
     assertThat(
-        query(
-            "SELECT myNum, m.author, m.info",
-            "WHERE myNum = 2 OR m.info = 'c'"
-        ),
+        query("SELECT myNum, m.author, m.info", "WHERE myNum = 2 OR m.info = 'c'"),
         hits(
-            hit(
-                myNum(2)
-            ), // Note: no inner hit here because of no match in nested field
-            hit(
-                myNum(3),
-                innerHits("message",
-                    hit(
-                        author("g"),
-                        info("c")
-                    )
-                )
-            ),
-            hit(
-                myNum(4),
-                innerHits("message",
-                    hit(
-                        author("h"),
-                        info("c")
-                    )
-                )
-            )
-        )
-    );
+            hit(myNum(2)), // Note: no inner hit here because of no match in nested field
+            hit(myNum(3), innerHits("message", hit(author("g"), info("c")))),
+            hit(myNum(4), innerHits("message", hit(author("h"), info("c"))))));
   }
 
   @Test
   public void leftJoinSelectAll() throws IOException {
-    String sql = "SELECT * " +
-        "FROM opensearch-sql_test_index_employee_nested e " +
-        "LEFT JOIN e.projects p";
+    String sql =
+        "SELECT * "
+            + "FROM opensearch-sql_test_index_employee_nested e "
+            + "LEFT JOIN e.projects p";
     String explain = explainQuery(sql);
-    assertThat(explain, containsString("{\"bool\":{\"must_not\":[{\"nested\":{\"query\":" +
-        "{\"exists\":{\"field\":\"projects\",\"boost\":1.0}},\"path\":\"projects\""));
+    assertThat(
+        explain,
+        containsString(
+            "{\"bool\":{\"must_not\":[{\"nested\":{\"query\":"
+                + "{\"exists\":{\"field\":\"projects\",\"boost\":1.0}},\"path\":\"projects\""));
 
     assertThat(explain, containsString("\"_source\":{\"includes\":[\"projects.*\""));
 
@@ -274,41 +157,49 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void leftJoinSpecificFields() throws IOException {
-    String sql = "SELECT e.name, p.name, p.started_year " +
-        "FROM opensearch-sql_test_index_employee_nested e " +
-        "LEFT JOIN e.projects p";
+    String sql =
+        "SELECT e.name, p.name, p.started_year "
+            + "FROM opensearch-sql_test_index_employee_nested e "
+            + "LEFT JOIN e.projects p";
     String explain = explainQuery(sql);
-    assertThat(explain, containsString("{\"bool\":{\"must_not\":[{\"nested\":{\"query\":" +
-        "{\"exists\":{\"field\":\"projects\",\"boost\":1.0}},\"path\":\"projects\""));
+    assertThat(
+        explain,
+        containsString(
+            "{\"bool\":{\"must_not\":[{\"nested\":{\"query\":"
+                + "{\"exists\":{\"field\":\"projects\",\"boost\":1.0}},\"path\":\"projects\""));
     assertThat(explain, containsString("\"_source\":{\"includes\":[\"name\"],"));
-    assertThat(explain,
+    assertThat(
+        explain,
         containsString("\"_source\":{\"includes\":[\"projects.name\",\"projects.started_year\"]"));
 
     JSONObject results = executeQuery(sql);
     Assert.assertThat(getTotalHits(results), equalTo(4));
   }
 
-  @Ignore("Comma join in left join won't pass syntax check in new ANTLR parser. "
-      + "Ignore for now and require to change grammar too when we want to support this case.")
+  @Ignore(
+      "Comma join in left join won't pass syntax check in new ANTLR parser. "
+          + "Ignore for now and require to change grammar too when we want to support this case.")
   @Test
   public void leftJoinExceptionOnExtraNestedFields() throws IOException {
-    String sql = "SELECT * " +
-        "FROM opensearch-sql_test_index_employee_nested e " +
-        "LEFT JOIN e.projects p, e.comments c";
+    String sql =
+        "SELECT * "
+            + "FROM opensearch-sql_test_index_employee_nested e "
+            + "LEFT JOIN e.projects p, e.comments c";
 
     try {
       String explain = explainQuery(sql);
       Assert.fail("Expected ResponseException, but none was thrown");
     } catch (ResponseException e) {
-      assertThat(e.getResponse().getStatusLine().getStatusCode(),
+      assertThat(
+          e.getResponse().getStatusLine().getStatusCode(),
           equalTo(RestStatus.BAD_REQUEST.getStatus()));
       final String entity = TestUtils.getResponseBody(e.getResponse());
-      assertThat(entity,
+      assertThat(
+          entity,
           containsString("only single nested field is allowed as right table for LEFT JOIN"));
       assertThat(entity, containsString("\"type\":\"verification_exception\""));
     }
   }
-
 
   @Test
   public void aggregationWithoutGroupBy() throws IOException {
@@ -317,7 +208,9 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "message.dayOfWeek@NESTED");
 
-    Assert.assertThat(((BigDecimal) aggregation.query("/avgDay/value")).doubleValue(), closeTo(3.166666666, 0.01));
+    Assert.assertThat(
+        ((BigDecimal) aggregation.query("/avgDay/value")).doubleValue(),
+        closeTo(3.166666666, 0.01));
   }
 
   @Test
@@ -351,39 +244,36 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     Assert.assertNotNull(msgInfoBuckets);
     Assert.assertThat(msgInfoBuckets.length(), equalTo(2));
     Assert.assertThat(msgInfoBuckets.query("/0/key"), equalTo("a"));
-    Assert.assertThat(((BigDecimal) msgInfoBuckets.query("/0/message.dayOfWeek@NESTED/sumDay/value")).doubleValue(),
+    Assert.assertThat(
+        ((BigDecimal) msgInfoBuckets.query("/0/message.dayOfWeek@NESTED/sumDay/value"))
+            .doubleValue(),
         closeTo(9.0, 0.01));
     Assert.assertThat(msgInfoBuckets.query("/1/key"), equalTo("b"));
-    Assert.assertThat(((BigDecimal) msgInfoBuckets.query("/1/message.dayOfWeek@NESTED/sumDay/value")).doubleValue(),
+    Assert.assertThat(
+        ((BigDecimal) msgInfoBuckets.query("/1/message.dayOfWeek@NESTED/sumDay/value"))
+            .doubleValue(),
         closeTo(10.0, 0.01));
   }
 
   @Test
   public void nestedFiledIsNotNull() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested as e, e.projects as p " +
-        "WHERE p IS NOT NULL";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested as e, e.projects as p "
+            + "WHERE p IS NOT NULL";
 
     assertThat(
         executeQuery(sql),
         hitAll(
             kvString("/_source/name", Is.is("Bob Smith")),
-            kvString("/_source/name", Is.is("Jane Smith"))
-        )
-    );
+            kvString("/_source/name", Is.is("Jane Smith"))));
   }
 
   // Doesn't support: aggregate function other than COUNT()
   @SuppressWarnings("unused")
   public void groupByNestedFieldAndAvg() throws IOException {
-    query(
-        "SELECT m.info, AVG(m.dayOfWeek)",
-        "GROUP BY m.info"
-    );
-    query(
-        "SELECT m.info, AVG(myNum)",
-        "GROUP BY m.info"
-    );
+    query("SELECT m.info, AVG(m.dayOfWeek)", "GROUP BY m.info");
+    query("SELECT m.info, AVG(myNum)", "GROUP BY m.info");
   }
 
   @Test
@@ -418,10 +308,11 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithoutWhere() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "GROUP BY e.name " +
-        "HAVING c > 1";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "GROUP BY e.name "
+            + "HAVING c > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -437,11 +328,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithWhereOnParent() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE e.name like '%smith%' " +
-        "GROUP BY e.name " +
-        "HAVING c > 1";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE e.name like '%smith%' "
+            + "GROUP BY e.name "
+            + "HAVING c > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -457,11 +349,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithWhereOnNested() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING c > 1";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING c > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -477,11 +370,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithWhereOnParentOrNested() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE e.name like '%smith%' or p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING c > 1";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE e.name like '%smith%' or p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING c > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -497,11 +391,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithWhereOnParentAndNested() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE e.name like '%smith%' AND p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING c > 1";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE e.name like '%smith%' AND p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING c > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -517,11 +412,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithWhereOnNestedAndNested() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.started_year > 2000 AND p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING c > 0";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.started_year > 2000 AND p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING c > 0";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -537,11 +433,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggWithWhereOnNestedOrNested() throws IOException {
-    String sql = "SELECT e.name, COUNT(p) as c " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.started_year > 2000 OR p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING c > 1";
+    String sql =
+        "SELECT e.name, COUNT(p) as c "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.started_year > 2000 OR p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING c > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -557,11 +454,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void countAggOnNestedInnerFieldWithoutWhere() throws IOException {
-    String sql = "SELECT e.name, COUNT(p.started_year) as count " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING count > 0";
+    String sql =
+        "SELECT e.name, COUNT(p.started_year) as count "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING count > 0";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -581,10 +479,11 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void maxAggOnNestedInnerFieldWithoutWhere() throws IOException {
-    String sql = "SELECT e.name, MAX(p.started_year) as max " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.name LIKE '%security%' " +
-        "GROUP BY e.name";
+    String sql =
+        "SELECT e.name, MAX(p.started_year) as max "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.name LIKE '%security%' "
+            + "GROUP BY e.name";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -594,20 +493,27 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     Assert.assertThat(bucket.length(), equalTo(2));
     Assert.assertThat(bucket.query("/0/key"), equalTo("Bob Smith"));
     Assert.assertThat(
-        ((BigDecimal) bucket.query("/0/projects.started_year@NESTED/projects.started_year@FILTER/max/value")).doubleValue(),
+        ((BigDecimal)
+                bucket.query(
+                    "/0/projects.started_year@NESTED/projects.started_year@FILTER/max/value"))
+            .doubleValue(),
         closeTo(2015.0, 0.01));
     Assert.assertThat(bucket.query("/1/key"), equalTo("Jane Smith"));
     Assert.assertThat(
-        ((BigDecimal) bucket.query("/1/projects.started_year@NESTED/projects.started_year@FILTER/max/value")).doubleValue(),
+        ((BigDecimal)
+                bucket.query(
+                    "/1/projects.started_year@NESTED/projects.started_year@FILTER/max/value"))
+            .doubleValue(),
         closeTo(2015.0, 0.01));
   }
 
   @Test
   public void havingCountAggWithoutWhere() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 1";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -623,11 +529,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggWithWhereOnParent() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE e.name like '%smith%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 1";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE e.name like '%smith%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -643,11 +550,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggWithWhereOnNested() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 1";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -663,11 +571,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggWithWhereOnParentOrNested() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE e.name like '%smith%' or p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 1";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE e.name like '%smith%' or p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -683,11 +592,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggWithWhereOnParentAndNested() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE e.name like '%smith%' AND p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 1";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE e.name like '%smith%' AND p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -703,11 +613,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggWithWhereOnNestedAndNested() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.started_year > 2000 AND p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 0";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.started_year > 2000 AND p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 0";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -723,11 +634,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggWithWhereOnNestedOrNested() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.started_year > 2000 OR p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p) > 1";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.started_year > 2000 OR p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p) > 1";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -743,11 +655,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingCountAggOnNestedInnerFieldWithoutWhere() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING COUNT(p.started_year) > 0";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING COUNT(p.started_year) > 0";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -767,11 +680,12 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
   @Test
   public void havingMaxAggOnNestedInnerFieldWithoutWhere() throws IOException {
-    String sql = "SELECT e.name " +
-        "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p " +
-        "WHERE p.name LIKE '%security%' " +
-        "GROUP BY e.name " +
-        "HAVING MAX(p.started_year) > 1990";
+    String sql =
+        "SELECT e.name "
+            + "FROM opensearch-sql_test_index_employee_nested AS e, e.projects AS p "
+            + "WHERE p.name LIKE '%security%' "
+            + "GROUP BY e.name "
+            + "HAVING MAX(p.started_year) > 1990";
 
     JSONObject result = executeQuery(sql);
     JSONObject aggregation = getAggregation(result, "name.keyword");
@@ -781,22 +695,28 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     Assert.assertThat(bucket.length(), equalTo(2));
     Assert.assertThat(bucket.query("/0/key"), equalTo("Bob Smith"));
     Assert.assertThat(
-        ((BigDecimal) bucket.query("/0/projects.started_year@NESTED/projects.started_year@FILTER/max_0/value")).doubleValue(),
+        ((BigDecimal)
+                bucket.query(
+                    "/0/projects.started_year@NESTED/projects.started_year@FILTER/max_0/value"))
+            .doubleValue(),
         closeTo(2015.0, 0.01));
     Assert.assertThat(bucket.query("/1/key"), equalTo("Jane Smith"));
     Assert.assertThat(
-        ((BigDecimal) bucket.query("/1/projects.started_year@NESTED/projects.started_year@FILTER/max_0/value")).doubleValue(),
+        ((BigDecimal)
+                bucket.query(
+                    "/1/projects.started_year@NESTED/projects.started_year@FILTER/max_0/value"))
+            .doubleValue(),
         closeTo(2015.0, 0.01));
   }
 
   /***********************************************************
-   Matchers for Non-Aggregation Testing
+   * Matchers for Non-Aggregation Testing
    ***********************************************************/
 
   @SafeVarargs
   private final Matcher<SearchResponse> hits(Matcher<SearchHit>... subMatchers) {
-    return featureValueOf("hits", arrayContainingInAnyOrder(subMatchers),
-        resp -> resp.getHits().getHits());
+    return featureValueOf(
+        "hits", arrayContainingInAnyOrder(subMatchers), resp -> resp.getHits().getHits());
   }
 
   @SafeVarargs
@@ -834,8 +754,7 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
       }
 
       @Override
-      public void describeTo(Description description) {
-      }
+      public void describeTo(Description description) {}
     };
   }
 
@@ -860,16 +779,15 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     return featureValueOf(
         "innerHits",
         arrayContainingInAnyOrder(innerHitMatchers),
-        hit -> hit.getInnerHits().get(path).getHits()
-    );
+        hit -> hit.getInnerHits().get(path).getHits());
   }
 
   /***********************************************************
-   Matchers for Aggregation Testing
+   * Matchers for Aggregation Testing
    ***********************************************************/
 
-  private <T, U> FeatureMatcher<T, U> featureValueOf(String name, Matcher<U> subMatcher,
-                                                     Function<T, U> getter) {
+  private <T, U> FeatureMatcher<T, U> featureValueOf(
+      String name, Matcher<U> subMatcher, Function<T, U> getter) {
     return new FeatureMatcher<T, U>(subMatcher, name, name) {
       @Override
       protected U featureValueOf(T actual) {
@@ -879,7 +797,7 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
   }
 
   /***********************************************************
-   Query Utility to Fetch Response for SQL
+   * Query Utility to Fetch Response for SQL
    ***********************************************************/
 
   private SearchResponse query(String select, String... statements) throws IOException {
@@ -889,10 +807,11 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
   private SearchResponse execute(String sql) throws IOException {
     final JSONObject jsonObject = executeQuery(sql);
 
-    final XContentParser parser = new JsonXContentParser(
-        NamedXContentRegistry.EMPTY,
-        LoggingDeprecationHandler.INSTANCE,
-        new JsonFactory().createParser(jsonObject.toString()));
+    final XContentParser parser =
+        new JsonXContentParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            new JsonFactory().createParser(jsonObject.toString()));
     return SearchResponse.fromXContent(parser);
   }
 
@@ -904,5 +823,4 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
     Assert.assertTrue(aggregations.has(aggregationName));
     return aggregations.getJSONObject(aggregationName);
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/ObjectFieldSelectIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/ObjectFieldSelectIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DEEP_NESTED;
@@ -18,9 +17,8 @@ import org.junit.Test;
 import org.opensearch.sql.legacy.utils.StringUtils;
 
 /**
- * Integration test for OpenSearch object field (and nested field).
- * This class is focused on simple SELECT-FROM query to ensure right column
- * number and value is returned.
+ * Integration test for OpenSearch object field (and nested field). This class is focused on simple
+ * SELECT-FROM query to ensure right column number and value is returned.
  */
 public class ObjectFieldSelectIT extends SQLIntegTestCase {
 
@@ -36,33 +34,28 @@ public class ObjectFieldSelectIT extends SQLIntegTestCase {
     verifySchema(response, schema("city", null, "object"));
 
     // Expect object field itself is returned in a single cell
-    verifyDataRows(response,
-        rows(new JSONObject(
-            "{\n"
-                + "  \"name\": \"Seattle\",\n"
-                + "  \"location\": {\"latitude\": 10.5}\n"
-                + "}")
-        )
-    );
+    verifyDataRows(
+        response,
+        rows(
+            new JSONObject(
+                "{\n"
+                    + "  \"name\": \"Seattle\",\n"
+                    + "  \"location\": {\"latitude\": 10.5}\n"
+                    + "}")));
   }
 
   @Test
   public void testSelectObjectInnerFields() {
-    JSONObject response = new JSONObject(query(
-        "SELECT city.location, city.location.latitude FROM %s"));
+    JSONObject response =
+        new JSONObject(query("SELECT city.location, city.location.latitude FROM %s"));
 
-    verifySchema(response,
+    verifySchema(
+        response,
         schema("city.location", null, "object"),
-        schema("city.location.latitude", null, "double")
-    );
+        schema("city.location.latitude", null, "double"));
 
     // Expect inner regular or object field returned in its single cell
-    verifyDataRows(response,
-        rows(
-            new JSONObject("{\"latitude\": 10.5}"),
-            10.5
-        )
-    );
+    verifyDataRows(response, rows(new JSONObject("{\"latitude\": 10.5}"), 10.5));
   }
 
   @Test
@@ -72,15 +65,15 @@ public class ObjectFieldSelectIT extends SQLIntegTestCase {
     verifySchema(response, schema("projects", null, "nested"));
 
     // Expect nested field itself is returned in a single cell
-    verifyDataRows(response,
-        rows(new JSONArray(
-            "[\n"
-                + "  {\"name\": \"AWS Redshift Spectrum querying\"},\n"
-                + "  {\"name\": \"AWS Redshift security\"},\n"
-                + "  {\"name\": \"AWS Aurora security\"}\n"
-                + "]")
-        )
-    );
+    verifyDataRows(
+        response,
+        rows(
+            new JSONArray(
+                "[\n"
+                    + "  {\"name\": \"AWS Redshift Spectrum querying\"},\n"
+                    + "  {\"name\": \"AWS Redshift security\"},\n"
+                    + "  {\"name\": \"AWS Aurora security\"}\n"
+                    + "]")));
   }
 
   @Test
@@ -100,10 +93,6 @@ public class ObjectFieldSelectIT extends SQLIntegTestCase {
   }
 
   private String query(String sql) {
-    return executeQuery(
-        StringUtils.format(sql, TEST_INDEX_DEEP_NESTED),
-        "jdbc"
-    );
+    return executeQuery(StringUtils.format(sql, TEST_INDEX_DEEP_NESTED), "jdbc");
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static java.util.Collections.unmodifiableList;
@@ -43,8 +42,9 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 /**
- * OpenSearch SQL integration test base class to support both security disabled and enabled OpenSearch cluster.
- * Allows interaction with multiple external test clusters using OpenSearch's {@link RestClient}.
+ * OpenSearch SQL integration test base class to support both security disabled and enabled
+ * OpenSearch cluster. Allows interaction with multiple external test clusters using OpenSearch's
+ * {@link RestClient}.
  */
 public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
 
@@ -53,17 +53,20 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
   public static final String MATCH_ALL_REMOTE_CLUSTER = "*";
 
   private static RestClient remoteClient;
+
   /**
-   * A client for the running remote OpenSearch cluster configured to take test administrative actions
-   * like remove all indexes after the test completes
+   * A client for the running remote OpenSearch cluster configured to take test administrative
+   * actions like remove all indexes after the test completes
    */
   private static RestClient remoteAdminClient;
 
   protected boolean isHttps() {
-    boolean isHttps = Optional.ofNullable(System.getProperty("https"))
-        .map("true"::equalsIgnoreCase).orElse(false);
+    boolean isHttps =
+        Optional.ofNullable(System.getProperty("https"))
+            .map("true"::equalsIgnoreCase)
+            .orElse(false);
     if (isHttps) {
-      //currently only external cluster is supported for security enabled testing
+      // currently only external cluster is supported for security enabled testing
       if (!Optional.ofNullable(System.getProperty("tests.rest.cluster")).isPresent()) {
         throw new RuntimeException(
             "external cluster url should be provided for security enabled testing");
@@ -77,16 +80,14 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
     return isHttps() ? "https" : "http";
   }
 
-  /**
-   * Get the client to remote cluster used for ordinary api calls while writing a test.
-   */
+  /** Get the client to remote cluster used for ordinary api calls while writing a test. */
   protected static RestClient remoteClient() {
     return remoteClient;
   }
 
   /**
-   * Get the client to remote cluster used for test administrative actions.
-   * Do not use this while writing a test. Only use it for cleaning up after tests.
+   * Get the client to remote cluster used for test administrative actions. Do not use this while
+   * writing a test. Only use it for cleaning up after tests.
    */
   protected static RestClient remoteAdminClient() {
     return remoteAdminClient;
@@ -128,9 +129,7 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
     assert remoteAdminClient != null;
   }
 
-  /**
-   * Get a comma delimited list of [host:port] to which to send REST requests.
-   */
+  /** Get a comma delimited list of [host:port] to which to send REST requests. */
   protected String getTestRestCluster(String clusterName) {
     String cluster = System.getProperty("tests.rest." + clusterName + ".http_hosts");
     if (cluster == null) {
@@ -138,15 +137,12 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
           "Must specify [tests.rest."
               + clusterName
               + ".http_hosts] system property with a comma delimited list of [host:port] "
-              + "to which to send REST requests"
-      );
+              + "to which to send REST requests");
     }
     return cluster;
   }
 
-  /**
-   * Get a comma delimited list of [host:port] for connections between clusters.
-   */
+  /** Get a comma delimited list of [host:port] for connections between clusters. */
   protected String getTestTransportCluster(String clusterName) {
     String cluster = System.getProperty("tests.rest." + clusterName + ".transport_hosts");
     if (cluster == null) {
@@ -154,8 +150,7 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
           "Must specify [tests.rest."
               + clusterName
               + ".transport_hosts] system property with a comma delimited list of [host:port] "
-              + "for connections between clusters"
-      );
+              + "for connections between clusters");
     }
     return cluster;
   }
@@ -181,18 +176,22 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
     // include all the indices, included hidden indices.
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html#cat-indices-api-query-params
     try {
-      Response response = client.performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
+      Response response =
+          client.performRequest(
+              new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
       JSONArray jsonArray = new JSONArray(EntityUtils.toString(response.getEntity(), "UTF-8"));
       for (Object object : jsonArray) {
         JSONObject jsonObject = (JSONObject) object;
         String indexName = jsonObject.getString("index");
         try {
-          // System index, mostly named .opensearch-xxx or .opendistro-xxx, are not allowed to delete
+          // System index, mostly named .opensearch-xxx or .opendistro-xxx, are not allowed to
+          // delete
           if (!indexName.startsWith(".opensearch") && !indexName.startsWith(".opendistro")) {
             client.performRequest(new Request("DELETE", "/" + indexName));
           }
         } catch (Exception e) {
-          // TODO: Ignore index delete error for now. Remove this if strict check on system index added above.
+          // TODO: Ignore index delete error for now. Remove this if strict check on system index
+          // added above.
           LOG.warn("Failed to delete index: " + indexName, e);
         }
       }
@@ -201,9 +200,8 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
     }
   }
 
-  protected static void configureHttpsClient(RestClientBuilder builder, Settings settings,
-                                             HttpHost httpHost)
-      throws IOException {
+  protected static void configureHttpsClient(
+      RestClientBuilder builder, Settings settings, HttpHost httpHost) throws IOException {
     Map<String, String> headers = ThreadContext.buildDefaultHeaders(settings);
     Header[] defaultHeaders = new Header[headers.size()];
     int i = 0;
@@ -211,56 +209,66 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
       defaultHeaders[i++] = new BasicHeader(entry.getKey(), entry.getValue());
     }
     builder.setDefaultHeaders(defaultHeaders);
-    builder.setHttpClientConfigCallback(httpClientBuilder -> {
-      String userName = Optional.ofNullable(System.getProperty("user"))
-          .orElseThrow(() -> new RuntimeException("user name is missing"));
-      String password = Optional.ofNullable(System.getProperty("password"))
-          .orElseThrow(() -> new RuntimeException("password is missing"));
-      BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-      credentialsProvider
-          .setCredentials(new AuthScope(httpHost), new UsernamePasswordCredentials(userName,
-              password.toCharArray()));
-      try {
-        final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-            .setSslContext(SSLContextBuilder.create()
-                .loadTrustMaterial(null, (chains, authType) -> true)
-                .build())
-            .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-            .build();
+    builder.setHttpClientConfigCallback(
+        httpClientBuilder -> {
+          String userName =
+              Optional.ofNullable(System.getProperty("user"))
+                  .orElseThrow(() -> new RuntimeException("user name is missing"));
+          String password =
+              Optional.ofNullable(System.getProperty("password"))
+                  .orElseThrow(() -> new RuntimeException("password is missing"));
+          BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+          credentialsProvider.setCredentials(
+              new AuthScope(httpHost),
+              new UsernamePasswordCredentials(userName, password.toCharArray()));
+          try {
+            final TlsStrategy tlsStrategy =
+                ClientTlsStrategyBuilder.create()
+                    .setSslContext(
+                        SSLContextBuilder.create()
+                            .loadTrustMaterial(null, (chains, authType) -> true)
+                            .build())
+                    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    .build();
 
-        return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
-            .setConnectionManager(PoolingAsyncClientConnectionManagerBuilder.create()
-                .setTlsStrategy(tlsStrategy)
-                .build());
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+            return httpClientBuilder
+                .setDefaultCredentialsProvider(credentialsProvider)
+                .setConnectionManager(
+                    PoolingAsyncClientConnectionManagerBuilder.create()
+                        .setTlsStrategy(tlsStrategy)
+                        .build());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
 
     final String socketTimeoutString = settings.get(CLIENT_SOCKET_TIMEOUT);
     final TimeValue socketTimeout =
-        TimeValue.parseTimeValue(socketTimeoutString == null ? "60s" : socketTimeoutString,
-            CLIENT_SOCKET_TIMEOUT);
+        TimeValue.parseTimeValue(
+            socketTimeoutString == null ? "60s" : socketTimeoutString, CLIENT_SOCKET_TIMEOUT);
     builder.setRequestConfigCallback(
-        conf -> conf.setResponseTimeout(Timeout.ofMilliseconds(Math.toIntExact(socketTimeout.getMillis()))));
+        conf ->
+            conf.setResponseTimeout(
+                Timeout.ofMilliseconds(Math.toIntExact(socketTimeout.getMillis()))));
     if (settings.hasValue(CLIENT_PATH_PREFIX)) {
       builder.setPathPrefix(settings.get(CLIENT_PATH_PREFIX));
     }
   }
 
   /**
-   * Initialize rest client to remote cluster,
-   * and create a connection to it from the coordinating cluster.
+   * Initialize rest client to remote cluster, and create a connection to it from the coordinating
+   * cluster.
    */
   public void configureMultiClusters() throws IOException {
     initRemoteClient();
 
     Request connectionRequest = new Request("PUT", "_cluster/settings");
-    String connectionSetting = "{\"persistent\": {\"cluster\": {\"remote\": {\""
-        + REMOTE_CLUSTER
-        + "\": {\"seeds\": [\""
-        + getTestTransportCluster(REMOTE_CLUSTER).split(",")[0]
-        + "\"]}}}}}";
+    String connectionSetting =
+        "{\"persistent\": {\"cluster\": {\"remote\": {\""
+            + REMOTE_CLUSTER
+            + "\": {\"seeds\": [\""
+            + getTestTransportCluster(REMOTE_CLUSTER).split(",")[0]
+            + "\"]}}}}}";
     connectionRequest.setJsonEntity(connectionSetting);
     adminClient().performRequest(connectionRequest);
   }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OrderIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OrderIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -76,17 +75,17 @@ public class OrderIT extends SQLIntegTestCase {
     assertThat(query(hits, "/0/_source/id"), equalTo("5"));
 
     // Another equivalent syntax
-    assertThat(explainQuery("SELECT * FROM opensearch-sql_test_index_order " +
-            "ORDER BY id IS NULL, id DESC"),
-        equalTo(explainQuery("SELECT * FROM opensearch-sql_test_index_order " +
-            "ORDER BY id IS NULL DESC"))
-    );
+    assertThat(
+        explainQuery(
+            "SELECT * FROM opensearch-sql_test_index_order " + "ORDER BY id IS NULL, id DESC"),
+        equalTo(
+            explainQuery(
+                "SELECT * FROM opensearch-sql_test_index_order " + "ORDER BY id IS NULL DESC")));
   }
 
   @Test
   public void orderByIsNotNull() throws IOException {
-    String query =
-        "SELECT id, name FROM opensearch-sql_test_index_order ORDER BY name IS NOT NULL";
+    String query = "SELECT id, name FROM opensearch-sql_test_index_order ORDER BY name IS NOT NULL";
     JSONArray result = getSortExplain(query);
     assertThat(1, equalTo(result.length()));
     assertThat(query(result, "/0/name.keyword/order"), equalTo("asc"));
@@ -95,21 +94,24 @@ public class OrderIT extends SQLIntegTestCase {
     JSONObject response = executeQuery(query);
     JSONArray hits = getHits(response);
     assertFalse(hits.getJSONObject(0).getJSONObject("_source").has("name"));
-    assertThat(hits.getJSONObject(hits.length() - 1).query("/_source/name").toString(),
-        equalTo("f"));
+    assertThat(
+        hits.getJSONObject(hits.length() - 1).query("/_source/name").toString(), equalTo("f"));
 
     // Another equivalent syntax
-    assertThat(explainQuery("SELECT id, name FROM opensearch-sql_test_index_order " +
-            "ORDER BY name IS NOT NULL"),
-        equalTo(explainQuery("SELECT id, name FROM opensearch-sql_test_index_order " +
-            "ORDER BY name IS NOT NULL ASC"))
-    );
+    assertThat(
+        explainQuery(
+            "SELECT id, name FROM opensearch-sql_test_index_order " + "ORDER BY name IS NOT NULL"),
+        equalTo(
+            explainQuery(
+                "SELECT id, name FROM opensearch-sql_test_index_order "
+                    + "ORDER BY name IS NOT NULL ASC")));
   }
 
   @Test
   public void multipleOrderByWithNulls() throws IOException {
     String query =
-        "SELECT id, name FROM opensearch-sql_test_index_order ORDER BY id IS NULL, name IS NOT NULL";
+        "SELECT id, name FROM opensearch-sql_test_index_order ORDER BY id IS NULL, name IS NOT"
+            + " NULL";
     JSONArray result = getSortExplain(query);
     assertThat(result.length(), equalTo(2));
     assertThat(query(result, "/0/id/missing"), equalTo("_last"));
@@ -118,8 +120,9 @@ public class OrderIT extends SQLIntegTestCase {
 
   @Test
   public void testOrderByMergeForSameField() throws IOException {
-    String query = "SELECT * FROM opensearch-sql_test_index_order " +
-        "ORDER BY id IS NULL, name DESC, id DESC, id IS NOT NULL, name IS NULL";
+    String query =
+        "SELECT * FROM opensearch-sql_test_index_order "
+            + "ORDER BY id IS NULL, name DESC, id DESC, id IS NOT NULL, name IS NULL";
     JSONArray result = getSortExplain(query);
     assertThat(2, equalTo(result.length()));
     assertThat(query(result, "/0/id/order"), equalTo("asc"));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OrdinalAliasRewriterIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OrdinalAliasRewriterIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -23,125 +22,191 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
   // tests query results with jdbc output
   @Test
   public void simpleGroupByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT lastname FROM %s AS b GROUP BY lastname LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT lastname FROM %s AS b GROUP BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT),
-        "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname FROM %s AS b GROUP BY lastname LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname FROM %s AS b GROUP BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void multipleGroupByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT lastname, firstname, age FROM %s AS b GROUP BY firstname, age, lastname LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT lastname, firstname, age FROM %s AS b GROUP BY 2, 3, 1 LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname, firstname, age FROM %s AS b GROUP BY firstname, age, lastname"
+                    + " LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname, firstname, age FROM %s AS b GROUP BY 2, 3, 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void selectFieldiWithBacticksGroupByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT `lastname` FROM %s AS b GROUP BY `lastname` LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT `lastname` FROM %s AS b GROUP BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT),
-        "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `lastname` FROM %s AS b GROUP BY `lastname` LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `lastname` FROM %s AS b GROUP BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void selectFieldiWithBacticksAndTableAliasGroupByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT `b`.`lastname`, `age`, firstname FROM %s AS b GROUP BY `age`, `b`.`lastname` , firstname LIMIT 10",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT `b`.`lastname`, `age`, firstname  FROM %s AS b GROUP BY 2, 1, 3 LIMIT 10",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname`, `age`, firstname FROM %s AS b GROUP BY `age`,"
+                    + " `b`.`lastname` , firstname LIMIT 10",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname`, `age`, firstname  FROM %s AS b GROUP BY 2, 1, 3 LIMIT 10",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void simpleOrderByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT lastname FROM %s AS b ORDER BY lastname LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT lastname FROM %s AS b ORDER BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT),
-        "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname FROM %s AS b ORDER BY lastname LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname FROM %s AS b ORDER BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void multipleOrderByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT lastname, firstname, age FROM %s AS b ORDER BY firstname, age, lastname LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT lastname, firstname, age FROM %s AS b ORDER BY 2, 3, 1 LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname, firstname, age FROM %s AS b ORDER BY firstname, age, lastname"
+                    + " LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT lastname, firstname, age FROM %s AS b ORDER BY 2, 3, 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void selectFieldiWithBacticksOrderByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT `lastname` FROM %s AS b ORDER BY `lastname` LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT `lastname` FROM %s AS b ORDER BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT),
-        "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `lastname` FROM %s AS b ORDER BY `lastname` LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void selectFieldiWithBacticksAndTableAliasOrderByOrdinal() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT `b`.`lastname` FROM %s AS b ORDER BY `b`.`lastname` LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT `b`.`lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s AS b ORDER BY `b`.`lastname` LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
 
   // ORDER BY IS NULL/NOT NULL
   @Test
   public void selectFieldiWithBacticksAndTableAliasOrderByOrdinalAndNull() {
-    String expected = executeQuery(StringUtils.format(
-        "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC, age is NULL LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    String actual = executeQuery(StringUtils.format(
-        "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC,"
+                    + " age is NULL LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
+    String actual =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL"
+                    + " LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT),
+            "jdbc");
     assertThat(actual, equalTo(expected));
   }
-
 
   // explain
   @Test
   public void explainSelectFieldiWithBacticksAndTableAliasGroupByOrdinal() throws IOException {
-    String expected = explainQuery(StringUtils.format(
-        "SELECT `b`.`lastname` FROM %s AS b GROUP BY `b`.`lastname` LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT));
-    String actual = explainQuery(StringUtils.format(
-        "SELECT `b`.`lastname` FROM %s AS b GROUP BY 1 LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT));
+    String expected =
+        explainQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s AS b GROUP BY `b`.`lastname` LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT));
+    String actual =
+        explainQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s AS b GROUP BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT));
     assertThat(actual, equalTo(expected));
   }
 
   @Test
   public void explainSelectFieldiWithBacticksAndTableAliasOrderByOrdinal() throws IOException {
-    String expected = explainQuery(StringUtils.format(
-        "SELECT `b`.`lastname` FROM %s AS b ORDER BY `b`.`lastname` LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT));
-    String actual = explainQuery(StringUtils.format(
-        "SELECT `b`.`lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT));
+    String expected =
+        explainQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s AS b ORDER BY `b`.`lastname` LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT));
+    String actual =
+        explainQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT));
     assertThat(actual, equalTo(expected));
   }
 
@@ -149,12 +214,18 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
   @Ignore("only work for legacy engine")
   public void explainSelectFieldiWithBacticksAndTableAliasOrderByOrdinalAndNull()
       throws IOException {
-    String expected = explainQuery(StringUtils.format(
-        "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC, age is NULL LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT));
-    String actual = explainQuery(StringUtils.format(
-        "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL LIMIT 3",
-        TestsConstants.TEST_INDEX_ACCOUNT));
+    String expected =
+        explainQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC,"
+                    + " age is NULL LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT));
+    String actual =
+        explainQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL"
+                    + " LIMIT 3",
+                TestsConstants.TEST_INDEX_ACCOUNT));
     assertThat(actual, equalTo(expected));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -33,8 +32,9 @@ public class PluginIT extends SQLIntegTestCase {
   public void sqlEnableSettingsTest() throws IOException {
     loadIndex(Index.ACCOUNT);
     updateClusterSettings(new ClusterSetting(PERSISTENT, "plugins.sql.enabled", "true"));
-    String query = String
-        .format(Locale.ROOT, "SELECT firstname FROM %s WHERE account_number=1", TEST_INDEX_ACCOUNT);
+    String query =
+        String.format(
+            Locale.ROOT, "SELECT firstname FROM %s WHERE account_number=1", TEST_INDEX_ACCOUNT);
     JSONObject queryResult = executeQuery(query);
     assertThat(getHits(queryResult).length(), equalTo(1));
 
@@ -50,16 +50,19 @@ public class PluginIT extends SQLIntegTestCase {
     assertThat(queryResult.getInt("status"), equalTo(400));
     JSONObject error = queryResult.getJSONObject("error");
     assertThat(error.getString("reason"), equalTo("Invalid SQL query"));
-    assertThat(error.getString("details"), equalTo(
-        "Either plugins.sql.enabled or rest.action.multi.allow_explicit_index setting is false"));
+    assertThat(
+        error.getString("details"),
+        equalTo(
+            "Either plugins.sql.enabled or rest.action.multi.allow_explicit_index setting is"
+                + " false"));
     assertThat(error.getString("type"), equalTo("SQLFeatureDisabledException"));
     wipeAllClusterSettings();
   }
 
   @Test
   public void sqlDeleteSettingsTest() throws IOException {
-    updateClusterSettings(new ClusterSetting(PERSISTENT,
-        Settings.Key.SQL_DELETE_ENABLED.getKeyValue(), "false"));
+    updateClusterSettings(
+        new ClusterSetting(PERSISTENT, Settings.Key.SQL_DELETE_ENABLED.getKeyValue(), "false"));
 
     String deleteQuery = StringUtils.format("DELETE FROM %s", TestsConstants.TEST_INDEX_ACCOUNT);
     final ResponseException exception =
@@ -70,8 +73,8 @@ public class PluginIT extends SQLIntegTestCase {
             "{\n"
                 + "  \"error\": {\n"
                 + "    \"reason\": \"Invalid SQL query\",\n"
-                + "    \"details\": \"DELETE clause is disabled by default and will be deprecated. Using "
-                + "the plugins.sql.delete.enabled setting to enable it\",\n"
+                + "    \"details\": \"DELETE clause is disabled by default and will be deprecated."
+                + " Using the plugins.sql.delete.enabled setting to enable it\",\n"
                 + "    \"type\": \"SQLFeatureDisabledException\"\n"
                 + "  },\n"
                 + "  \"status\": 400\n"
@@ -84,329 +87,355 @@ public class PluginIT extends SQLIntegTestCase {
   @Test
   public void sqlTransientOnlySettingTest() throws IOException {
     // (1) compact form
-    String settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins.query.metrics.rolling_interval\": \"80\"" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins.query.metrics.rolling_interval\": \"80\""
+            + "  }"
+            + "}";
     JSONObject actual = updateViaSQLSettingsAPI(settings);
-    JSONObject expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : { }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_interval\" : \"80\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    JSONObject expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : { },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_interval\" : \"80\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
 
     // (2) partial expanded form
-    settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics.rolling_interval\": \"75\"" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}";
+    settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins\" : {"
+            + "      \"query\" : {"
+            + "        \"metrics.rolling_interval\": \"75\""
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
     actual = updateViaSQLSettingsAPI(settings);
-    expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : { }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_interval\" : \"75\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : { },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_interval\" : \"75\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
 
-
     // (3) full expanded form
-    settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\": {" +
-        "          \"rolling_interval\": \"65\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}";
+    settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins\" : {"
+            + "      \"query\" : {"
+            + "        \"metrics\": {"
+            + "          \"rolling_interval\": \"65\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
     actual = updateViaSQLSettingsAPI(settings);
-    expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : { }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_interval\" : \"65\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : { },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_interval\" : \"65\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
   }
 
   @Test
   public void sqlPersistentOnlySettingTest() throws IOException {
     // (1) compact form
-    String settings = "{" +
-        "  \"persistent\": {" +
-        "    \"plugins.query.metrics.rolling_interval\": \"80\"" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"persistent\": {"
+            + "    \"plugins.query.metrics.rolling_interval\": \"80\""
+            + "  }"
+            + "}";
     JSONObject actual = updateViaSQLSettingsAPI(settings);
-    JSONObject expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"transient\" : { }," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_interval\" : \"80\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    JSONObject expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"transient\" : { },"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_interval\" : \"80\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
 
     // (2) partial expanded form
-    settings = "{" +
-        "  \"persistent\": {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics.rolling_interval\": \"75\"" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}";
+    settings =
+        "{"
+            + "  \"persistent\": {"
+            + "    \"plugins\" : {"
+            + "      \"query\" : {"
+            + "        \"metrics.rolling_interval\": \"75\""
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
     actual = updateViaSQLSettingsAPI(settings);
-    expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"transient\" : { }," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_interval\" : \"75\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"transient\" : { },"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_interval\" : \"75\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
 
-
     // (3) full expanded form
-    settings = "{" +
-        "  \"persistent\": {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\": {" +
-        "          \"rolling_interval\": \"65\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}";
+    settings =
+        "{"
+            + "  \"persistent\": {"
+            + "    \"plugins\" : {"
+            + "      \"query\" : {"
+            + "        \"metrics\": {"
+            + "          \"rolling_interval\": \"65\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
     actual = updateViaSQLSettingsAPI(settings);
-    expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"transient\" : { }," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_interval\" : \"65\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"transient\" : { },"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_interval\" : \"65\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
   }
 
   /**
-   * Both transient and persistent settings are applied for same settings.
-   * This is similar to _cluster/settings behavior
+   * Both transient and persistent settings are applied for same settings. This is similar to
+   * _cluster/settings behavior
    */
   @Test
   public void sqlCombinedSettingTest() throws IOException {
-    String settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins.query.metrics.rolling_window\": \"3700\"" +
-        "  }," +
-        "  \"persistent\": {" +
-        "    \"plugins.sql.slowlog\" : \"2\"" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins.query.metrics.rolling_window\": \"3700\""
+            + "  },"
+            + "  \"persistent\": {"
+            + "    \"plugins.sql.slowlog\" : \"2\""
+            + "  }"
+            + "}";
     JSONObject actual = updateViaSQLSettingsAPI(settings);
-    JSONObject expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"sql\" : {" +
-        "        \"slowlog\" : \"2\"" +
-        "      }" +
-        "    }" +
-        "  }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_window\" : \"3700\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    JSONObject expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"sql\" : {"
+                + "        \"slowlog\" : \"2\""
+                + "      }"
+                + "    }"
+                + "  },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_window\" : \"3700\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
   }
 
-  /**
-   * Ignore all non plugins.sql settings.
-   * Only settings starting with plugins.sql. are affected
-   */
+  /** Ignore all non plugins.sql settings. Only settings starting with plugins.sql. are affected */
   @Test
   public void ignoreNonSQLSettingsTest() throws IOException {
-    String settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins.query.metrics.rolling_window\": \"3700\"," +
-        "    \"plugins.alerting.metrics.rolling_window\": \"3700\"," +
-        "    \"search.max_buckets\": \"10000\"," +
-        "    \"search.max_keep_alive\": \"24h\"" +
-        "  }," +
-        "  \"persistent\": {" +
-        "    \"plugins.sql.slowlog\": \"2\"," +
-        "    \"plugins.alerting.metrics.rolling_window\": \"3700\"," +
-        "    \"thread_pool.analyze.queue_size\": \"16\"" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins.query.metrics.rolling_window\": \"3700\","
+            + "    \"plugins.alerting.metrics.rolling_window\": \"3700\","
+            + "    \"search.max_buckets\": \"10000\","
+            + "    \"search.max_keep_alive\": \"24h\""
+            + "  },"
+            + "  \"persistent\": {"
+            + "    \"plugins.sql.slowlog\": \"2\","
+            + "    \"plugins.alerting.metrics.rolling_window\": \"3700\","
+            + "    \"thread_pool.analyze.queue_size\": \"16\""
+            + "  }"
+            + "}";
     JSONObject actual = updateViaSQLSettingsAPI(settings);
-    JSONObject expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"sql\" : {" +
-        "        \"slowlog\" : \"2\"" +
-        "      }" +
-        "    }" +
-        "  }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_window\" : \"3700\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    JSONObject expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"sql\" : {"
+                + "        \"slowlog\" : \"2\""
+                + "      }"
+                + "    }"
+                + "  },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_window\" : \"3700\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
   }
 
   @Test
   public void ignoreNonTransientNonPersistentSettingsTest() throws IOException {
-    String settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins.query.metrics.rolling_window\": \"3700\"" +
-        "  }," +
-        "  \"persistent\": {" +
-        "    \"plugins.sql.slowlog\": \"2\"" +
-        "  }," +
-        "  \"hello\": {" +
-        "    \"world\" : {" +
-        "      \"name\" : \"John Doe\"" +
-        "    }" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins.query.metrics.rolling_window\": \"3700\""
+            + "  },"
+            + "  \"persistent\": {"
+            + "    \"plugins.sql.slowlog\": \"2\""
+            + "  },"
+            + "  \"hello\": {"
+            + "    \"world\" : {"
+            + "      \"name\" : \"John Doe\""
+            + "    }"
+            + "  }"
+            + "}";
     JSONObject actual = updateViaSQLSettingsAPI(settings);
-    JSONObject expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"sql\" : {" +
-        "        \"slowlog\" : \"2\"" +
-        "      }" +
-        "    }" +
-        "  }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_window\" : \"3700\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    JSONObject expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"sql\" : {"
+                + "        \"slowlog\" : \"2\""
+                + "      }"
+                + "    }"
+                + "  },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_window\" : \"3700\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
   }
 
   @Test
   public void sqlCombinedMixedSettingTest() throws IOException {
-    String settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins.query.metrics.rolling_window\": \"3700\"" +
-        "  }," +
-        "  \"persistent\": {" +
-        "    \"plugins\": {" +
-        "      \"sql\": {" +
-        "        \"slowlog\": \"1\"" +
-        "      }" +
-        "    }" +
-        "  }," +
-        "  \"hello\": {" +
-        "    \"world\": {" +
-        "      \"city\": \"Seattle\"" +
-        "    }" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins.query.metrics.rolling_window\": \"3700\""
+            + "  },"
+            + "  \"persistent\": {"
+            + "    \"plugins\": {"
+            + "      \"sql\": {"
+            + "        \"slowlog\": \"1\""
+            + "      }"
+            + "    }"
+            + "  },"
+            + "  \"hello\": {"
+            + "    \"world\": {"
+            + "      \"city\": \"Seattle\""
+            + "    }"
+            + "  }"
+            + "}";
     JSONObject actual = updateViaSQLSettingsAPI(settings);
-    JSONObject expected = new JSONObject("{" +
-        "  \"acknowledged\" : true," +
-        "  \"persistent\" : {" +
-        "    \"plugins\" : {" +
-        "      \"sql\" : {" +
-        "        \"slowlog\" : \"1\"" +
-        "      }" +
-        "    }" +
-        "  }," +
-        "  \"transient\" : {" +
-        "    \"plugins\" : {" +
-        "      \"query\" : {" +
-        "        \"metrics\" : {" +
-        "          \"rolling_window\" : \"3700\"" +
-        "        }" +
-        "      }" +
-        "    }" +
-        "  }" +
-        "}");
+    JSONObject expected =
+        new JSONObject(
+            "{"
+                + "  \"acknowledged\" : true,"
+                + "  \"persistent\" : {"
+                + "    \"plugins\" : {"
+                + "      \"sql\" : {"
+                + "        \"slowlog\" : \"1\""
+                + "      }"
+                + "    }"
+                + "  },"
+                + "  \"transient\" : {"
+                + "    \"plugins\" : {"
+                + "      \"query\" : {"
+                + "        \"metrics\" : {"
+                + "          \"rolling_window\" : \"3700\""
+                + "        }"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
     assertTrue(actual.similar(expected));
   }
 
   @Test
   public void nonRegisteredSQLSettingsThrowException() throws IOException {
-    String settings = "{" +
-        "  \"transient\": {" +
-        "    \"plugins.sql.query.state.city\": \"Seattle\"" +
-        "  }" +
-        "}";
+    String settings =
+        "{"
+            + "  \"transient\": {"
+            + "    \"plugins.sql.query.state.city\": \"Seattle\""
+            + "  }"
+            + "}";
 
     JSONObject actual;
     Response response = null;
@@ -421,8 +450,7 @@ public class PluginIT extends SQLIntegTestCase {
     assertThat(actual.query("/error/type"), equalTo("settings_exception"));
     assertThat(
         actual.query("/error/reason"),
-        equalTo("transient setting [plugins.sql.query.state.city], not recognized")
-    );
+        equalTo("transient setting [plugins.sql.query.state.city], not recognized"));
   }
 
   protected static JSONObject updateViaSQLSettingsAPI(String body) throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PreparedStatementIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PreparedStatementIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import java.io.IOException;
@@ -25,27 +24,34 @@ public class PreparedStatementIT extends SQLIntegTestCase {
   public void testPreparedStatement() throws IOException {
     int ageToCompare = 35;
 
-    JSONObject response = executeRequest(String.format("{\n" +
-        "  \"query\": \"SELECT * FROM %s WHERE age > ? AND state in (?, ?) LIMIT ?\",\n" +
-        "  \"parameters\": [\n" +
-        "    {\n" +
-        "      \"type\": \"integer\",\n" +
-        "      \"value\": \"" + ageToCompare + "\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"string\",\n" +
-        "      \"value\": \"TN\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"string\",\n" +
-        "      \"value\": \"UT\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"integer\",\n" +
-        "      \"value\": \"20\"\n" +
-        "    }\n" +
-        "  ]\n" +
-        "}", TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeRequest(
+            String.format(
+                "{\n"
+                    + "  \"query\": \"SELECT * FROM %s WHERE age > ? AND state in (?, ?) LIMIT"
+                    + " ?\",\n"
+                    + "  \"parameters\": [\n"
+                    + "    {\n"
+                    + "      \"type\": \"integer\",\n"
+                    + "      \"value\": \""
+                    + ageToCompare
+                    + "\"\n"
+                    + "    },\n"
+                    + "    {\n"
+                    + "      \"type\": \"string\",\n"
+                    + "      \"value\": \"TN\"\n"
+                    + "    },\n"
+                    + "    {\n"
+                    + "      \"type\": \"string\",\n"
+                    + "      \"value\": \"UT\"\n"
+                    + "    },\n"
+                    + "    {\n"
+                    + "      \"type\": \"integer\",\n"
+                    + "      \"value\": \"20\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     Assert.assertTrue(response.has("hits"));
     Assert.assertTrue(response.getJSONObject("hits").has("hits"));
@@ -58,23 +64,23 @@ public class PreparedStatementIT extends SQLIntegTestCase {
     }
   }
 
-    /* currently the integ test case will fail if run using Intellj, have to run using gradle command
-     * because the integ test cluster created by IntellJ has http diabled, need to spend some time later to
-     * figure out how to configure the integ test cluster properly. Related online resources:
-     *     https://discuss.elastic.co/t/http-enabled-with-OpenSearchIntegTestCase/102032
-     *     https://discuss.elastic.co/t/help-with-OpenSearchIntegTestCase/105245
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockTcpTransportPlugin.class);
-    }
+  /* currently the integ test case will fail if run using Intellj, have to run using gradle command
+   * because the integ test cluster created by IntellJ has http diabled, need to spend some time later to
+   * figure out how to configure the integ test cluster properly. Related online resources:
+   *     https://discuss.elastic.co/t/http-enabled-with-OpenSearchIntegTestCase/102032
+   *     https://discuss.elastic.co/t/help-with-OpenSearchIntegTestCase/105245
+  @Override
+  protected Collection<Class<? extends Plugin>> nodePlugins() {
+      return Arrays.asList(MockTcpTransportPlugin.class);
+  }
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
-                // .put("node.mode", "network")
-                .put("http.enabled", true)
-                //.put("http.type", "netty4")
-                .build();
-    }
-    */
+  @Override
+  protected Settings nodeSettings(int nodeOrdinal) {
+      return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+              // .put("node.mode", "network")
+              .put("http.enabled", true)
+              //.put("http.type", "netty4")
+              .build();
+  }
+  */
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static java.util.stream.Collectors.toSet;
@@ -30,6 +29,7 @@ import org.junit.Test;
 import org.opensearch.client.Request;
 
 /**
+ * <pre>
  * PrettyFormatResponseIT will likely be excluding some of the tests written in PrettyFormatResponseTest since
  * those tests were asserting on class objects directly. These updated tests will only be making assertions based
  * on the REST response.
@@ -40,21 +40,32 @@ import org.opensearch.client.Request;
  * Tests from original integ tests excluded:
  * - noIndexType()
  * - withIndexType()
+ * </pre>
  */
 public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
-  private static final Set<String> allAccountFields = Sets.newHashSet(
-      "account_number", "balance", "firstname", "lastname", "age", "gender", "address", "employer",
-      "email", "city", "state"
-  );
+  private static final Set<String> allAccountFields =
+      Sets.newHashSet(
+          "account_number",
+          "balance",
+          "firstname",
+          "lastname",
+          "age",
+          "gender",
+          "address",
+          "employer",
+          "email",
+          "city",
+          "state");
 
   private static final Set<String> regularFields = Sets.newHashSet("someField", "myNum");
 
-  private static final Set<String> messageFields = Sets.newHashSet(
-      "message.dayOfWeek", "message.info", "message.author");
+  private static final Set<String> messageFields =
+      Sets.newHashSet("message.dayOfWeek", "message.info", "message.author");
 
-  private static final Set<String> messageFieldsWithNestedFunction = Sets.newHashSet(
-      "nested(message.dayOfWeek)", "nested(message.info)", "nested(message.author)");
+  private static final Set<String> messageFieldsWithNestedFunction =
+      Sets.newHashSet(
+          "nested(message.dayOfWeek)", "nested(message.info)", "nested(message.author)");
 
   private static final Set<String> commentFields = Sets.newHashSet("comment.data", "comment.likes");
 
@@ -83,19 +94,20 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   public void wrongIndexType() throws IOException {
     String type = "wrongType";
     try {
-      executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s/%s",
-          TestsConstants.TEST_INDEX_ACCOUNT, type));
+      executeQuery(
+          String.format(
+              Locale.ROOT, "SELECT * FROM %s/%s", TestsConstants.TEST_INDEX_ACCOUNT, type));
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(),
-          is(String.format(Locale.ROOT, "Index type %s does not exist", type)));
+      assertThat(
+          e.getMessage(), is(String.format(Locale.ROOT, "Index type %s does not exist", type)));
     }
   }
 
   @Test
   public void selectAll() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(Locale.ROOT, "SELECT * FROM %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
     // This also tests that .keyword fields are ignored when SELECT * is called
     assertContainsColumnsInAnyOrder(getSchema(response), allAccountFields);
@@ -104,9 +116,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void selectNames() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT firstname, lastname FROM %s",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     assertContainsColumns(getSchema(response), nameFields);
     assertContainsData(getDataRows(response), nameFields);
@@ -115,13 +130,15 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   @Ignore("Semantic analysis takes care of this")
   @Test
   public void selectWrongField() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT wrongField FROM %s",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT wrongField FROM %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
     assertThat(getSchema(response).length(), equalTo(0));
 
-    // DataRows object will still get populated with SearchHits but since wrongField is not available in the Map
+    // DataRows object will still get populated with SearchHits but since wrongField is not
+    // available in the Map
     // each row in the response will be empty
     // TODO Perhaps a code change should be made to format logic to ensure a
     //  'datarows' length of 0 in response for this case
@@ -131,9 +148,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   @Test
   @Ignore("_score tested in V2 engine - @see org.opensearch.sql.sql.ScoreQueryIT")
   public void selectScore() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT _score FROM %s WHERE SCORE(match_phrase(phrase, 'brown fox'))",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT _score FROM %s WHERE SCORE(match_phrase(phrase, 'brown fox'))",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     List<String> fields = Collections.singletonList("_score");
     assertContainsColumns(getSchema(response), fields);
@@ -142,14 +162,14 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void selectAllFromNestedWithoutFieldInFrom() throws IOException {
-    assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s",
-        regularFields, fields("message", "comment"));
+    assertNestedFieldQueryResultContainsColumnsAndData(
+        "SELECT * FROM %s", regularFields, fields("message", "comment"));
   }
 
   @Test
   public void selectAllFromNestedWithFieldInFrom() throws IOException {
-    assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s e, e.message m",
-        regularFields, messageFields);
+    assertNestedFieldQueryResultContainsColumnsAndData(
+        "SELECT * FROM %s e, e.message m", regularFields, messageFields);
   }
 
   @Test
@@ -161,29 +181,27 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void selectAllNestedFromNestedWithFieldInFrom() throws IOException {
-    assertNestedFieldQueryResultContainsColumnsAndData("SELECT m.* FROM %s e, e.message m",
-        messageFields);
+    assertNestedFieldQueryResultContainsColumnsAndData(
+        "SELECT m.* FROM %s e, e.message m", messageFields);
   }
 
   @Test
   public void selectSpecificRegularFieldAndAllFromNestedWithFieldInFrom() throws IOException {
     assertNestedFieldQueryResultContainsColumnsAndData(
-        "SELECT e.someField, m.* FROM %s e, e.message m",
-        fields("someField"), messageFields);
+        "SELECT e.someField, m.* FROM %s e, e.message m", fields("someField"), messageFields);
   }
 
   /**
-   * Execute the query against index with nested fields and assert result contains columns and data as expected.
+   * Execute the query against index with nested fields and assert result contains columns and data
+   * as expected.
    */
   @SafeVarargs
-  private final void assertNestedFieldQueryResultContainsColumnsAndData(String query,
-                                                                        Set<String>... expectedFieldNames)
-      throws IOException {
+  private final void assertNestedFieldQueryResultContainsColumnsAndData(
+      String query, Set<String>... expectedFieldNames) throws IOException {
     JSONObject response =
         executeQuery(String.format(Locale.ROOT, query, TestsConstants.TEST_INDEX_NESTED_TYPE));
-    Set<String> allExpectedFieldNames = Stream.of(expectedFieldNames).
-        flatMap(Set::stream).
-        collect(toSet());
+    Set<String> allExpectedFieldNames =
+        Stream.of(expectedFieldNames).flatMap(Set::stream).collect(toSet());
 
     assertContainsColumnsInAnyOrder(getSchema(response), allExpectedFieldNames);
     assertContainsData(getDataRows(response), allExpectedFieldNames);
@@ -195,24 +213,31 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void selectNestedFields() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT nested(message.info), someField FROM %s",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT nested(message.info), someField FROM %s",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     List<String> fields = Arrays.asList("nested(message.info)", "someField");
     assertContainsColumns(getSchema(response), fields);
     assertContainsData(getDataRows(response), fields);
 
-    // The nested test index being used contains 5 entries but one of them has an array of 2 message objects, so
+    // The nested test index being used contains 5 entries but one of them has an array of 2 message
+    // objects, so
     // we check to see if the amount of data rows is 6 since that is the result after flattening
     assertThat(getDataRows(response).length(), equalTo(6));
   }
 
   @Test
   public void selectNestedFieldWithWildcard() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT nested(message.*) FROM %s",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT nested(message.*) FROM %s",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     assertContainsColumnsInAnyOrder(getSchema(response), messageFieldsWithNestedFunction);
     assertContainsData(getDataRows(response), messageFields);
@@ -221,11 +246,13 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   @Test
   public void selectWithWhere() throws IOException {
     int balanceToCompare = 30000;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT balance " +
-                "FROM %s " +
-                "WHERE balance > %d",
-            TestsConstants.TEST_INDEX_ACCOUNT, balanceToCompare));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT balance " + "FROM %s " + "WHERE balance > %d",
+                TestsConstants.TEST_INDEX_ACCOUNT,
+                balanceToCompare));
 
     /*
      * Previously the DataRows map was used to check specific fields but the JDBC response for "datarows" is a
@@ -243,9 +270,10 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void groupBySingleField() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s GROUP BY age",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT * FROM %s GROUP BY age", TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Collections.singletonList("age");
     assertContainsColumns(getSchema(response), fields);
@@ -254,9 +282,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void groupByMultipleFields() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s GROUP BY age, balance",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s GROUP BY age, balance",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Arrays.asList("age", "balance");
     assertContainsColumns(getSchema(response), fields);
@@ -265,35 +296,42 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Ignore("only work for legacy engine")
   public void testSizeAndTotal() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE balance > 30000 " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * " + "FROM %s " + "WHERE balance > 30000 " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     JSONArray dataRows = getDataRows(response);
     assertThat(dataRows.length(), equalTo(5));
 
-    // The value to compare to here was obtained by running the query in the plugin and looking at the SearchHits
+    // The value to compare to here was obtained by running the query in the plugin and looking at
+    // the SearchHits
     int totalHits = response.getInt("total");
     assertThat(totalHits, equalTo(402));
   }
 
   @Test
   public void testSizeWithGroupBy() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s GROUP BY age LIMIT 5",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s GROUP BY age LIMIT 5",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     assertThat(getDataRows(response).length(), equalTo(5));
   }
 
   @Test
   public void aggregationFunctionInSelect() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT COUNT(*) FROM %s GROUP BY age",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT COUNT(*) FROM %s GROUP BY age",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Arrays.asList("COUNT(*)");
     assertContainsColumns(getSchema(response), fields);
@@ -310,9 +348,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   @Ignore("In MySQL and our new engine, the original text in SELECT is used as final column name")
   @Test
   public void aggregationFunctionInSelectCaseCheck() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT count(*) FROM %s GROUP BY age",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT count(*) FROM %s GROUP BY age",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Arrays.asList("COUNT(*)");
     assertContainsColumns(getSchema(response), fields);
@@ -328,9 +369,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Ignore("only work for legacy engine")
   public void aggregationFunctionInSelectWithAlias() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT COUNT(*) AS total FROM %s GROUP BY age",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT COUNT(*) AS total FROM %s GROUP BY age",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Arrays.asList("total");
     assertContainsColumns(getSchema(response), fields);
@@ -346,8 +390,10 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void aggregationFunctionInSelectNoGroupBy() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT SUM(age) FROM %s",
-        TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT SUM(age) FROM %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
     String ageSum = "SUM(age)";
     assertContainsColumns(getSchema(response), Collections.singletonList(ageSum));
@@ -363,9 +409,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void multipleAggregationFunctionsInSelect() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT COUNT(*), AVG(age) FROM %s GROUP BY age",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT COUNT(*), AVG(age) FROM %s GROUP BY age",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Arrays.asList("COUNT(*)", "AVG(age)");
     assertContainsColumns(getSchema(response), fields);
@@ -374,12 +423,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void aggregationFunctionInHaving() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT gender " +
-            "FROM %s " +
-            "GROUP BY gender " +
-            "HAVING count(*) > 500",
-        TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT gender " + "FROM %s " + "GROUP BY gender " + "HAVING count(*) > 500",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     String ageSum = "gender";
     assertContainsColumns(getSchema(response), Collections.singletonList(ageSum));
@@ -390,20 +439,24 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   }
 
   /**
-   * This case doesn't seem to be supported by the plugin at the moment.
-   * Looks like the painless script of the inner function is put inside the aggregation function but
-   * this syntax may not be correct since it returns 0 which is the default value (since 0 is returned in
-   * cases like COUNT(wrongField) as well).
+   * This case doesn't seem to be supported by the plugin at the moment. Looks like the painless
+   * script of the inner function is put inside the aggregation function but this syntax may not be
+   * correct since it returns 0 which is the default value (since 0 is returned in cases like
+   * COUNT(wrongField) as well).
    */
-//    @Test
-//    public void nestedAggregationFunctionInSelect() {
-//        String query = String.format(Locale.ROOT, "SELECT SUM(SQRT(age)) FROM age GROUP BY age", TEST_INDEX_ACCOUNT);
-//    }
+  //    @Test
+  //    public void nestedAggregationFunctionInSelect() {
+  //        String query = String.format(Locale.ROOT, "SELECT SUM(SQRT(age)) FROM age GROUP BY age",
+  // TEST_INDEX_ACCOUNT);
+  //    }
   @Test
   public void fieldsWithAlias() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT firstname AS first, age AS a FROM %s",
-            TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT firstname AS first, age AS a FROM %s",
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     Map<String, String> aliases = new HashMap<>();
     aliases.put("firstname", "first");
@@ -414,25 +467,32 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void indexWithMissingFields() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT phrase, insert_time2 " +
-                "FROM %s " +
-                "WHERE match_phrase(phrase, 'brown fox')",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT phrase, insert_time2 "
+                    + "FROM %s "
+                    + "WHERE match_phrase(phrase, 'brown fox')",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray dataRowEntry = getDataRows(response).getJSONArray(0);
     assertThat(dataRowEntry.length(), equalTo(2));
     assertThat(dataRowEntry.get(0), equalTo("brown fox"));
-    assertThat(dataRowEntry.get(1),
-        equalTo(JSONObject.NULL)); // TODO See if this null check is failing
+    assertThat(
+        dataRowEntry.get(1), equalTo(JSONObject.NULL)); // TODO See if this null check is failing
   }
 
   @Test
   public void joinQuery() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT b1.balance, b1.age, b2.firstname " +
-                "FROM %s b1 JOIN %s b2 ON b1.age = b2.age",
-            TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT b1.balance, b1.age, b2.firstname "
+                    + "FROM %s b1 JOIN %s b2 ON b1.age = b2.age",
+                TestsConstants.TEST_INDEX_ACCOUNT,
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Arrays.asList("b1.balance", "b1.age", "b2.firstname");
     assertContainsColumns(getSchema(response), fields);
@@ -441,9 +501,14 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void joinQueryWithAlias() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT b1.balance AS bal, " +
-            " b1.age AS age, b2.firstname AS name FROM %s b1 JOIN %s b2 ON b1.age = b2.age",
-        TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT b1.balance AS bal,  b1.age AS age, b2.firstname AS name FROM %s b1 JOIN %s"
+                    + " b2 ON b1.age = b2.age",
+                TestsConstants.TEST_INDEX_ACCOUNT,
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     Map<String, String> aliases = new HashMap<>();
     aliases.put("b1.balance", "bal");
@@ -456,16 +521,20 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void joinQueryWithObjectFieldInSelect() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT c.name.firstname, d.name.lastname " +
-                "FROM %s c JOIN %s d ON d.hname = c.house",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES,
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT c.name.firstname, d.name.lastname "
+                    + "FROM %s c JOIN %s d ON d.hname = c.house",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES,
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     List<String> fields = Arrays.asList("c.name.firstname", "d.name.lastname");
     assertContainsColumns(getSchema(response), fields);
 
-    // d.name.lastname is null here since entries with hname don't have a name.lastname entry, so only length is
+    // d.name.lastname is null here since entries with hname don't have a name.lastname entry, so
+    // only length is
     // checked
     JSONArray dataRows = getDataRows(response);
     assertThat(dataRows.length(), greaterThan(0));
@@ -476,10 +545,13 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
   @Test
   public void joinQuerySelectOnlyOnOneTable() throws Exception {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT b1.age " +
-                "FROM %s b1 JOIN %s b2 ON b1.firstname = b2.firstname",
-            TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT b1.age " + "FROM %s b1 JOIN %s b2 ON b1.firstname = b2.firstname",
+                TestsConstants.TEST_INDEX_ACCOUNT,
+                TestsConstants.TEST_INDEX_ACCOUNT));
 
     List<String> fields = Collections.singletonList("b1.age");
     assertContainsColumns(getSchema(response), fields);
@@ -508,8 +580,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
       throws IOException {
 
     final String fields = String.join(", ", expectedFields);
-    final String query = String.format(Locale.ROOT, "SELECT %s FROM %s " +
-        "WHERE email='amberduke@pyrami.com'", fields, TestsConstants.TEST_INDEX_ACCOUNT);
+    final String query =
+        String.format(
+            Locale.ROOT,
+            "SELECT %s FROM %s " + "WHERE email='amberduke@pyrami.com'",
+            fields,
+            TestsConstants.TEST_INDEX_ACCOUNT);
     final JSONObject result = executeQuery(query);
 
     for (int i = 0; i < expectedFields.length; ++i) {

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatterIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatterIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -29,16 +28,18 @@ public class PrettyFormatterIT extends SQLIntegTestCase {
   public void assertExplainPrettyFormatted() throws IOException {
     String query = StringUtils.format("SELECT firstname FROM %s", TEST_INDEX_ACCOUNT);
 
-    String notPrettyExplainOutputFilePath = TestUtils.getResourceFilePath(
-        "src/test/resources/expectedOutput/explainIT_format_not_pretty.json");
+    String notPrettyExplainOutputFilePath =
+        TestUtils.getResourceFilePath(
+            "src/test/resources/expectedOutput/explainIT_format_not_pretty.json");
     String notPrettyExplainOutput =
         Files.toString(new File(notPrettyExplainOutputFilePath), StandardCharsets.UTF_8);
 
     assertThat(executeExplainRequest(query, ""), equalTo(notPrettyExplainOutput));
     assertThat(executeExplainRequest(query, "pretty=false"), equalTo(notPrettyExplainOutput));
 
-    String prettyExplainOutputFilePath = TestUtils.getResourceFilePath(
-        "src/test/resources/expectedOutput/explainIT_format_pretty.json");
+    String prettyExplainOutputFilePath =
+        TestUtils.getResourceFilePath(
+            "src/test/resources/expectedOutput/explainIT_format_pretty.json");
     String prettyExplainOutput =
         Files.toString(new File(prettyExplainOutputFilePath), StandardCharsets.UTF_8);
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/QueryAnalysisIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/QueryAnalysisIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.containsString;
@@ -24,9 +23,7 @@ import org.opensearch.sql.legacy.antlr.syntax.SyntaxAnalysisException;
 import org.opensearch.sql.legacy.exception.SqlFeatureNotImplementedException;
 import org.opensearch.sql.legacy.utils.StringUtils;
 
-/**
- * Integration test for syntax and semantic analysis against query by new ANTLR parser.
- */
+/** Integration test for syntax and semantic analysis against query by new ANTLR parser. */
 public class QueryAnalysisIT extends SQLIntegTestCase {
 
   @Override
@@ -41,9 +38,7 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
 
   @Test
   public void unsupportedOperatorShouldThrowSyntaxException() {
-    queryShouldThrowSyntaxException(
-        "SELECT * FROM opensearch-sql_test_index_bank WHERE age <=> 1"
-    );
+    queryShouldThrowSyntaxException("SELECT * FROM opensearch-sql_test_index_bank WHERE age <=> 1");
   }
 
   @Test
@@ -51,8 +46,8 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank WHERE balance1 = 1000",
         "Field [balance1] cannot be found or used here."
-        //"Did you mean [balance]?"
-    );
+        // "Did you mean [balance]?"
+        );
   }
 
   @Test
@@ -60,16 +55,15 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank b WHERE a.balance = 1000",
         "Field [a.balance] cannot be found or used here."
-        //"Did you mean [b.balance]?"
-    );
+        // "Did you mean [b.balance]?"
+        );
   }
 
   @Test
   public void indexJoinNonNestedFieldShouldThrowSemanticException() {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank b1, b1.firstname f1",
-        "Operator [JOIN] cannot work with [INDEX, KEYWORD]."
-    );
+        "Operator [JOIN] cannot work with [INDEX, KEYWORD].");
   }
 
   @Test
@@ -77,8 +71,7 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank WHERE ABSa(age) = 1",
         "Function [ABSA] cannot be found or used here.",
-        "Did you mean [ABS]?"
-    );
+        "Did you mean [ABS]?");
   }
 
   @Test
@@ -86,17 +79,16 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank WHERE LOG(lastname) = 1",
         "Function [LOG] cannot work with [KEYWORD].",
-        "Usage: LOG(NUMBER T) -> DOUBLE or LOG(NUMBER T, NUMBER) -> DOUBLE"
-    );
+        "Usage: LOG(NUMBER T) -> DOUBLE or LOG(NUMBER T, NUMBER) -> DOUBLE");
   }
 
   @Test
   public void aggregateFunctionCallWithWrongNumberOfArgumentShouldThrowSemanticException() {
     queryShouldThrowSemanticException(
-        "SELECT city FROM opensearch-sql_test_index_bank GROUP BY city HAVING MAX(age, birthdate) > 1",
+        "SELECT city FROM opensearch-sql_test_index_bank GROUP BY city HAVING MAX(age, birthdate) >"
+            + " 1",
         "Function [MAX] cannot work with [INTEGER, DATE].",
-        "Usage: MAX(NUMBER T) -> T"
-    );
+        "Usage: MAX(NUMBER T) -> T");
   }
 
   @Test
@@ -104,8 +96,7 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank b WHERE b.age IS FALSE",
         "Operator [IS] cannot work with [INTEGER, BOOLEAN].",
-        "Usage: Please use compatible types from each side."
-    );
+        "Usage: Please use compatible types from each side.");
   }
 
   @Test
@@ -113,8 +104,7 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank b WHERE b.age >= 'test'",
         "Operator [>=] cannot work with [INTEGER, STRING].",
-        "Usage: Please use compatible types from each side."
-    );
+        "Usage: Please use compatible types from each side.");
   }
 
   @Test
@@ -122,43 +112,38 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowSemanticException(
         "SELECT * FROM opensearch-sql_test_index_bank b WHERE LOG(b.balance) != 'test'",
         "Operator [!=] cannot work with [DOUBLE, STRING].",
-        "Usage: Please use compatible types from each side."
-    );
+        "Usage: Please use compatible types from each side.");
   }
 
   @Test
   public void unionNumberFieldWithStringShouldThrowSemanticException() {
     queryShouldThrowSemanticException(
-        "SELECT age FROM opensearch-sql_test_index_bank" +
-            " UNION SELECT address FROM opensearch-sql_test_index_bank",
-        "Operator [UNION] cannot work with [INTEGER, TEXT]."
-    );
+        "SELECT age FROM opensearch-sql_test_index_bank"
+            + " UNION SELECT address FROM opensearch-sql_test_index_bank",
+        "Operator [UNION] cannot work with [INTEGER, TEXT].");
   }
 
   @Test
   public void minusBooleanFieldWithDateShouldThrowSemanticException() {
     queryShouldThrowSemanticException(
-        "SELECT male FROM opensearch-sql_test_index_bank" +
-            " MINUS SELECT birthdate FROM opensearch-sql_test_index_bank",
-        "Operator [MINUS] cannot work with [BOOLEAN, DATE]."
-    );
+        "SELECT male FROM opensearch-sql_test_index_bank"
+            + " MINUS SELECT birthdate FROM opensearch-sql_test_index_bank",
+        "Operator [MINUS] cannot work with [BOOLEAN, DATE].");
   }
 
   @Test
   public void useInClauseWithIncompatibleFieldTypesShouldFail() {
     queryShouldThrowSemanticException(
-        "SELECT * FROM opensearch-sql_test_index_bank WHERE male " +
-            " IN (SELECT 1 FROM opensearch-sql_test_index_bank)",
-        "Operator [IN] cannot work with [BOOLEAN, INTEGER]."
-    );
+        "SELECT * FROM opensearch-sql_test_index_bank WHERE male "
+            + " IN (SELECT 1 FROM opensearch-sql_test_index_bank)",
+        "Operator [IN] cannot work with [BOOLEAN, INTEGER].");
   }
 
   @Test
   public void queryWithNestedFunctionShouldFail() {
     queryShouldThrowFeatureNotImplementedException(
         "SELECT abs(log(balance)) FROM opensearch-sql_test_index_bank",
-        "Nested function calls like [abs(log(balance))] are not supported yet"
-    );
+        "Nested function calls like [abs(log(balance))] are not supported yet");
   }
 
   @Test
@@ -170,29 +155,24 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
   public void aggregateWithFunctionAggregatorShouldFail() {
     queryShouldThrowFeatureNotImplementedException(
         "SELECT max(log(age)) FROM opensearch-sql_test_index_bank",
-        "Aggregation calls with function aggregator like [max(log(age))] are not supported yet"
-    );
+        "Aggregation calls with function aggregator like [max(log(age))] are not supported yet");
   }
 
   @Test
   public void queryWithUnsupportedFunctionShouldFail() {
     queryShouldThrowFeatureNotImplementedException(
         "SELECT balance DIV age FROM opensearch-sql_test_index_bank",
-        "Operator [DIV] is not supported yet"
-    );
+        "Operator [DIV] is not supported yet");
   }
 
   @Test
   public void useNegativeNumberConstantShouldPass() {
     queryShouldPassAnalysis(
-        "SELECT * FROM opensearch-sql_test_index_bank " +
-            "WHERE age > -1 AND balance < -123.456789"
-    );
+        "SELECT * FROM opensearch-sql_test_index_bank "
+            + "WHERE age > -1 AND balance < -123.456789");
   }
 
-  /**
-   * Run the query with cluster setting changed and cleaned after complete
-   */
+  /** Run the query with cluster setting changed and cleaned after complete */
   private void runWithClusterSetting(ClusterSetting setting, Runnable query) {
     try {
       updateClusterSettings(setting);
@@ -201,7 +181,8 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
       throw new IllegalStateException(
           StringUtils.format("Exception raised when running with cluster setting [%s]", setting));
     } finally {
-      // Clean up or OpenSearch will throw java.lang.AssertionError: test leaves persistent cluster metadata behind
+      // Clean up or OpenSearch will throw java.lang.AssertionError: test leaves persistent cluster
+      // metadata behind
       try {
         updateClusterSettings(setting.nullify());
       } catch (IOException e) {
@@ -218,20 +199,19 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
     queryShouldThrowException(query, SemanticAnalysisException.class, expectedMsgs);
   }
 
-  private void queryShouldThrowFeatureNotImplementedException(String query,
-                                                              String... expectedMsgs) {
-    queryShouldThrowExceptionWithRestStatus(query, SqlFeatureNotImplementedException.class,
-        SERVICE_UNAVAILABLE, expectedMsgs);
+  private void queryShouldThrowFeatureNotImplementedException(
+      String query, String... expectedMsgs) {
+    queryShouldThrowExceptionWithRestStatus(
+        query, SqlFeatureNotImplementedException.class, SERVICE_UNAVAILABLE, expectedMsgs);
   }
 
-  private <T> void queryShouldThrowException(String query, Class<T> exceptionType,
-                                             String... expectedMsgs) {
+  private <T> void queryShouldThrowException(
+      String query, Class<T> exceptionType, String... expectedMsgs) {
     queryShouldThrowExceptionWithRestStatus(query, exceptionType, BAD_REQUEST, expectedMsgs);
   }
 
-  private <T> void queryShouldThrowExceptionWithRestStatus(String query, Class<T> exceptionType,
-                                                           RestStatus status,
-                                                           String... expectedMsgs) {
+  private <T> void queryShouldThrowExceptionWithRestStatus(
+      String query, Class<T> exceptionType, RestStatus status, String... expectedMsgs) {
     try {
       executeQuery(query);
       Assert.fail("Expected ResponseException, but none was thrown for query: " + query);
@@ -244,8 +224,8 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
       }
     } catch (IOException e) {
       throw new IllegalStateException(
-          "Unexpected IOException raised rather than expected AnalysisException for query: " +
-              query);
+          "Unexpected IOException raised rather than expected AnalysisException for query: "
+              + query);
     }
   }
 
@@ -285,5 +265,4 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
       assertThat(body, containsString(content));
     }
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/QueryFunctionsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/QueryFunctionsIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.anyOf;
@@ -44,10 +43,11 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
   private static final String FROM_PHRASE = "FROM " + TEST_INDEX_PHRASE;
 
   /**
+   * <pre>
    * TODO Looks like Math/Date Functions test all use the same query() and execute() functions
    * TODO execute/featureValueOf/hits functions are the same as used in NestedFieldQueryIT, should refactor into util
+   * </pre>
    */
-
   @Override
   protected void init() throws Exception {
     loadIndex(Index.ACCOUNT);
@@ -58,63 +58,39 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
   @Test
   public void query() throws IOException {
     assertThat(
-        query(
-            "SELECT state",
-            FROM_ACCOUNTS,
-            "WHERE QUERY('CA')"
-        ),
-        hits(
-            hasValueForFields("CA", "state")
-        )
-    );
+        query("SELECT state", FROM_ACCOUNTS, "WHERE QUERY('CA')"),
+        hits(hasValueForFields("CA", "state")));
   }
 
   @Test
   public void matchQueryRegularField() throws IOException {
     assertThat(
-        query(
-            "SELECT firstname",
-            FROM_ACCOUNTS,
-            "WHERE MATCH_QUERY(firstname, 'Ayers')"
-        ),
-        hits(
-            hasValueForFields("Ayers", "firstname")
-        )
-    );
+        query("SELECT firstname", FROM_ACCOUNTS, "WHERE MATCH_QUERY(firstname, 'Ayers')"),
+        hits(hasValueForFields("Ayers", "firstname")));
   }
 
   @Test
   public void matchQueryNestedField() throws IOException {
     SearchHit[] hits =
         query("SELECT comment.data", FROM_NESTED, "WHERE MATCH_QUERY(NESTED(comment.data), 'aa')")
-            .getHits().getHits();
+            .getHits()
+            .getHits();
     Map<String, Object> source = hits[0].getSourceAsMap();
     // SearchHits innerHits = hits[0].getInnerHits().get("comment");
     assertThat(
-        query(
-            "SELECT comment.data",
-            FROM_NESTED,
-            "WHERE MATCH_QUERY(NESTED(comment.data), 'aa')"
-        ),
+        query("SELECT comment.data", FROM_NESTED, "WHERE MATCH_QUERY(NESTED(comment.data), 'aa')"),
         hits(
-            anyOf(hasNestedField("comment", "data", "aa"),
-                hasNestedArrayField("comment", "data", "aa"))
-        )
-    );
+            anyOf(
+                hasNestedField("comment", "data", "aa"),
+                hasNestedArrayField("comment", "data", "aa"))));
   }
 
   @Test
   public void scoreQuery() throws IOException {
     assertThat(
         query(
-            "SELECT firstname",
-            FROM_ACCOUNTS,
-            "WHERE SCORE(MATCH_QUERY(firstname, 'Ayers'), 10)"
-        ),
-        hits(
-            hasValueForFields("Ayers", "firstname")
-        )
-    );
+            "SELECT firstname", FROM_ACCOUNTS, "WHERE SCORE(MATCH_QUERY(firstname, 'Ayers'), 10)"),
+        hits(hasValueForFields("Ayers", "firstname")));
   }
 
   @Test
@@ -123,42 +99,24 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
         query(
             "SELECT comment.data",
             FROM_NESTED,
-            "WHERE SCORE(MATCH_QUERY(NESTED(comment.data), 'ab'), 10)"
-        ),
+            "WHERE SCORE(MATCH_QUERY(NESTED(comment.data), 'ab'), 10)"),
         hits(
-            //hasValueForFields("ab", "comment.data")
-            hasNestedField("comment",
-                "data", "ab")
-        )
-    );
+            // hasValueForFields("ab", "comment.data")
+            hasNestedField("comment", "data", "ab")));
   }
 
   @Test
   public void wildcardQuery() throws IOException {
     assertThat(
-        query(
-            "SELECT city",
-            FROM_ACCOUNTS,
-            "WHERE WILDCARD_QUERY(city.keyword, 'B*')"
-        ),
-        hits(
-            hasFieldWithPrefix("city", "B")
-        )
-    );
+        query("SELECT city", FROM_ACCOUNTS, "WHERE WILDCARD_QUERY(city.keyword, 'B*')"),
+        hits(hasFieldWithPrefix("city", "B")));
   }
 
   @Test
   public void matchPhraseQuery() throws IOException {
     assertThat(
-        query(
-            "SELECT phrase",
-            FROM_PHRASE,
-            "WHERE MATCH_PHRASE(phrase, 'brown fox')"
-        ),
-        hits(
-            hasValueForFields("brown fox", "phrase")
-        )
-    );
+        query("SELECT phrase", FROM_PHRASE, "WHERE MATCH_PHRASE(phrase, 'brown fox')"),
+        hits(hasValueForFields("brown fox", "phrase")));
   }
 
   @Test
@@ -167,12 +125,8 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
         query(
             "SELECT firstname",
             FROM_ACCOUNTS,
-            "WHERE MULTI_MATCH('query'='Ayers', 'fields'='firstname')"
-        ),
-        hits(
-            hasValueForFields("Ayers", "firstname")
-        )
-    );
+            "WHERE MULTI_MATCH('query'='Ayers', 'fields'='firstname')"),
+        hits(hasValueForFields("Ayers", "firstname")));
   }
 
   @Test
@@ -181,36 +135,30 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
         query(
             "SELECT firstname, lastname",
             FROM_ACCOUNTS,
-            "WHERE MULTI_MATCH('query'='Bradshaw', 'fields'='*name')"
-        ),
-        hits(
-            hasValueForFields("Bradshaw", "firstname", "lastname")
-        )
-    );
+            "WHERE MULTI_MATCH('query'='Bradshaw', 'fields'='*name')"),
+        hits(hasValueForFields("Bradshaw", "firstname", "lastname")));
   }
 
   @Test
   public void numberLiteralInSelectField() {
     assertTrue(
-        executeQuery(StringUtils.format("SELECT 234234 AS number from %s", TEST_INDEX_ACCOUNT),
-            "jdbc")
-            .contains("234234")
-    );
+        executeQuery(
+                StringUtils.format("SELECT 234234 AS number from %s", TEST_INDEX_ACCOUNT), "jdbc")
+            .contains("234234"));
 
     assertTrue(
-        executeQuery(StringUtils.format("SELECT 2.34234 AS number FROM %s", TEST_INDEX_ACCOUNT),
-            "jdbc")
-            .contains("2.34234")
-    );
+        executeQuery(
+                StringUtils.format("SELECT 2.34234 AS number FROM %s", TEST_INDEX_ACCOUNT), "jdbc")
+            .contains("2.34234"));
   }
 
   private final Matcher<SearchResponse> hits(Matcher<SearchHit> subMatcher) {
-    return featureValueOf("hits", everyItem(subMatcher),
-        resp -> Arrays.asList(resp.getHits().getHits()));
+    return featureValueOf(
+        "hits", everyItem(subMatcher), resp -> Arrays.asList(resp.getHits().getHits()));
   }
 
-  private <T, U> FeatureMatcher<T, U> featureValueOf(String name, Matcher<U> subMatcher,
-                                                     Function<T, U> getter) {
+  private <T, U> FeatureMatcher<T, U> featureValueOf(
+      String name, Matcher<U> subMatcher, Function<T, U> getter) {
     return new FeatureMatcher<T, U>(subMatcher, name, name) {
       @Override
       protected U featureValueOf(T actual) {
@@ -220,6 +168,7 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
   }
 
   /**
+   * <pre>
    * Create Matchers for each field and its value
    * Only one of the Matchers need to match (per hit)
    * <p>
@@ -228,36 +177,33 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
    * <p>
    * Then the value "Ayers" can be found in either the firstname or lastname field. Only one of these fields
    * need to satisfy the query value to be evaluated as correct expected output.
-   *
-   * @param value  The value to match for a field in the sourceMap
+   * </pre>
+   * @param value The value to match for a field in the sourceMap
    * @param fields A list of fields to match
    */
   @SafeVarargs
   private final Matcher<SearchHit> hasValueForFields(String value, String... fields) {
     return anyOf(
-        Arrays.asList(fields).
-            stream().
-            map(field -> kv(field, is(value))).
-            collect(Collectors.toList()));
+        Arrays.asList(fields).stream()
+            .map(field -> kv(field, is(value)))
+            .collect(Collectors.toList()));
   }
 
   private final Matcher<SearchHit> hasFieldWithPrefix(String field, String prefix) {
-    return featureValueOf(field, startsWith(prefix),
-        hit -> (String) hit.getSourceAsMap().get(field));
+    return featureValueOf(
+        field, startsWith(prefix), hit -> (String) hit.getSourceAsMap().get(field));
   }
 
   private final Matcher<SearchHit> hasNestedField(String path, String field, String value) {
-    return featureValueOf(field, is(value),
-        hit -> ((HashMap) hit.getSourceAsMap().get(path)).get(field));
+    return featureValueOf(
+        field, is(value), hit -> ((HashMap) hit.getSourceAsMap().get(path)).get(field));
   }
 
   private final Matcher<SearchHit> hasNestedArrayField(String path, String field, String value) {
 
     return new BaseMatcher<SearchHit>() {
       @Override
-      public void describeTo(Description description) {
-
-      }
+      public void describeTo(Description description) {}
 
       @Override
       public boolean matches(Object item) {
@@ -275,7 +221,7 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
   }
 
   /***********************************************************
-   Query Utility to Fetch Response for SQL
+   * Query Utility to Fetch Response for SQL
    ***********************************************************/
 
   private SearchResponse query(String select, String from, String... statements)
@@ -286,10 +232,11 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
   private SearchResponse execute(String sql) throws IOException {
     final JSONObject jsonObject = executeQuery(sql);
 
-    final XContentParser parser = new JsonXContentParser(
-        NamedXContentRegistry.EMPTY,
-        LoggingDeprecationHandler.INSTANCE,
-        new JsonFactory().createParser(jsonObject.toString()));
+    final XContentParser parser =
+        new JsonXContentParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            new JsonFactory().createParser(jsonObject.toString()));
     return SearchResponse.fromXContent(parser);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/QueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/QueryIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.allOf;
@@ -44,6 +43,7 @@ import org.opensearch.sql.legacy.utils.StringUtils;
 public class QueryIT extends SQLIntegTestCase {
 
   /**
+   * <pre>
    * Currently commenting out tests related to JoinType index since there is an issue with mapping.
    * <p>
    * Also ignoring the following tests as they are failing, will require investigation:
@@ -57,10 +57,11 @@ public class QueryIT extends SQLIntegTestCase {
    * The following tests are being ignored because subquery is still running in OpenSearch transport thread:
    * - twoSubQueriesTest()
    * - inTermsSubQueryTest()
+   * </pre>
    */
+  static final int BANK_INDEX_MALE_TRUE = 4;
 
-  final static int BANK_INDEX_MALE_TRUE = 4;
-  final static int BANK_INDEX_MALE_FALSE = 3;
+  static final int BANK_INDEX_MALE_FALSE = 3;
 
   @Override
   protected void init() throws Exception {
@@ -87,92 +88,87 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void searchTypeTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s LIMIT 1000",
-        TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT * FROM %s LIMIT 1000", TestsConstants.TEST_INDEX_PHRASE));
     Assert.assertTrue(response.has("hits"));
     Assert.assertEquals(6, getTotalHits(response));
   }
 
   @Test
   public void multipleFromTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s, %s LIMIT 2000",
-        TestsConstants.TEST_INDEX_BANK, TestsConstants.TEST_INDEX_BANK_TWO));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s, %s LIMIT 2000",
+                TestsConstants.TEST_INDEX_BANK,
+                TestsConstants.TEST_INDEX_BANK_TWO));
     Assert.assertTrue(response.has("hits"));
     Assert.assertEquals(14, getTotalHits(response));
   }
 
   @Test
   public void selectAllWithFieldReturnsAll() throws IOException {
-    JSONObject response = executeQuery(StringUtils.format(
-        "SELECT *, age " +
-            "FROM %s " +
-            "LIMIT 5",
-        TestsConstants.TEST_INDEX_BANK
-    ));
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT *, age " + "FROM %s " + "LIMIT 5", TestsConstants.TEST_INDEX_BANK));
 
     checkSelectAllAndFieldResponseSize(response);
   }
 
   @Test
   public void selectAllWithFieldReverseOrder() throws IOException {
-    JSONObject response = executeQuery(StringUtils.format(
-        "SELECT *, age " +
-            "FROM %s " +
-            "LIMIT 5",
-        TestsConstants.TEST_INDEX_BANK
-    ));
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT *, age " + "FROM %s " + "LIMIT 5", TestsConstants.TEST_INDEX_BANK));
 
     checkSelectAllAndFieldResponseSize(response);
   }
 
   @Test
   public void selectAllWithMultipleFields() throws IOException {
-    JSONObject response = executeQuery(StringUtils.format(
-        "SELECT *, age, address " +
-            "FROM %s " +
-            "LIMIT 5",
-        TestsConstants.TEST_INDEX_BANK
-    ));
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT *, age, address " + "FROM %s " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkSelectAllAndFieldResponseSize(response);
   }
 
   @Test
   public void selectAllWithFieldAndOrderBy() throws IOException {
-    JSONObject response = executeQuery(StringUtils.format(
-        "SELECT *, age " +
-            "FROM %s " +
-            "ORDER BY age " +
-            "LIMIT 5",
-        TestsConstants.TEST_INDEX_BANK
-    ));
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT *, age " + "FROM %s " + "ORDER BY age " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkSelectAllAndFieldResponseSize(response);
   }
 
   @Test
   public void selectAllWithFieldAndGroupBy() throws IOException {
-    JSONObject response = executeQuery(StringUtils.format(
-        "SELECT *, age " +
-            "FROM %s " +
-            "GROUP BY age " +
-            "LIMIT 10",
-        TestsConstants.TEST_INDEX_BANK
-    ));
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT *, age " + "FROM %s " + "GROUP BY age " + "LIMIT 10",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkSelectAllAndFieldAggregationResponseSize(response, "age");
   }
 
   @Test
   public void selectAllWithFieldAndGroupByReverseOrder() throws IOException {
-    JSONObject response = executeQuery(StringUtils.format(
-        "SELECT *, age " +
-            "FROM %s " +
-            "GROUP BY age " +
-            "LIMIT 10",
-        TestsConstants.TEST_INDEX_BANK
-    ));
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT *, age " + "FROM %s " + "GROUP BY age " + "LIMIT 10",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkSelectAllAndFieldAggregationResponseSize(response, "age");
   }
@@ -180,14 +176,16 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   public void selectFieldWithAliasAndGroupBy() {
     String response =
-        executeQuery("SELECT lastname AS name FROM " + TEST_INDEX_ACCOUNT + " GROUP BY name",
-            "jdbc");
+        executeQuery(
+            "SELECT lastname AS name FROM " + TEST_INDEX_ACCOUNT + " GROUP BY name", "jdbc");
     assertThat(response, containsString("\"alias\": \"name\""));
   }
 
   public void indexWithWildcardTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s* LIMIT 1000",
-        TestsConstants.TEST_INDEX_BANK));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT * FROM %s* LIMIT 1000", TestsConstants.TEST_INDEX_BANK));
     Assert.assertTrue(response.has("hits"));
     assertThat(getTotalHits(response), greaterThan(0));
   }
@@ -198,8 +196,8 @@ public class QueryIT extends SQLIntegTestCase {
     Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
     JSONObject response =
-        executeQuery(String.format(Locale.ROOT, "SELECT age, account_number FROM %s",
-            TEST_INDEX_ACCOUNT));
+        executeQuery(
+            String.format(Locale.ROOT, "SELECT age, account_number FROM %s", TEST_INDEX_ACCOUNT));
     assertResponseForSelectSpecificFields(response, expectedSource);
   }
 
@@ -209,8 +207,9 @@ public class QueryIT extends SQLIntegTestCase {
     Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
     JSONObject response =
-        executeQuery(String.format(Locale.ROOT, "SELECT a.age, a.account_number FROM %s a",
-            TEST_INDEX_ACCOUNT));
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT a.age, a.account_number FROM %s a", TEST_INDEX_ACCOUNT));
     assertResponseForSelectSpecificFields(response, expectedSource);
   }
 
@@ -219,15 +218,18 @@ public class QueryIT extends SQLIntegTestCase {
     String[] arr = new String[] {"age", "account_number"};
     Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT opensearch-sql_test_index_account.age, opensearch-sql_test_index_account.account_number" +
-            " FROM %s",
-        TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT opensearch-sql_test_index_account.age,"
+                    + " opensearch-sql_test_index_account.account_number FROM %s",
+                TEST_INDEX_ACCOUNT));
     assertResponseForSelectSpecificFields(response, expectedSource);
   }
 
-  private void assertResponseForSelectSpecificFields(JSONObject response,
-                                                     Set<String> expectedSource) {
+  private void assertResponseForSelectSpecificFields(
+      JSONObject response, Set<String> expectedSource) {
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
       JSONObject hit = hits.getJSONObject(i);
@@ -240,9 +242,12 @@ public class QueryIT extends SQLIntegTestCase {
     String[] arr = new String[] {"test field"};
     Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT ['test field'] FROM %s " +
-            "WHERE ['test field'] IS NOT null",
-        TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT ['test field'] FROM %s " + "WHERE ['test field'] IS NOT null",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -259,19 +264,28 @@ public class QueryIT extends SQLIntegTestCase {
     String[] arr = new String[] {"myage", "myaccount_number"};
     Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
-    JSONObject result = executeQuery(String.format(Locale.ROOT,
-        "SELECT age AS myage, account_number AS myaccount_number FROM %s", TEST_INDEX_ACCOUNT));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT age AS myage, account_number AS myaccount_number FROM %s",
+                TEST_INDEX_ACCOUNT));
     JSONArray hits = getHits(result);
-    hits.forEach(hitObj -> {
-      JSONObject hit = (JSONObject) hitObj;
-      Assert.assertEquals(expectedSource, hit.getJSONObject("_source").keySet());
-    });
+    hits.forEach(
+        hitObj -> {
+          JSONObject hit = (JSONObject) hitObj;
+          Assert.assertEquals(expectedSource, hit.getJSONObject("_source").keySet());
+        });
   }
 
   @Test
   public void useTableAliasInWhereClauseTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s a WHERE a.city = 'Nogal' LIMIT 1000", TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s a WHERE a.city = 'Nogal' LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -280,8 +294,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void notUseTableAliasInWhereClauseTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s a WHERE city = 'Nogal' LIMIT 1000", TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s a WHERE city = 'Nogal' LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -290,10 +308,13 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void useTableNamePrefixInWhereClauseTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s WHERE opensearch-sql_test_index_account.city = 'Nogal' LIMIT 1000",
-        TEST_INDEX_ACCOUNT
-    ));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE opensearch-sql_test_index_account.city = 'Nogal' LIMIT"
+                    + " 1000",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -302,8 +323,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void equalityTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s WHERE city = 'Nogal' LIMIT 1000", TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE city = 'Nogal' LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -312,9 +337,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void equalityTestPhrase() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s WHERE " +
-            "match_phrase(phrase, 'quick fox here') LIMIT 1000",
-        TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE " + "match_phrase(phrase, 'quick fox here') LIMIT 1000",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -324,10 +352,13 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   public void greaterThanTest() throws IOException {
     int someAge = 25;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age > %s LIMIT 1000",
-            TestsConstants.TEST_INDEX_PEOPLE,
-            someAge));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age > %s LIMIT 1000",
+                TestsConstants.TEST_INDEX_PEOPLE,
+                someAge));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -340,10 +371,13 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   public void greaterThanOrEqualTest() throws IOException {
     int someAge = 25;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age >= %s LIMIT 1000",
-            TEST_INDEX_ACCOUNT,
-            someAge));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age >= %s LIMIT 1000",
+                TEST_INDEX_ACCOUNT,
+                someAge));
 
     boolean isEqualFound = false;
     JSONArray hits = getHits(response);
@@ -352,24 +386,27 @@ public class QueryIT extends SQLIntegTestCase {
       int age = getSource(hit).getInt("age");
       assertThat(age, greaterThanOrEqualTo(someAge));
 
-        if (age == someAge) {
-            isEqualFound = true;
-        }
+      if (age == someAge) {
+        isEqualFound = true;
+      }
     }
 
     Assert.assertTrue(
-        String.format(Locale.ROOT, "At least one of the documents need to contains age equal to %s",
-            someAge),
+        String.format(
+            Locale.ROOT, "At least one of the documents need to contains age equal to %s", someAge),
         isEqualFound);
   }
 
   @Test
   public void lessThanTest() throws IOException {
     int someAge = 25;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age < %s LIMIT 1000",
-            TestsConstants.TEST_INDEX_PEOPLE,
-            someAge));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age < %s LIMIT 1000",
+                TestsConstants.TEST_INDEX_PEOPLE,
+                someAge));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -382,10 +419,13 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   public void lessThanOrEqualTest() throws IOException {
     int someAge = 25;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age <= %s LIMIT 1000",
-            TEST_INDEX_ACCOUNT,
-            someAge));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age <= %s LIMIT 1000",
+                TEST_INDEX_ACCOUNT,
+                someAge));
 
     boolean isEqualFound = false;
     JSONArray hits = getHits(response);
@@ -394,32 +434,39 @@ public class QueryIT extends SQLIntegTestCase {
       int age = getSource(hit).getInt("age");
       assertThat(age, lessThanOrEqualTo(someAge));
 
-        if (age == someAge) {
-            isEqualFound = true;
-        }
+      if (age == someAge) {
+        isEqualFound = true;
+      }
     }
 
     Assert.assertTrue(
-        String.format(Locale.ROOT, "At least one of the documents need to contains age equal to %s",
-            someAge),
+        String.format(
+            Locale.ROOT, "At least one of the documents need to contains age equal to %s", someAge),
         isEqualFound);
   }
 
   @Test
   public void orTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-            "FROM %s " +
-            "WHERE match_phrase(gender, 'F') OR match_phrase(gender, 'M') " +
-            "LIMIT 1000", TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE match_phrase(gender, 'F') OR match_phrase(gender, 'M') "
+                    + "LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
     Assert.assertEquals(1000, getTotalHits(response));
   }
 
   @Test
   public void andTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age=32 AND gender='M' LIMIT 1000",
-            TestsConstants.TEST_INDEX_PEOPLE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age=32 AND gender='M' LIMIT 1000",
+                TestsConstants.TEST_INDEX_PEOPLE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -431,9 +478,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void likeTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE firstname LIKE 'amb%%' LIMIT 1000",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE firstname LIKE 'amb%%' LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -442,9 +492,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void notLikeTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE firstname NOT LIKE 'amb%%'",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE firstname NOT LIKE 'amb%%'",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertNotEquals(0, getTotalHits(response));
@@ -456,11 +509,13 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void regexQueryTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE dog_name = REGEXP_QUERY('sn.*', 'INTERSECTION|COMPLEMENT|EMPTY', 10000)",
-            TestsConstants.TEST_INDEX_DOG));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE dog_name = REGEXP_QUERY('sn.*',"
+                    + " 'INTERSECTION|COMPLEMENT|EMPTY', 10000)",
+                TestsConstants.TEST_INDEX_DOG));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -473,11 +528,13 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void negativeRegexQueryTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE NOT(dog_name = REGEXP_QUERY('sn.*', 'INTERSECTION|COMPLEMENT|EMPTY', 10000))",
-            TestsConstants.TEST_INDEX_DOG));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE NOT(dog_name = REGEXP_QUERY('sn.*',"
+                    + " 'INTERSECTION|COMPLEMENT|EMPTY', 10000))",
+                TestsConstants.TEST_INDEX_DOG));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -489,28 +546,36 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void doubleNotTest() throws IOException {
-    JSONObject response1 = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE NOT gender LIKE 'm' AND NOT gender LIKE 'f'",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response1 =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE NOT gender LIKE 'm' AND NOT gender LIKE 'f'",
+                TEST_INDEX_ACCOUNT));
     Assert.assertEquals(0, getTotalHits(response1));
 
-    JSONObject response2 = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE NOT gender LIKE 'm' AND gender NOT LIKE 'f'",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response2 =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE NOT gender LIKE 'm' AND gender NOT LIKE 'f'",
+                TEST_INDEX_ACCOUNT));
     Assert.assertEquals(0, getTotalHits(response2));
 
-    JSONObject response3 = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE gender NOT LIKE 'm' AND gender NOT LIKE 'f'",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response3 =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE gender NOT LIKE 'm' AND gender NOT LIKE 'f'",
+                TEST_INDEX_ACCOUNT));
     Assert.assertEquals(0, getTotalHits(response3));
 
-    JSONObject response4 = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE gender LIKE 'm' AND NOT gender LIKE 'f'",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response4 =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE gender LIKE 'm' AND NOT gender LIKE 'f'",
+                TEST_INDEX_ACCOUNT));
     // Assert there are results and they all have gender 'm'
     Assert.assertNotEquals(0, getTotalHits(response4));
     JSONArray hits = getHits(response4);
@@ -519,16 +584,19 @@ public class QueryIT extends SQLIntegTestCase {
       Assert.assertEquals("m", getSource(hit).getString("gender").toLowerCase());
     }
 
-    JSONObject response5 = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE NOT (gender = 'm' OR gender = 'f')",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response5 =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE NOT (gender = 'm' OR gender = 'f')",
+                TEST_INDEX_ACCOUNT));
     Assert.assertEquals(0, getTotalHits(response5));
   }
 
   @Test
   public void limitTest() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s LIMIT 30",
-        TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s LIMIT 30", TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(30, hits.length());
@@ -538,9 +606,14 @@ public class QueryIT extends SQLIntegTestCase {
   public void betweenTest() throws IOException {
     int min = 27;
     int max = 30;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age BETWEEN %s AND %s LIMIT 1000",
-            TestsConstants.TEST_INDEX_PEOPLE, min, max));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age BETWEEN %s AND %s LIMIT 1000",
+                TestsConstants.TEST_INDEX_PEOPLE,
+                min,
+                max));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -556,9 +629,14 @@ public class QueryIT extends SQLIntegTestCase {
   public void notBetweenTest() throws IOException {
     int min = 20;
     int max = 37;
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age NOT BETWEEN %s AND %s LIMIT 1000",
-            TestsConstants.TEST_INDEX_PEOPLE, min, max));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE age NOT BETWEEN %s AND %s LIMIT 1000",
+                TestsConstants.TEST_INDEX_PEOPLE,
+                min,
+                max));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -575,9 +653,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void inTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT age FROM %s WHERE age IN (20, 22) LIMIT 1000",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT age FROM %s WHERE age IN (20, 22) LIMIT 1000",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -589,10 +670,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void inTestWithStrings() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT phrase FROM %s WHERE phrase IN ('quick', 'fox') LIMIT 1000",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT phrase FROM %s WHERE phrase IN ('quick', 'fox') LIMIT 1000",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -604,12 +687,15 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void inTermsTestWithIdentifiersTreatedLikeStrings() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE name.firstname = IN_TERMS('daenerys','eddard') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name "
+                    + "FROM %s "
+                    + "WHERE name.firstname = IN_TERMS('daenerys','eddard') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(2, getTotalHits(response));
@@ -622,12 +708,15 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void inTermsTestWithStrings() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE name.firstname = IN_TERMS('daenerys','eddard') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name "
+                    + "FROM %s "
+                    + "WHERE name.firstname = IN_TERMS('daenerys','eddard') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(2, getTotalHits(response));
@@ -640,12 +729,15 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void inTermsWithNumbers() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE name.ofHisName = IN_TERMS(4,2) " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name "
+                    + "FROM %s "
+                    + "WHERE name.ofHisName = IN_TERMS(4,2) "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -657,10 +749,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void termQueryWithNumber() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT name FROM %s WHERE name.ofHisName = term(4) LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name FROM %s WHERE name.ofHisName = term(4) LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -672,12 +766,15 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void termQueryWithStringIdentifier() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE name.firstname = term('brandon') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name "
+                    + "FROM %s "
+                    + "WHERE name.firstname = term('brandon') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -689,12 +786,15 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void termQueryWithStringLiteral() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE name.firstname = term('brandon') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name "
+                    + "FROM %s "
+                    + "WHERE name.firstname = term('brandon') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -708,9 +808,12 @@ public class QueryIT extends SQLIntegTestCase {
   //  are returned as well. This may be incorrect behavior.
   @Test
   public void notInTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT age FROM %s WHERE age NOT IN (20, 22) LIMIT 1000",
-            TestsConstants.TEST_INDEX_PEOPLE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT age FROM %s WHERE age NOT IN (20, 22) LIMIT 1000",
+                TestsConstants.TEST_INDEX_PEOPLE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -730,9 +833,12 @@ public class QueryIT extends SQLIntegTestCase {
     DateTimeFormatter formatter = DateTimeFormat.forPattern(TestsConstants.DATE_FORMAT);
     DateTime dateToCompare = new DateTime(2014, 8, 18, 0, 0, 0);
 
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT insert_time FROM %s WHERE insert_time < '2014-08-18'",
-            TestsConstants.TEST_INDEX_ONLINE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT insert_time FROM %s WHERE insert_time < '2014-08-18'",
+                TestsConstants.TEST_INDEX_ONLINE));
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
       JSONObject hit = hits.getJSONObject(i);
@@ -740,8 +846,8 @@ public class QueryIT extends SQLIntegTestCase {
       DateTime insertTime = formatter.parseDateTime(source.getString("insert_time"));
 
       String errorMessage =
-          String.format(Locale.ROOT, "insert_time must be before 2014-08-18. Found: %s",
-              insertTime);
+          String.format(
+              Locale.ROOT, "insert_time must be before 2014-08-18. Found: %s", insertTime);
       Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
     }
   }
@@ -751,10 +857,12 @@ public class QueryIT extends SQLIntegTestCase {
     DateTimeFormatter formatter = DateTimeFormat.forPattern(TestsConstants.TS_DATE_FORMAT);
     DateTime dateToCompare = new DateTime(2015, 3, 15, 0, 0, 0);
 
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT odbc_time FROM %s WHERE odbc_time < {ts '2015-03-15 00:00:00.000'}",
-            TestsConstants.TEST_INDEX_ODBC));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT odbc_time FROM %s WHERE odbc_time < {ts '2015-03-15 00:00:00.000'}",
+                TestsConstants.TEST_INDEX_ODBC));
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
       JSONObject hit = hits.getJSONObject(i);
@@ -764,8 +872,8 @@ public class QueryIT extends SQLIntegTestCase {
 
       DateTime insertTime = formatter.parseDateTime(insertTimeStr);
       String errorMessage =
-          String.format(Locale.ROOT, "insert_time must be before 2015-03-15. Found: %s",
-              insertTime);
+          String.format(
+              Locale.ROOT, "insert_time must be before 2015-03-15. Found: %s", insertTime);
       Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
     }
   }
@@ -777,20 +885,24 @@ public class QueryIT extends SQLIntegTestCase {
     DateTime dateLimit1 = new DateTime(2014, 8, 18, 0, 0, 0);
     DateTime dateLimit2 = new DateTime(2014, 8, 21, 0, 0, 0);
 
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT insert_time " +
-                "FROM %s " +
-                "WHERE insert_time BETWEEN '2014-08-18' AND '2014-08-21' " +
-                "LIMIT 3",
-            TestsConstants.TEST_INDEX_ONLINE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT insert_time "
+                    + "FROM %s "
+                    + "WHERE insert_time BETWEEN '2014-08-18' AND '2014-08-21' "
+                    + "LIMIT 3",
+                TestsConstants.TEST_INDEX_ONLINE));
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
       JSONObject hit = hits.getJSONObject(i);
       JSONObject source = getSource(hit);
       DateTime insertTime = formatter.parseDateTime(source.getString("insert_time"));
 
-      boolean isBetween = (insertTime.isAfter(dateLimit1) || insertTime.isEqual(dateLimit1)) &&
-          (insertTime.isBefore(dateLimit2) || insertTime.isEqual(dateLimit2));
+      boolean isBetween =
+          (insertTime.isAfter(dateLimit1) || insertTime.isEqual(dateLimit1))
+              && (insertTime.isBefore(dateLimit2) || insertTime.isEqual(dateLimit2));
 
       Assert.assertTrue("insert_time must be between 2014-08-18 and 2014-08-21", isBetween);
     }
@@ -798,9 +910,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void missFilterSearch() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE insert_time2 IS missing",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE insert_time2 IS missing",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(4, getTotalHits(response));
@@ -814,9 +929,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void notMissFilterSearch() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE insert_time2 IS NOT missing",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE insert_time2 IS NOT missing",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(2, getTotalHits(response));
@@ -830,15 +948,19 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void complexConditionQuery() throws IOException {
-    String errorMessage = "Result does not exist to the condition " +
-        "(gender='m' AND (age> 25 OR account_number>5)) OR (gender='f' AND (age>30 OR account_number < 8)";
+    String errorMessage =
+        "Result does not exist to the condition (gender='m' AND (age> 25 OR account_number>5)) OR"
+            + " (gender='f' AND (age>30 OR account_number < 8)";
 
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE (gender='m' AND (age> 25 OR account_number>5)) " +
-                "OR (gender='f' AND (age>30 OR account_number < 8))",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE (gender='m' AND (age> 25 OR account_number>5)) "
+                    + "OR (gender='f' AND (age>30 OR account_number < 8))",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -849,7 +971,8 @@ public class QueryIT extends SQLIntegTestCase {
       int age = source.getInt("age");
       int accountNumber = source.getInt("account_number");
 
-      Assert.assertTrue(errorMessage,
+      Assert.assertTrue(
+          errorMessage,
           (gender.equals("m") && (age > 25 || accountNumber > 5))
               || (gender.equals("f") && (age > 30 || accountNumber < 8)));
     }
@@ -857,16 +980,20 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void complexNotConditionQuery() throws IOException {
-    String errorMessage = "Result does not exist to the condition " +
-        "NOT (gender='m' AND NOT (age > 25 OR account_number > 5)) " +
-        "OR (NOT gender='f' AND NOT (age > 30 OR account_number < 8))";
+    String errorMessage =
+        "Result does not exist to the condition "
+            + "NOT (gender='m' AND NOT (age > 25 OR account_number > 5)) "
+            + "OR (NOT gender='f' AND NOT (age > 30 OR account_number < 8))";
 
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE NOT (gender='m' AND NOT (age > 25 OR account_number > 5)) " +
-                "OR (NOT gender='f' AND NOT (age > 30 OR account_number < 8))",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE NOT (gender='m' AND NOT (age > 25 OR account_number > 5)) "
+                    + "OR (NOT gender='f' AND NOT (age > 30 OR account_number < 8))",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertNotEquals(0, hits.length());
@@ -878,7 +1005,8 @@ public class QueryIT extends SQLIntegTestCase {
       int age = source.getInt("age");
       int accountNumber = source.getInt("account_number");
 
-      Assert.assertTrue(errorMessage,
+      Assert.assertTrue(
+          errorMessage,
           !(gender.equals("m") && !(age > 25 || accountNumber > 5))
               || (!gender.equals("f") && !(age > 30 || accountNumber < 8)));
     }
@@ -887,9 +1015,10 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   @SuppressWarnings("unchecked")
   public void orderByAscTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT age FROM %s ORDER BY age ASC LIMIT 1000",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT age FROM %s ORDER BY age ASC LIMIT 1000", TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     ArrayList<Integer> ages = new ArrayList<>();
@@ -907,17 +1036,23 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void orderByDescTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT age FROM %s ORDER BY age DESC LIMIT 1000",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT age FROM %s ORDER BY age DESC LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
     assertResponseForOrderByTest(response);
   }
 
   @Test
   public void orderByDescUsingTableAliasTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT a.age FROM %s a ORDER BY a.age DESC LIMIT 1000",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT a.age FROM %s a ORDER BY a.age DESC LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
     assertResponseForOrderByTest(response);
   }
 
@@ -940,13 +1075,16 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   @SuppressWarnings("unchecked")
   public void orderByAscFieldWithSpaceTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE `test field` IS NOT null " +
-                "ORDER BY `test field` ASC " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE `test field` IS NOT null "
+                    + "ORDER BY `test field` ASC "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     ArrayList<Integer> testFields = new ArrayList<>();
@@ -964,195 +1102,177 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void testWhereWithBoolEqualsTrue() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male = true " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male = true " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkResponseSize(response, BANK_INDEX_MALE_TRUE);
   }
 
   @Test
   public void testWhereWithBoolEqualsTrueAndGroupBy() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male = true " +
-                "GROUP BY balance " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male = true " + "GROUP BY balance " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkAggregationResponseSize(response, BANK_INDEX_MALE_TRUE);
   }
 
   @Test
   public void testWhereWithBoolEqualsTrueAndOrderBy() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male = true " +
-                "ORDER BY age " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male = true " + "ORDER BY age " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkResponseSize(response, BANK_INDEX_MALE_TRUE);
   }
 
   @Test
   public void testWhereWithBoolIsTrue() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male IS true " +
-                "GROUP BY balance " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male IS true " + "GROUP BY balance " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkAggregationResponseSize(response, BANK_INDEX_MALE_TRUE);
   }
 
   @Test
   public void testWhereWithBoolIsNotTrue() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male IS NOT true " +
-                "GROUP BY balance " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE male IS NOT true "
+                    + "GROUP BY balance "
+                    + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkAggregationResponseSize(response, BANK_INDEX_MALE_FALSE);
   }
 
   @Test
   public void testWhereWithBoolEqualsFalse() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male = false " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male = false " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkResponseSize(response, BANK_INDEX_MALE_FALSE);
   }
 
   @Test
   public void testWhereWithBoolEqualsFalseAndGroupBy() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male = false " +
-                "GROUP BY balance " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male = false " + "GROUP BY balance " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkAggregationResponseSize(response, BANK_INDEX_MALE_FALSE);
   }
 
   @Test
   public void testWhereWithBoolEqualsFalseAndOrderBy() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male = false " +
-                "ORDER BY age " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male = false " + "ORDER BY age " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkResponseSize(response, BANK_INDEX_MALE_FALSE);
   }
 
   @Test
   public void testWhereWithBoolIsFalse() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male IS false " +
-                "GROUP BY balance " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * " + "FROM %s " + "WHERE male IS false " + "GROUP BY balance " + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkAggregationResponseSize(response, BANK_INDEX_MALE_FALSE);
   }
 
   @Test
   public void testWhereWithBoolIsNotFalse() throws IOException {
-    JSONObject response = executeQuery(
-        StringUtils.format(
-            "SELECT * " +
-                "FROM %s " +
-                "WHERE male IS NOT false " +
-                "GROUP BY balance " +
-                "LIMIT 5",
-            TestsConstants.TEST_INDEX_BANK)
-    );
+    JSONObject response =
+        executeQuery(
+            StringUtils.format(
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE male IS NOT false "
+                    + "GROUP BY balance "
+                    + "LIMIT 5",
+                TestsConstants.TEST_INDEX_BANK));
 
     checkAggregationResponseSize(response, BANK_INDEX_MALE_TRUE);
   }
 
   @Test
   public void testMultiPartWhere() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE (firstname LIKE 'opal' OR firstname LIKE 'rodriquez') " +
-                "AND (state like 'oh' OR state like 'hi')",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE (firstname LIKE 'opal' OR firstname LIKE 'rodriquez') "
+                    + "AND (state like 'oh' OR state like 'hi')",
+                TEST_INDEX_ACCOUNT));
 
     Assert.assertEquals(2, getTotalHits(response));
   }
 
   @Test
   public void testMultiPartWhere2() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE ((account_number > 200 AND account_number < 300) OR gender LIKE 'm') " +
-                "AND (state LIKE 'hi' OR address LIKE 'avenue')",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE ((account_number > 200 AND account_number < 300) OR gender LIKE 'm') "
+                    + "AND (state LIKE 'hi' OR address LIKE 'avenue')",
+                TEST_INDEX_ACCOUNT));
 
     Assert.assertEquals(127, getTotalHits(response));
   }
 
   @Test
   public void testMultiPartWhere3() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE ((account_number > 25 AND account_number < 75) AND age >35 ) " +
-                "AND (state LIKE 'md' OR (address LIKE 'avenue' OR address LIKE 'street'))",
-            TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE ((account_number > 25 AND account_number < 75) AND age >35 ) "
+                    + "AND (state LIKE 'md' OR (address LIKE 'avenue' OR address LIKE 'street'))",
+                TEST_INDEX_ACCOUNT));
 
     Assert.assertEquals(7, getTotalHits(response));
   }
 
   @Test
   public void filterPolygonTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE GEO_INTERSECTS(place,'POLYGON ((102 2, 103 2, 103 3, 102 3, 102 2))')",
-            TestsConstants.TEST_INDEX_LOCATION));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE GEO_INTERSECTS(place,'POLYGON ((102 2, 103 2, 103 3, 102 3, 102 2))')",
+                TestsConstants.TEST_INDEX_LOCATION));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -1163,10 +1283,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void boundingBox() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE GEO_BOUNDING_BOX(center, 100.0, 1.0, 101, 0.0)",
-            TestsConstants.TEST_INDEX_LOCATION));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE GEO_BOUNDING_BOX(center, 100.0, 1.0, 101, 0.0)",
+                TestsConstants.TEST_INDEX_LOCATION));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -1177,10 +1299,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void geoDistance() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE GEO_DISTANCE(center, '1km', 100.5, 0.500001)",
-            TestsConstants.TEST_INDEX_LOCATION));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE GEO_DISTANCE(center, '1km', 100.5, 0.500001)",
+                TestsConstants.TEST_INDEX_LOCATION));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -1191,10 +1315,12 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void geoPolygon() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT * FROM %s WHERE GEO_POLYGON(center, 100,0, 100.5, 2, 101.0,0)",
-            TestsConstants.TEST_INDEX_LOCATION));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE GEO_POLYGON(center, 100,0, 100.5, 2, 101.0,0)",
+                TestsConstants.TEST_INDEX_LOCATION));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -1206,36 +1332,45 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void escapedCharactersCheck() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE MATCH_PHRASE(nickname, 'Daenerys \"Stormborn\"') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE MATCH_PHRASE(nickname, 'Daenerys \"Stormborn\"') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     Assert.assertEquals(1, getTotalHits(response));
   }
 
   @Test
   public void complexObjectSearch() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE MATCH_PHRASE(name.firstname, 'Jaime') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE MATCH_PHRASE(name.firstname, 'Jaime') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     Assert.assertEquals(1, getTotalHits(response));
   }
 
   @Test
   public void complexObjectReturnField() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT parents.father " +
-                "FROM %s " +
-                "WHERE MATCH_PHRASE(name.firstname, 'Brandon') " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT parents.father "
+                    + "FROM %s "
+                    + "WHERE MATCH_PHRASE(name.firstname, 'Brandon') "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, getTotalHits(response));
@@ -1246,14 +1381,18 @@ public class QueryIT extends SQLIntegTestCase {
 
   /**
    * TODO: Fields prefixed with @ gets converted to SQLVariantRefExpr instead of SQLIdentifierExpr
-   * Either change SQLVariantRefExpr to SQLIdentifierExpr
-   * Or handle the special case for SQLVariantRefExpr
+   * Either change SQLVariantRefExpr to SQLIdentifierExpr Or handle the special case for
+   * SQLVariantRefExpr
    */
   @Ignore
   @Test
   public void queryWithAtFieldOnWhere() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s where @wolf = 'Summer' LIMIT 1000", TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s where @wolf = 'Summer' LIMIT 1000",
+                TEST_INDEX_GAME_OF_THRONES));
     Assert.assertEquals(1, getTotalHits(response));
     JSONObject hit = getHits(response).getJSONObject(0);
     Assert.assertEquals("Summer", hit.get("@wolf"));
@@ -1265,19 +1404,22 @@ public class QueryIT extends SQLIntegTestCase {
     TestUtils.createHiddenIndexByRestClient(client(), ".bank", null);
     TestUtils.loadDataByRestClient(client(), ".bank", "/src/test/resources/.bank.json");
 
-    String response = executeQuery("SELECT education FROM .bank WHERE account_number = 12345",
-        "jdbc");
+    String response =
+        executeQuery("SELECT education FROM .bank WHERE account_number = 12345", "jdbc");
     Assert.assertTrue(response.contains("PhD"));
   }
 
   @Test
   public void notLikeTests() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE name.firstname NOT LIKE 'd%%' AND name IS NOT NULL " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name "
+                    + "FROM %s "
+                    + "WHERE name.firstname NOT LIKE 'd%%' AND name IS NOT NULL "
+                    + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(3, getTotalHits(response));
@@ -1286,45 +1428,49 @@ public class QueryIT extends SQLIntegTestCase {
       JSONObject source = getSource(hit);
 
       String name = source.getJSONObject("name").getString("firstname");
-      Assert
-          .assertFalse(String.format(Locale.ROOT, "Name [%s] should not match pattern [d%%]", name),
-              name.startsWith("d"));
+      Assert.assertFalse(
+          String.format(Locale.ROOT, "Name [%s] should not match pattern [d%%]", name),
+          name.startsWith("d"));
     }
   }
 
   @Test
   public void isNullTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE nickname IS NULL " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name " + "FROM %s " + "WHERE nickname IS NULL " + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     Assert.assertEquals(6, getTotalHits(response));
   }
 
   @Test
   public void isNotNullTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT name " +
-                "FROM %s " +
-                "WHERE nickname IS NOT NULL " +
-                "LIMIT 1000",
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT name " + "FROM %s " + "WHERE nickname IS NOT NULL " + "LIMIT 1000",
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     Assert.assertEquals(1, getTotalHits(response));
   }
 
   @Test
   public void innerQueryTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s D " +
-                "WHERE holdersName IN (SELECT firstname " +
-                "FROM %s " +
-                "WHERE firstname = 'Hattie')",
-            TestsConstants.TEST_INDEX_DOG, TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s D "
+                    + "WHERE holdersName IN (SELECT firstname "
+                    + "FROM %s "
+                    + "WHERE firstname = 'Hattie')",
+                TestsConstants.TEST_INDEX_DOG,
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -1339,19 +1485,22 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void twoSubQueriesTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE holdersName IN (SELECT firstname " +
-                "FROM %s " +
-                "WHERE firstname = 'Hattie') " +
-                "AND age IN (SELECT name.ofHisName " +
-                "FROM %s " +
-                "WHERE name.firstname <> 'Daenerys' " +
-                "AND name.ofHisName IS NOT NULL) ",
-            TestsConstants.TEST_INDEX_DOG,
-            TEST_INDEX_ACCOUNT,
-            TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE holdersName IN (SELECT firstname "
+                    + "FROM %s "
+                    + "WHERE firstname = 'Hattie') "
+                    + "AND age IN (SELECT name.ofHisName "
+                    + "FROM %s "
+                    + "WHERE name.firstname <> 'Daenerys' "
+                    + "AND name.ofHisName IS NOT NULL) ",
+                TestsConstants.TEST_INDEX_DOG,
+                TEST_INDEX_ACCOUNT,
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -1366,14 +1515,18 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void inTermsSubQueryTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE age = IN_TERMS (SELECT name.ofHisName " +
-                "FROM %s " +
-                "WHERE name.firstname <> 'Daenerys' " +
-                "AND name.ofHisName IS NOT NULL)",
-            TestsConstants.TEST_INDEX_DOG, TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE age = IN_TERMS (SELECT name.ofHisName "
+                    + "FROM %s "
+                    + "WHERE name.firstname <> 'Daenerys' "
+                    + "AND name.ofHisName IS NOT NULL)",
+                TestsConstants.TEST_INDEX_DOG,
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -1388,9 +1541,12 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void idsQueryOneId() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE _id = IDS_QUERY(dog, 1)",
-            TestsConstants.TEST_INDEX_DOG));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE _id = IDS_QUERY(dog, 1)",
+                TestsConstants.TEST_INDEX_DOG));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -1405,9 +1561,12 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void idsQueryMultipleId() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE _id = IDS_QUERY(dog, 1, 2, 3)",
-            TestsConstants.TEST_INDEX_DOG));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE _id = IDS_QUERY(dog, 1, 2, 3)",
+                TestsConstants.TEST_INDEX_DOG));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -1422,14 +1581,18 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void idsQuerySubQueryIds() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE _id = IDS_QUERY(dog, (SELECT name.ofHisName " +
-                "FROM %s " +
-                "WHERE name.firstname <> 'Daenerys' " +
-                "AND name.ofHisName IS NOT NULL))",
-            TestsConstants.TEST_INDEX_DOG, TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE _id = IDS_QUERY(dog, (SELECT name.ofHisName "
+                    + "FROM %s "
+                    + "WHERE name.firstname <> 'Daenerys' "
+                    + "AND name.ofHisName IS NOT NULL))",
+                TestsConstants.TEST_INDEX_DOG,
+                TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(1, hits.length());
@@ -1443,18 +1606,24 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void nestedEqualsTestFieldNormalField() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE nested(message.info)='b'",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE nested(message.info)='b'",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     Assert.assertEquals(1, getTotalHits(response));
   }
 
   @Test
   public void nestedEqualsTestFieldInsideArrays() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * FROM %s WHERE nested(message.info) = 'a'",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s WHERE nested(message.info) = 'a'",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     Assert.assertEquals(2, getTotalHits(response));
   }
@@ -1462,106 +1631,124 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore // Seems like we don't support nested with IN, throwing IllegalArgumentException
   @Test
   public void nestedOnInQuery() throws IOException {
-    JSONObject response = executeQuery(String.format(Locale.ROOT,
-        "SELECT * FROM %s where nested(message.info) IN ('a','b')", TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * FROM %s where nested(message.info) IN ('a','b')",
+                TEST_INDEX_NESTED_TYPE));
     Assert.assertEquals(3, getTotalHits(response));
   }
 
   @Test
   public void complexNestedQueryBothOnSameObject() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE nested('message', message.info = 'a' AND message.author ='i')",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE nested('message', message.info = 'a' AND message.author ='i')",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     Assert.assertEquals(1, getTotalHits(response));
   }
 
   @Test
   public void complexNestedQueryNotBothOnSameObject() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE nested('message', message.info = 'a' AND message.author ='h')",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * "
+                    + "FROM %s "
+                    + "WHERE nested('message', message.info = 'a' AND message.author ='h')",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     Assert.assertEquals(0, getTotalHits(response));
   }
 
   @Test
   public void nestedOnInTermsQuery() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT * " +
-                "FROM %s " +
-                "WHERE nested(message.info) = IN_TERMS('a', 'b')",
-            TestsConstants.TEST_INDEX_NESTED_TYPE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT * " + "FROM %s " + "WHERE nested(message.info) = IN_TERMS('a', 'b')",
+                TestsConstants.TEST_INDEX_NESTED_TYPE));
 
     Assert.assertEquals(3, getTotalHits(response));
   }
 
   // TODO Uncomment these after problem with loading join index is resolved
-//    @Test
-//    public void childrenEqualsTestFieldNormalField() throws IOException {
-//        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
-//                                      "FROM %s/joinType " +
-//                                      "WHERE children(childrenType, info) = 'b'", TestsConstants.TEST_INDEX_JOIN_TYPE));
-//
-//        Assert.assertEquals(1, getTotalHits(response));
-//    }
-//
-//    @Test
-//    public void childrenOnInQuery() throws IOException {
-//        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
-//                                      "FROM %s/joinType " +
-//                                      "WHERE children(childrenType, info) IN ('a', 'b')",
-//                                TestsConstants.TEST_INDEX_JOIN_TYPE));
-//
-//        Assert.assertEquals(2, getTotalHits(response));
-//    }
-//
-//    @Test
-//    public void complexChildrenQueryBothOnSameObject() throws IOException {
-//        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
-//                                      "FROM %s/joinType " +
-//                                      "WHERE children(childrenType, info = 'a' AND author ='e')",
-//                                TestsConstants.TEST_INDEX_JOIN_TYPE));
-//
-//        Assert.assertEquals(1, getTotalHits(response));
-//    }
-//
-//    @Test
-//    public void complexChildrenQueryNotOnSameObject() throws IOException {
-//        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
-//                                      "FROM %s/joinType " +
-//                                      "WHERE children(childrenType, info = 'a' AND author ='j')",
-//                                TestsConstants.TEST_INDEX_JOIN_TYPE));
-//
-//        Assert.assertEquals(0, getTotalHits(response));
-//    }
-//
-//    @Test
-//    public void childrenOnInTermsQuery() throws IOException {
-//        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
-//                                      "FROM %s/joinType " +
-//                                      "WHERE children(childrenType, info) = IN_TERMS(a, b)",
-//                                TestsConstants.TEST_INDEX_JOIN_TYPE));
-//
-//        Assert.assertEquals(2, getTotalHits(response));
-//    }
+  //    @Test
+  //    public void childrenEqualsTestFieldNormalField() throws IOException {
+  //        JSONObject response = executeQuery(
+  //                        String.format(Locale.ROOT, "SELECT * " +
+  //                                      "FROM %s/joinType " +
+  //                                      "WHERE children(childrenType, info) = 'b'",
+  // TestsConstants.TEST_INDEX_JOIN_TYPE));
+  //
+  //        Assert.assertEquals(1, getTotalHits(response));
+  //    }
+  //
+  //    @Test
+  //    public void childrenOnInQuery() throws IOException {
+  //        JSONObject response = executeQuery(
+  //                        String.format(Locale.ROOT, "SELECT * " +
+  //                                      "FROM %s/joinType " +
+  //                                      "WHERE children(childrenType, info) IN ('a', 'b')",
+  //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
+  //
+  //        Assert.assertEquals(2, getTotalHits(response));
+  //    }
+  //
+  //    @Test
+  //    public void complexChildrenQueryBothOnSameObject() throws IOException {
+  //        JSONObject response = executeQuery(
+  //                        String.format(Locale.ROOT, "SELECT * " +
+  //                                      "FROM %s/joinType " +
+  //                                      "WHERE children(childrenType, info = 'a' AND author
+  // ='e')",
+  //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
+  //
+  //        Assert.assertEquals(1, getTotalHits(response));
+  //    }
+  //
+  //    @Test
+  //    public void complexChildrenQueryNotOnSameObject() throws IOException {
+  //        JSONObject response = executeQuery(
+  //                        String.format(Locale.ROOT, "SELECT * " +
+  //                                      "FROM %s/joinType " +
+  //                                      "WHERE children(childrenType, info = 'a' AND author
+  // ='j')",
+  //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
+  //
+  //        Assert.assertEquals(0, getTotalHits(response));
+  //    }
+  //
+  //    @Test
+  //    public void childrenOnInTermsQuery() throws IOException {
+  //        JSONObject response = executeQuery(
+  //                        String.format(Locale.ROOT, "SELECT * " +
+  //                                      "FROM %s/joinType " +
+  //                                      "WHERE children(childrenType, info) = IN_TERMS(a, b)",
+  //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
+  //
+  //        Assert.assertEquals(2, getTotalHits(response));
+  //    }
 
   @Ignore // the hint does not really work, NoSuchIndexException is thrown
   @Test
   public void multipleIndicesOneNotExistWithHint() throws IOException {
 
-    JSONObject response = executeQuery(String
-        .format(Locale.ROOT, "SELECT /*! IGNORE_UNAVAILABLE */ * FROM %s,%s ", TEST_INDEX_ACCOUNT,
-            "badindex"));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT /*! IGNORE_UNAVAILABLE */ * FROM %s,%s ",
+                TEST_INDEX_ACCOUNT,
+                "badindex"));
 
     Assert.assertTrue(getTotalHits(response) > 0);
   }
@@ -1573,8 +1760,8 @@ public class QueryIT extends SQLIntegTestCase {
           String.format(Locale.ROOT, "SELECT * FROM %s, %s", TEST_INDEX_ACCOUNT, "badindex"));
       Assert.fail("Expected exception, but call succeeded");
     } catch (ResponseException e) {
-      Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(),
-          e.getResponse().getStatusLine().getStatusCode());
+      Assert.assertEquals(
+          RestStatus.BAD_REQUEST.getStatus(), e.getResponse().getStatusLine().getStatusCode());
       final String entity = TestUtils.getResponseBody(e.getResponse());
       Assert.assertThat(entity, containsString("\"type\": \"IndexNotFoundException\""));
     }
@@ -1582,29 +1769,36 @@ public class QueryIT extends SQLIntegTestCase {
 
   // TODO Find way to check routing() without SearchRequestBuilder
   //  to properly update these tests to OpenSearchIntegTestCase format
-//    @Test
-//    public void routingRequestOneRounting() throws IOException {
-//        SqlElasticSearchRequestBuilder request = getRequestBuilder(String.format(Locale.ROOT,
-//                                  "SELECT /*! ROUTINGS(hey) */ * FROM %s ", TEST_INDEX_ACCOUNT));
-//        SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) request.getBuilder();
-//        Assert.assertEquals("hey",searchRequestBuilder.request().routing());
-//    }
-//
-//    @Test
-//    public void routingRequestMultipleRountings() throws IOException {
-//        SqlElasticSearchRequestBuilder request = getRequestBuilder(String.format(Locale.ROOT,
-//                                  "SELECT /*! ROUTINGS(hey,bye) */ * FROM %s ", TEST_INDEX_ACCOUNT));
-//        SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) request.getBuilder();
-//        Assert.assertEquals("hey,bye",searchRequestBuilder.request().routing());
-//    }
+  //    @Test
+  //    public void routingRequestOneRounting() throws IOException {
+  //        SqlElasticSearchRequestBuilder request = getRequestBuilder(String.format(Locale.ROOT,
+  //                                  "SELECT /*! ROUTINGS(hey) */ * FROM %s ",
+  // TEST_INDEX_ACCOUNT));
+  //        SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) request.getBuilder();
+  //        Assert.assertEquals("hey",searchRequestBuilder.request().routing());
+  //    }
+  //
+  //    @Test
+  //    public void routingRequestMultipleRountings() throws IOException {
+  //        SqlElasticSearchRequestBuilder request = getRequestBuilder(String.format(Locale.ROOT,
+  //                                  "SELECT /*! ROUTINGS(hey,bye) */ * FROM %s ",
+  // TEST_INDEX_ACCOUNT));
+  //        SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) request.getBuilder();
+  //        Assert.assertEquals("hey,bye",searchRequestBuilder.request().routing());
+  //    }
 
   @Ignore // Getting parser error: syntax error, expect RPAREN, actual IDENTIFIER insert_time
   @Test
   public void scriptFilterNoParams() throws IOException {
 
-    JSONObject result = executeQuery(String.format(Locale.ROOT,
-        "SELECT insert_time FROM %s where script('doc[\\'insert_time\''].date.hourOfDay==16') " +
-            "and insert_time <'2014-08-21T00:00:00.000Z'", TEST_INDEX_ONLINE));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT insert_time FROM %s where"
+                    + " script('doc[\\'insert_time\''].date.hourOfDay==16') and insert_time"
+                    + " <'2014-08-21T00:00:00.000Z'",
+                TEST_INDEX_ONLINE));
     Assert.assertEquals(237, getTotalHits(result));
   }
 
@@ -1612,20 +1806,28 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   public void scriptFilterWithParams() throws IOException {
 
-    JSONObject result = executeQuery(String.format(Locale.ROOT,
-        "SELECT insert_time FROM %s where script('doc[\\'insert_time\''].date.hourOfDay==x','x'=16) " +
-            "and insert_time <'2014-08-21T00:00:00.000Z'", TEST_INDEX_ONLINE));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT insert_time FROM %s where"
+                    + " script('doc[\\'insert_time\''].date.hourOfDay==x','x'=16) and insert_time"
+                    + " <'2014-08-21T00:00:00.000Z'",
+                TEST_INDEX_ONLINE));
     Assert.assertEquals(237, getTotalHits(result));
   }
 
   @Test
   public void highlightPreTagsAndPostTags() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT,
-            "SELECT /*! HIGHLIGHT(phrase, pre_tags : ['<b>'], post_tags : ['</b>']) */ " +
-                "* FROM %s " +
-                "WHERE phrase LIKE 'fox' " +
-                "ORDER BY _score", TestsConstants.TEST_INDEX_PHRASE));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT /*! HIGHLIGHT(phrase, pre_tags : ['<b>'], post_tags : ['</b>']) */ "
+                    + "* FROM %s "
+                    + "WHERE phrase LIKE 'fox' "
+                    + "ORDER BY _score",
+                TestsConstants.TEST_INDEX_PHRASE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -1640,13 +1842,17 @@ public class QueryIT extends SQLIntegTestCase {
   @Ignore
   @Test
   public void fieldCollapsingTest() throws IOException {
-    JSONObject response = executeQuery(
-        String.format(Locale.ROOT, "SELECT /*! COLLAPSE({\"field\":\"age\"," +
-            "\"inner_hits\":{\"name\": \"account\"," +
-            "\"size\":1," +
-            "\"sort\":[{\"age\":\"asc\"}]}," +
-            "\"max_concurrent_group_searches\": 4}) */ " +
-            "* FROM %s", TEST_INDEX_ACCOUNT));
+    JSONObject response =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "SELECT /*! COLLAPSE({\"field\":\"age\","
+                    + "\"inner_hits\":{\"name\": \"account\","
+                    + "\"size\":1,"
+                    + "\"sort\":[{\"age\":\"asc\"}]},"
+                    + "\"max_concurrent_group_searches\": 4}) */ "
+                    + "* FROM %s",
+                TEST_INDEX_ACCOUNT));
 
     JSONArray hits = getHits(response);
     Assert.assertEquals(21, hits.length());
@@ -1656,8 +1862,8 @@ public class QueryIT extends SQLIntegTestCase {
   @Test
   public void backticksQuotedIndexNameTest() throws Exception {
     TestUtils.createIndexByRestClient(client(), "bank_unquote", null);
-    TestUtils
-        .loadDataByRestClient(client(), "bank", "/src/test/resources/bank_for_unquote_test.json");
+    TestUtils.loadDataByRestClient(
+        client(), "bank", "/src/test/resources/bank_for_unquote_test.json");
 
     JSONArray hits = getHits(executeQuery("SELECT lastname FROM `bank`"));
     Object responseIndex = ((JSONObject) hits.get(0)).query("/_index");
@@ -1665,39 +1871,57 @@ public class QueryIT extends SQLIntegTestCase {
 
     assertEquals(
         executeQuery("SELECT lastname FROM bank", "jdbc"),
-        executeQuery("SELECT `bank`.`lastname` FROM `bank`", "jdbc")
-    );
+        executeQuery("SELECT `bank`.`lastname` FROM `bank`", "jdbc"));
 
     assertEquals(
         executeQuery(
-            "SELECT `b`.`age` AS `AGE`, AVG(`b`.`balance`) FROM `bank` AS `b` " +
-                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`age` ORDER BY `b`.`age`",
+            "SELECT `b`.`age` AS `AGE`, AVG(`b`.`balance`) FROM `bank` AS `b` "
+                + "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`age` ORDER BY `b`.`age`",
             "jdbc"),
-        executeQuery("SELECT b.age AS AGE, AVG(balance) FROM bank AS b " +
-                "WHERE ABS(age) > 20 GROUP BY b.age ORDER BY b.age",
-            "jdbc")
-    );
+        executeQuery(
+            "SELECT b.age AS AGE, AVG(balance) FROM bank AS b "
+                + "WHERE ABS(age) > 20 GROUP BY b.age ORDER BY b.age",
+            "jdbc"));
   }
 
   @Test
   public void backticksQuotedFieldNamesTest() {
-    String expected = executeQuery(StringUtils.format("SELECT b.lastname FROM %s " +
-        "AS b ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
-    String quotedFieldResult = executeQuery(StringUtils.format("SELECT b.`lastname` FROM %s " +
-        "AS b ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT b.lastname FROM %s " + "AS b ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
+    String quotedFieldResult =
+        executeQuery(
+            StringUtils.format(
+                "SELECT b.`lastname` FROM %s " + "AS b ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
 
     assertEquals(expected, quotedFieldResult);
   }
 
   @Test
   public void backticksQuotedAliasTest() {
-    String expected = executeQuery(StringUtils.format("SELECT b.lastname FROM %s " +
-        "AS b ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
-    String quotedAliasResult = executeQuery(StringUtils.format("SELECT `b`.lastname FROM %s" +
-        " AS `b` ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT b.lastname FROM %s " + "AS b ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
+    String quotedAliasResult =
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.lastname FROM %s" + " AS `b` ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
     String quotedAliasAndFieldResult =
-        executeQuery(StringUtils.format("SELECT `b`.`lastname` FROM %s " +
-            "AS `b` ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b`.`lastname` FROM %s " + "AS `b` ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
 
     assertEquals(expected, quotedAliasResult);
     assertEquals(expected, quotedAliasAndFieldResult);
@@ -1705,19 +1929,28 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void backticksQuotedAliasWithSpecialCharactersTest() {
-    String expected = executeQuery(StringUtils.format("SELECT b.lastname FROM %s " +
-        "AS b ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
+    String expected =
+        executeQuery(
+            StringUtils.format(
+                "SELECT b.lastname FROM %s " + "AS b ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
     String specialCharAliasResult =
-        executeQuery(StringUtils.format("SELECT `b k`.lastname FROM %s " +
-            "AS `b k` ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK), "jdbc");
+        executeQuery(
+            StringUtils.format(
+                "SELECT `b k`.lastname FROM %s " + "AS `b k` ORDER BY age LIMIT 3",
+                TestsConstants.TEST_INDEX_BANK),
+            "jdbc");
 
     assertEquals(expected, specialCharAliasResult);
   }
 
   @Test
   public void backticksQuotedAliasInJDBCResponseTest() {
-    String query = StringUtils.format("SELECT `b`.`lastname` AS `name` FROM %s AS `b` " +
-        "ORDER BY age LIMIT 3", TestsConstants.TEST_INDEX_BANK);
+    String query =
+        StringUtils.format(
+            "SELECT `b`.`lastname` AS `name` FROM %s AS `b` " + "ORDER BY age LIMIT 3",
+            TestsConstants.TEST_INDEX_BANK);
     String response = executeQuery(query, "jdbc");
 
     assertTrue(response.contains("\"alias\": \"name\""));
@@ -1725,10 +1958,14 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void caseWhenSwitchTest() throws IOException {
-    JSONObject response = executeQuery("SELECT CASE age " +
-        "WHEN 30 THEN '1' " +
-        "WHEN 40 THEN '2' " +
-        "ELSE '0' END AS cases FROM " + TEST_INDEX_ACCOUNT + " WHERE age IS NOT NULL");
+    JSONObject response =
+        executeQuery(
+            "SELECT CASE age "
+                + "WHEN 30 THEN '1' "
+                + "WHEN 40 THEN '2' "
+                + "ELSE '0' END AS cases FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE age IS NOT NULL");
     JSONObject hit = getHits(response).getJSONObject(0);
     String age = hit.query("/_source/age").toString();
     String cases = age.equals("30") ? "1" : age.equals("40") ? "2" : "0";
@@ -1738,49 +1975,61 @@ public class QueryIT extends SQLIntegTestCase {
 
   @Test
   public void caseWhenJdbcResponseTest() {
-    String response = executeQuery("SELECT CASE age " +
-        "WHEN 30 THEN 'age is 30' " +
-        "WHEN 40 THEN 'age is 40' " +
-        "ELSE 'NA' END AS cases FROM " + TEST_INDEX_ACCOUNT + " WHERE age is not null", "jdbc");
+    String response =
+        executeQuery(
+            "SELECT CASE age "
+                + "WHEN 30 THEN 'age is 30' "
+                + "WHEN 40 THEN 'age is 40' "
+                + "ELSE 'NA' END AS cases FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE age is not null",
+            "jdbc");
     assertTrue(
-        response.contains("age is 30") ||
-            response.contains("age is 40") ||
-            response.contains("NA")
-    );
+        response.contains("age is 30")
+            || response.contains("age is 40")
+            || response.contains("NA"));
   }
 
   @Ignore("This is already supported in new SQL engine")
   @Test
   public void functionInCaseFieldShouldThrowESExceptionDueToIllegalScriptInJdbc() {
-    String response = executeQuery(
-        "select case lower(firstname) when 'amber' then '1' else '2' end as cases from " +
-            TEST_INDEX_ACCOUNT,
-        "jdbc");
-    queryInJdbcResponseShouldIndicateESException(response, "SearchPhaseExecutionException",
+    String response =
+        executeQuery(
+            "select case lower(firstname) when 'amber' then '1' else '2' end as cases from "
+                + TEST_INDEX_ACCOUNT,
+            "jdbc");
+    queryInJdbcResponseShouldIndicateESException(
+        response,
+        "SearchPhaseExecutionException",
         "For more details, please send request for Json format");
   }
 
   @Ignore("This is already supported in our new query engine")
   @Test
   public void functionCallWithIllegalScriptShouldThrowESExceptionInJdbc() {
-    String response = executeQuery("select log(balance + 2) from " + TEST_INDEX_BANK,
-        "jdbc");
-    queryInJdbcResponseShouldIndicateESException(response, "SearchPhaseExecutionException",
+    String response = executeQuery("select log(balance + 2) from " + TEST_INDEX_BANK, "jdbc");
+    queryInJdbcResponseShouldIndicateESException(
+        response,
+        "SearchPhaseExecutionException",
         "please send request for Json format to see the raw response from OpenSearch engine.");
   }
 
-  @Ignore("Goes in different route, does not call PrettyFormatRestExecutor.execute methods." +
-      "The performRequest method in RestClient doesn't throw any exceptions for null value fields in script")
+  @Ignore(
+      "Goes in different route, does not call PrettyFormatRestExecutor.execute methods.The"
+          + " performRequest method in RestClient doesn't throw any exceptions for null value"
+          + " fields in script")
   @Test
   public void functionArgWithNullValueFieldShouldThrowESExceptionInJdbc() {
-    String response = executeQuery(
-        "select log(balance) from " + TEST_INDEX_BANK_WITH_NULL_VALUES, "jdbc");
-    queryInJdbcResponseShouldIndicateESException(response, "SearchPhaseExecutionException",
+    String response =
+        executeQuery("select log(balance) from " + TEST_INDEX_BANK_WITH_NULL_VALUES, "jdbc");
+    queryInJdbcResponseShouldIndicateESException(
+        response,
+        "SearchPhaseExecutionException",
         "For more details, please send request for Json format");
   }
 
-  private void queryInJdbcResponseShouldIndicateESException(String response, String exceptionType,
-                                                            String... errMsgs) {
+  private void queryInJdbcResponseShouldIndicateESException(
+      String response, String exceptionType, String... errMsgs) {
     Assert.assertThat(response, containsString(exceptionType));
     for (String errMsg : errMsgs) {
       Assert.assertThat(response, containsString(errMsg));
@@ -1803,9 +2052,21 @@ public class QueryIT extends SQLIntegTestCase {
 
   private void checkSelectAllAndFieldResponseSize(JSONObject response) {
     String[] arr =
-        new String[] {"account_number", "firstname", "address", "birthdate", "gender", "city",
-            "lastname",
-            "balance", "employer", "state", "age", "email", "male"};
+        new String[] {
+          "account_number",
+          "firstname",
+          "address",
+          "birthdate",
+          "gender",
+          "city",
+          "lastname",
+          "balance",
+          "employer",
+          "state",
+          "age",
+          "email",
+          "male"
+        };
     Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
     JSONArray hits = getHits(response);

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/RestIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/RestIntegTestCase.java
@@ -44,11 +44,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.core.common.Strings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 /**
+ * <pre>
  * SQL plugin integration test base class (migrated from SQLIntegTestCase)
  * <p>
  * The execution of order is as follows:
@@ -60,6 +62,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
  * XXXTIT:                  3) init()             5) init()
  * <p>
  * TODO: this base class should extends ODFERestTestCase
+ * </pre>
  */
 public abstract class RestIntegTestCase extends OpenSearchSQLRestTestCase {
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLFunctionsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLFunctionsIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.allOf;
@@ -45,10 +44,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 
-
-/**
- * Created by allwefantasy on 8/25/16.
- */
+/** Created by allwefantasy on 8/25/16. */
 public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Override
@@ -61,70 +57,75 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void functionFieldAliasAndGroupByAlias() throws Exception {
-    String query = "SELECT " +
-        "floor(substring(address,0,3)*20) as key," +
-        "sum(age) cvalue FROM " + TEST_INDEX_ACCOUNT + " where address is not null " +
-        "group by key order by cvalue desc limit 10  ";
+    String query =
+        "SELECT "
+            + "floor(substring(address,0,3)*20) as key,"
+            + "sum(age) cvalue FROM "
+            + TEST_INDEX_ACCOUNT
+            + " where address is not null "
+            + "group by key order by cvalue desc limit 10  ";
     final JSONObject result = executeQuery(query);
 
-
-    IntStream.rangeClosed(0, 9).forEach(i -> {
-          Assert.assertNotNull(result.query(String.format("/aggregations/key/buckets/%d/key", i)));
-          Assert.assertNotNull(
-              result.query(String.format("/aggregations/key/buckets/%d/cvalue/value", i)));
-        }
-    );
+    IntStream.rangeClosed(0, 9)
+        .forEach(
+            i -> {
+              Assert.assertNotNull(
+                  result.query(String.format("/aggregations/key/buckets/%d/key", i)));
+              Assert.assertNotNull(
+                  result.query(String.format("/aggregations/key/buckets/%d/cvalue/value", i)));
+            });
   }
 
   /**
    * todo fix the issue.
    *
-   * @see <a href="https://github.com/opendistro-for-elasticsearch/sql/issues/59">https://github.com/opendistro-for-elasticsearch/sql/issues/59</a>
+   * @see <a
+   *     href="https://github.com/opendistro-for-elasticsearch/sql/issues/59">https://github.com/opendistro-for-elasticsearch/sql/issues/59</a>
    */
   @Ignore
   public void normalFieldAlias() throws Exception {
 
-    //here is a bug,csv field with spa
-    String query = "SELECT " +
-        "address as key,age from " +
-        TEST_INDEX_ACCOUNT + " where address is not null " +
-        "limit 10  ";
+    // here is a bug,csv field with spa
+    String query =
+        "SELECT "
+            + "address as key,age from "
+            + TEST_INDEX_ACCOUNT
+            + " where address is not null "
+            + "limit 10  ";
 
-    assertThat(
-        executeQuery(query),
-        hitAny(kvString("/_source/key", not(isEmptyOrNullString())))
-    );
+    assertThat(executeQuery(query), hitAny(kvString("/_source/key", not(isEmptyOrNullString()))));
   }
 
   @Test
   public void functionAlias() throws Exception {
-    //here is a bug,if only script fields are included,then all fields will return; fix later
-    String query = "SELECT " +
-        "substring(address,0,3) as key,address from " +
-        TEST_INDEX_ACCOUNT + " where address is not null " +
-        "order by address desc limit 10  ";
+    // here is a bug,if only script fields are included,then all fields will return; fix later
+    String query =
+        "SELECT "
+            + "substring(address,0,3) as key,address from "
+            + TEST_INDEX_ACCOUNT
+            + " where address is not null "
+            + "order by address desc limit 10  ";
 
     assertThat(
         executeQuery(query),
-        hitAny(both(kvString("/_source/address", equalTo("863 Wythe Place")))
-            .and(kvString("/fields/key/0",
-                equalTo("863"))))
-    );
+        hitAny(
+            both(kvString("/_source/address", equalTo("863 Wythe Place")))
+                .and(kvString("/fields/key/0", equalTo("863")))));
   }
 
   @Test
   public void caseChangeTest() throws IOException {
-    String query = "SELECT LOWER(firstname) " +
-        "FROM opensearch-sql_test_index_account " +
-        "WHERE UPPER(lastname)='DUKE' " +
-        "ORDER BY upper(lastname) ";
+    String query =
+        "SELECT LOWER(firstname) "
+            + "FROM opensearch-sql_test_index_account "
+            + "WHERE UPPER(lastname)='DUKE' "
+            + "ORDER BY upper(lastname) ";
 
     assertThat(
         executeQuery(query),
         hitAny(
             kvString("/_source/address", equalTo("880 Holmes Lane")),
-            kvString("/fields/LOWER(firstname)/0", equalTo("amber")))
-    );
+            kvString("/fields/LOWER(firstname)/0", equalTo("amber"))));
   }
 
   @Test
@@ -133,23 +134,23 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     // "IL".toLowerCase() in a Turkish locale returns "ıl"
     // https://stackoverflow.com/questions/11063102/using-locales-with-javas-tolowercase-and-touppercase
 
-    String query = "SELECT LOWER(state.keyword, 'tr') " +
-        "FROM opensearch-sql_test_index_account " +
-        "WHERE account_number=1";
+    String query =
+        "SELECT LOWER(state.keyword, 'tr') "
+            + "FROM opensearch-sql_test_index_account "
+            + "WHERE account_number=1";
 
     assertThat(
         executeQuery(query),
-        hitAny(
-            kvString("/fields/LOWER(state.keyword, 'tr')/0", equalTo("ıl")))
-    );
+        hitAny(kvString("/fields/LOWER(state.keyword, 'tr')/0", equalTo("ıl"))));
   }
 
   @Test
   public void caseChangeWithAggregationTest() throws IOException {
-    String query = "SELECT UPPER(e.firstname) AS upper, COUNT(*)" +
-        "FROM opensearch-sql_test_index_account e " +
-        "WHERE LOWER(e.lastname)='duke' " +
-        "GROUP BY upper";
+    String query =
+        "SELECT UPPER(e.firstname) AS upper, COUNT(*)"
+            + "FROM opensearch-sql_test_index_account e "
+            + "WHERE LOWER(e.lastname)='duke' "
+            + "GROUP BY upper";
 
     assertThat(
         executeQuery(query),
@@ -158,8 +159,10 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void castIntFieldToDoubleWithoutAliasTest() throws IOException {
-    String query = "SELECT CAST(age AS DOUBLE) FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-        " ORDER BY age DESC LIMIT 5";
+    String query =
+        "SELECT CAST(age AS DOUBLE) FROM "
+            + TestsConstants.TEST_INDEX_ACCOUNT
+            + " ORDER BY age DESC LIMIT 5";
 
     SearchHit[] hits = query(query).getHits();
     checkSuccessfulFieldCast(hits, "cast_age", "DOUBLE");
@@ -171,8 +174,9 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   @Test
   public void castIntFieldToDoubleWithAliasTest() throws IOException {
     String query =
-        "SELECT CAST(age AS DOUBLE) AS test_alias FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-            " ORDER BY age LIMIT 5";
+        "SELECT CAST(age AS DOUBLE) AS test_alias FROM "
+            + TestsConstants.TEST_INDEX_ACCOUNT
+            + " ORDER BY age LIMIT 5";
 
     SearchHit[] hits = query(query).getHits();
     checkSuccessfulFieldCast(hits, "test_alias", "DOUBLE");
@@ -183,8 +187,10 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void castIntFieldToStringWithoutAliasTest() throws IOException {
-    String query = "SELECT CAST(balance AS STRING) FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-        " ORDER BY balance LIMIT 1";
+    String query =
+        "SELECT CAST(balance AS STRING) FROM "
+            + TestsConstants.TEST_INDEX_ACCOUNT
+            + " ORDER BY balance LIMIT 1";
 
     SearchHit[] hits = query(query).getHits();
     checkSuccessfulFieldCast(hits, "cast_balance", "STRING");
@@ -195,48 +201,51 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void castIntFieldToStringWithAliasTest() throws IOException {
-    String query = "SELECT CAST(balance AS STRING) AS cast_string_alias FROM " +
-        TestsConstants.TEST_INDEX_ACCOUNT +
-        " ORDER BY cast_string_alias DESC LIMIT 1";
+    String query =
+        "SELECT CAST(balance AS STRING) AS cast_string_alias FROM "
+            + TestsConstants.TEST_INDEX_ACCOUNT
+            + " ORDER BY cast_string_alias DESC LIMIT 1";
 
     SearchHit[] hits = query(query).getHits();
     checkSuccessfulFieldCast(hits, "cast_string_alias", "STRING");
     for (int i = 0; i < hits.length; ++i) {
       Assert.assertThat(hits[i].getFields().get("cast_string_alias").getValue(), is("9838"));
     }
-
   }
 
   @Test
   public void castIntFieldToFloatWithoutAliasJdbcFormatTest() {
-    JSONObject response = executeJdbcRequest(
-        "SELECT CAST(balance AS FLOAT) AS cast_balance FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-            " ORDER BY balance DESC LIMIT 1");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(balance AS FLOAT) AS cast_balance FROM "
+                + TestsConstants.TEST_INDEX_ACCOUNT
+                + " ORDER BY balance DESC LIMIT 1");
 
-    verifySchema(response,
-        schema("CAST(balance AS FLOAT)", "cast_balance", "float"));
+    verifySchema(response, schema("CAST(balance AS FLOAT)", "cast_balance", "float"));
 
-    verifyDataRows(response,
-        rows(49989.0));
+    verifyDataRows(response, rows(49989.0));
   }
 
   @Test
   public void castIntFieldToFloatWithAliasJdbcFormatTest() {
-    JSONObject response = executeJdbcRequest(
-        "SELECT CAST(balance AS FLOAT) AS jdbc_float_alias " +
-            "FROM " + TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY jdbc_float_alias LIMIT 1");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(balance AS FLOAT) AS jdbc_float_alias "
+                + "FROM "
+                + TestsConstants.TEST_INDEX_ACCOUNT
+                + " ORDER BY jdbc_float_alias LIMIT 1");
 
-    verifySchema(response,
-        schema("CAST(balance AS FLOAT)", "jdbc_float_alias", "float"));
+    verifySchema(response, schema("CAST(balance AS FLOAT)", "jdbc_float_alias", "float"));
 
-    verifyDataRows(response,
-        rows(1011.0));
+    verifyDataRows(response, rows(1011.0));
   }
 
   @Test
   public void castIntFieldToDoubleWithoutAliasOrderByTest() throws IOException {
-    String query = "SELECT CAST(age AS DOUBLE) FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-        " ORDER BY age LIMIT 1";
+    String query =
+        "SELECT CAST(age AS DOUBLE) FROM "
+            + TestsConstants.TEST_INDEX_ACCOUNT
+            + " ORDER BY age LIMIT 1";
 
     SearchHit[] hits = query(query).getHits();
     checkSuccessfulFieldCast(hits, "cast_age", "DOUBLE");
@@ -247,148 +256,138 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void castIntFieldToDoubleWithAliasOrderByTest() throws IOException {
-    String query = "SELECT CAST(age AS DOUBLE) AS alias FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-        " ORDER BY alias DESC LIMIT 1";
+    String query =
+        "SELECT CAST(age AS DOUBLE) AS alias FROM "
+            + TestsConstants.TEST_INDEX_ACCOUNT
+            + " ORDER BY alias DESC LIMIT 1";
 
     SearchHit[] hits = query(query).getHits();
     checkSuccessfulFieldCast(hits, "alias", "DOUBLE");
     for (int i = 0; i < hits.length; ++i) {
       Assert.assertThat(hits[i].getFields().get("alias").getValue(), is(40.0));
     }
-
   }
 
   @Test
   public void castIntFieldToFloatWithoutAliasJdbcFormatGroupByTest() {
-    JSONObject response = executeJdbcRequest(
-        "SELECT CAST(balance AS FLOAT) FROM " +
-            TestsConstants.TEST_INDEX_ACCOUNT + " GROUP BY balance ORDER BY balance DESC LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(balance AS FLOAT) FROM "
+                + TestsConstants.TEST_INDEX_ACCOUNT
+                + " GROUP BY balance ORDER BY balance DESC LIMIT 5");
 
-    verifySchema(response,
-        schema("CAST(balance AS FLOAT)", null, "float"));
+    verifySchema(response, schema("CAST(balance AS FLOAT)", null, "float"));
 
-    verifyDataRows(response,
-        rows(49989.0),
-        rows(49795.0),
-        rows(49741.0),
-        rows(49671.0),
-        rows(49587.0));
+    verifyDataRows(
+        response, rows(49989.0), rows(49795.0), rows(49741.0), rows(49671.0), rows(49587.0));
   }
 
   @Test
   public void castIntFieldToFloatWithAliasJdbcFormatGroupByTest() {
-    JSONObject response = executeJdbcRequest(
-        "SELECT CAST(balance AS FLOAT) AS jdbc_float_alias "
-            + " FROM " + TestsConstants.TEST_INDEX_ACCOUNT
-            + " GROUP BY jdbc_float_alias "
-            + " ORDER BY jdbc_float_alias ASC "
-            + " LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(balance AS FLOAT) AS jdbc_float_alias "
+                + " FROM "
+                + TestsConstants.TEST_INDEX_ACCOUNT
+                + " GROUP BY jdbc_float_alias "
+                + " ORDER BY jdbc_float_alias ASC "
+                + " LIMIT 5");
 
-    verifySchema(response,
-        schema("CAST(balance AS FLOAT)", "jdbc_float_alias", "float"));
+    verifySchema(response, schema("CAST(balance AS FLOAT)", "jdbc_float_alias", "float"));
 
-    verifyDataRows(response,
-        rows(1011.0),
-        rows(10116.0),
-        rows(10138.0),
-        rows(10147.0),
-        rows(10178.0));
+    verifyDataRows(
+        response, rows(1011.0), rows(10116.0), rows(10138.0), rows(10147.0), rows(10178.0));
   }
 
   @Test
   public void castIntFieldToDoubleWithAliasJdbcFormatGroupByTest() {
-    JSONObject response = executeJdbcRequest(
-        "SELECT CAST(age AS DOUBLE) AS jdbc_double_alias " +
-            "FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
-            " GROUP BY jdbc_double_alias DESC LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(age AS DOUBLE) AS jdbc_double_alias "
+                + "FROM "
+                + TestsConstants.TEST_INDEX_ACCOUNT
+                + " GROUP BY jdbc_double_alias DESC LIMIT 5");
 
-    verifySchema(response,
-        schema("jdbc_double_alias", "jdbc_double_alias", "double"));
+    verifySchema(response, schema("jdbc_double_alias", "jdbc_double_alias", "double"));
 
-    verifyDataRows(response,
-        rows("31.0"),
-        rows("39.0"),
-        rows("26.0"),
-        rows("32.0"),
-        rows("35.0"));
+    verifyDataRows(response, rows("31.0"), rows("39.0"), rows("26.0"), rows("32.0"), rows("35.0"));
   }
 
   @Test
   public void castKeywordFieldToDatetimeWithoutAliasJdbcFormatTest() {
-    JSONObject response = executeJdbcRequest("SELECT CAST(date_keyword AS DATETIME) FROM "
-        + TestsConstants.TEST_INDEX_DATE + " ORDER BY date_keyword");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(date_keyword AS DATETIME) FROM "
+                + TestsConstants.TEST_INDEX_DATE
+                + " ORDER BY date_keyword");
 
     verifySchema(response, schema("cast_date_keyword", null, "date"));
 
-    verifyDataRows(response,
-        rows("2014-08-19 07:09:13.434"),
-        rows("2019-09-25 02:04:13.469"));
+    verifyDataRows(response, rows("2014-08-19 07:09:13.434"), rows("2019-09-25 02:04:13.469"));
   }
 
   @Test
   public void castKeywordFieldToDatetimeWithAliasJdbcFormatTest() {
     JSONObject response =
-        executeJdbcRequest("SELECT CAST(date_keyword AS DATETIME) AS test_alias FROM "
-            + TestsConstants.TEST_INDEX_DATE + " ORDER BY date_keyword");
+        executeJdbcRequest(
+            "SELECT CAST(date_keyword AS DATETIME) AS test_alias FROM "
+                + TestsConstants.TEST_INDEX_DATE
+                + " ORDER BY date_keyword");
 
     verifySchema(response, schema("test_alias", null, "date"));
 
-    verifyDataRows(response,
-        rows("2014-08-19 07:09:13.434"),
-        rows("2019-09-25 02:04:13.469"));
+    verifyDataRows(response, rows("2014-08-19 07:09:13.434"), rows("2019-09-25 02:04:13.469"));
   }
 
   @Test
   public void castFieldToDatetimeWithWhereClauseJdbcFormatTest() {
-    JSONObject response = executeJdbcRequest("SELECT CAST(date_keyword AS DATETIME) FROM "
-        + TestsConstants.TEST_INDEX_DATE + " WHERE date_keyword IS NOT NULL ORDER BY date_keyword");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT CAST(date_keyword AS DATETIME) FROM "
+                + TestsConstants.TEST_INDEX_DATE
+                + " WHERE date_keyword IS NOT NULL ORDER BY date_keyword");
 
     verifySchema(response, schema("cast_date_keyword", null, "date"));
 
-    verifyDataRows(response,
-        rows("2014-08-19 07:09:13.434"),
-        rows("2019-09-25 02:04:13.469"));
+    verifyDataRows(response, rows("2014-08-19 07:09:13.434"), rows("2019-09-25 02:04:13.469"));
   }
 
   @Test
   public void castFieldToDatetimeWithGroupByJdbcFormatTest() {
     JSONObject response =
-        executeJdbcRequest("SELECT CAST(date_keyword AS DATETIME) AS test_alias FROM "
-            + TestsConstants.TEST_INDEX_DATE + " GROUP BY test_alias DESC");
+        executeJdbcRequest(
+            "SELECT CAST(date_keyword AS DATETIME) AS test_alias FROM "
+                + TestsConstants.TEST_INDEX_DATE
+                + " GROUP BY test_alias DESC");
 
     verifySchema(response, schema("test_alias", "test_alias", "double"));
 
-    verifyDataRows(response,
-        rows("2014-08-19T07:09:13.434Z"),
-        rows("2019-09-25T02:04:13.469Z"));
+    verifyDataRows(response, rows("2014-08-19T07:09:13.434Z"), rows("2019-09-25T02:04:13.469Z"));
   }
-
 
   @Test
   public void castBoolFieldToNumericValueInSelectClause() {
     JSONObject response =
         executeJdbcRequest(
             "SELECT "
-            + " male, "
-            + " CAST(male AS INT) AS cast_int, "
-            + " CAST(male AS LONG) AS cast_long, "
-            + " CAST(male AS FLOAT) AS cast_float, "
-            + " CAST(male AS DOUBLE) AS cast_double "
-            + "FROM " + TestsConstants.TEST_INDEX_BANK + " "
-            + "WHERE account_number = 1 OR account_number = 13"
-        );
+                + " male, "
+                + " CAST(male AS INT) AS cast_int, "
+                + " CAST(male AS LONG) AS cast_long, "
+                + " CAST(male AS FLOAT) AS cast_float, "
+                + " CAST(male AS DOUBLE) AS cast_double "
+                + "FROM "
+                + TestsConstants.TEST_INDEX_BANK
+                + " "
+                + "WHERE account_number = 1 OR account_number = 13");
 
-    verifySchema(response,
+    verifySchema(
+        response,
         schema("male", "boolean"),
         schema("CAST(male AS INT)", "cast_int", "integer"),
         schema("CAST(male AS LONG)", "cast_long", "long"),
         schema("CAST(male AS FLOAT)", "cast_float", "float"),
-        schema("CAST(male AS DOUBLE)", "cast_double", "double")
-    );
-    verifyDataRows(response,
-        rows(true, 1, 1, 1.0, 1.0),
-        rows(false, 0, 0, 0.0, 0.0)
-    );
+        schema("CAST(male AS DOUBLE)", "cast_double", "double"));
+    verifyDataRows(response, rows(true, 1, 1, 1.0, 1.0), rows(false, 0, 0, 0.0, 0.0));
   }
 
   @Test
@@ -396,90 +395,82 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     JSONObject response =
         executeJdbcRequest(
             "SELECT "
-            + "CAST(male AS INT) AS cast_int, "
-            + "COUNT(*) "
-            + "FROM " + TestsConstants.TEST_INDEX_BANK + " "
-            + "GROUP BY cast_int"
-        );
+                + "CAST(male AS INT) AS cast_int, "
+                + "COUNT(*) "
+                + "FROM "
+                + TestsConstants.TEST_INDEX_BANK
+                + " "
+                + "GROUP BY cast_int");
 
-    verifySchema(response,
+    verifySchema(
+        response,
         schema("CAST(male AS INT)", "cast_int", "integer"),
-        schema("COUNT(*)", "integer")
-    );
-    verifyDataRows(response,
-        rows(0, 3),
-        rows(1, 4)
-    );
+        schema("COUNT(*)", "integer"));
+    verifyDataRows(response, rows(0, 3), rows(1, 4));
   }
 
   @Test
   public void castStatementInWhereClauseGreaterThanTest() {
-    JSONObject response = executeJdbcRequest("SELECT balance FROM " + TEST_INDEX_ACCOUNT
-        + " WHERE (account_number < CAST(age AS DOUBLE)) ORDER BY balance LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT balance FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE (account_number < CAST(age AS DOUBLE)) ORDER BY balance LIMIT 5");
 
     verifySchema(response, schema("balance", null, "long"));
 
-    verifyDataRows(response,
-        rows(4180),
-        rows(5686),
-        rows(7004),
-        rows(7831),
-        rows(14127));
+    verifyDataRows(response, rows(4180), rows(5686), rows(7004), rows(7831), rows(14127));
   }
 
   @Test
   public void castStatementInWhereClauseLessThanTest() {
-    JSONObject response = executeJdbcRequest("SELECT balance FROM " + TEST_INDEX_ACCOUNT
-        + " WHERE (account_number > CAST(age AS DOUBLE)) ORDER BY balance LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT balance FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE (account_number > CAST(age AS DOUBLE)) ORDER BY balance LIMIT 5");
 
     verifySchema(response, schema("balance", null, "long"));
 
-    verifyDataRows(response,
-        rows(1011),
-        rows(1031),
-        rows(1110),
-        rows(1133),
-        rows(1172));
+    verifyDataRows(response, rows(1011), rows(1031), rows(1110), rows(1133), rows(1172));
   }
 
   @Test
   public void castStatementInWhereClauseEqualToConstantTest() {
-    JSONObject response = executeJdbcRequest("SELECT balance FROM " + TEST_INDEX_ACCOUNT
-        + " WHERE (CAST(age AS DOUBLE) = 36.0) ORDER BY balance LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT balance FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE (CAST(age AS DOUBLE) = 36.0) ORDER BY balance LIMIT 5");
 
     verifySchema(response, schema("balance", null, "long"));
-    verifyDataRows(response,
-        rows(1249),
-        rows(1463),
-        rows(3960),
-        rows(5686),
-        rows(6025));
+    verifyDataRows(response, rows(1249), rows(1463), rows(3960), rows(5686), rows(6025));
   }
 
   @Test
   public void castStatementInWhereClauseLessThanConstantTest() {
-    JSONObject response = executeJdbcRequest("SELECT balance FROM " + TEST_INDEX_ACCOUNT
-        + " WHERE (CAST(age AS DOUBLE) < 36.0) ORDER BY balance LIMIT 5");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT balance FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE (CAST(age AS DOUBLE) < 36.0) ORDER BY balance LIMIT 5");
 
     verifySchema(response, schema("balance", null, "long"));
 
-    verifyDataRows(response,
-        rows(1011),
-        rows(1031),
-        rows(1110),
-        rows(1133),
-        rows(1172));
+    verifyDataRows(response, rows(1011), rows(1031), rows(1110), rows(1133), rows(1172));
   }
 
   /**
-   * Testing compilation
-   * Result comparison is empty then comparing different types (Date and keyword)
+   * Testing compilation Result comparison is empty then comparing different types (Date and
+   * keyword)
    */
   @Test
   public void castStatementInWhereClauseDatetimeCastTest() {
-    JSONObject response = executeJdbcRequest("SELECT date_keyword FROM "
-        + TestsConstants.TEST_INDEX_DATE
-        + " WHERE (CAST(date_keyword AS DATETIME) = '2014-08-19T07:09:13.434Z')");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT date_keyword FROM "
+                + TestsConstants.TEST_INDEX_DATE
+                + " WHERE (CAST(date_keyword AS DATETIME) = '2014-08-19T07:09:13.434Z')");
 
     String schema_result = "{\"name\":\"date_keyword\",\"type\":\"keyword\"}";
     assertEquals(response.getJSONArray("schema").get(0).toString(), schema_result);
@@ -487,30 +478,32 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void concat_ws_field_and_string() throws Exception {
-    //here is a bug,csv field with spa
-    String query = "SELECT " +
-        " concat_ws('-',age,'-') as age,address from " +
-        TEST_INDEX_ACCOUNT + " " +
-        " limit 10  ";
+    // here is a bug,csv field with spa
+    String query =
+        "SELECT "
+            + " concat_ws('-',age,'-') as age,address from "
+            + TEST_INDEX_ACCOUNT
+            + " "
+            + " limit 10  ";
 
-    assertThat(
-        executeQuery(query),
-        hitAny(kvString("/fields/age/0", endsWith("--")))
-    );
+    assertThat(executeQuery(query), hitAny(kvString("/fields/age/0", endsWith("--"))));
   }
 
   /**
    * Ignore this test case because painless doesn't allowlist String.split function.
    *
-   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
+   * @see <a
+   *     href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
    */
   @Ignore
   public void whereConditionLeftFunctionRightVariableEqualTest() throws Exception {
 
-    String query = "SELECT " +
-        " * from " +
-        TestsConstants.TEST_INDEX + " " +
-        " where split(address,' ')[0]='806' limit 1000  ";
+    String query =
+        "SELECT "
+            + " * from "
+            + TestsConstants.TEST_INDEX
+            + " "
+            + " where split(address,' ')[0]='806' limit 1000  ";
 
     assertThat(executeQuery(query).query("/hits/total"), equalTo(4));
   }
@@ -518,15 +511,18 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   /**
    * Ignore this test case because painless doesn't allowlist String.split function.
    *
-   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
+   * @see <a
+   *     href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
    */
   @Ignore
   public void whereConditionLeftFunctionRightVariableGreatTest() throws Exception {
 
-    String query = "SELECT " +
-        " * from " +
-        TestsConstants.TEST_INDEX + " " +
-        " where floor(split(address,' ')[0]+0) > 805 limit 1000  ";
+    String query =
+        "SELECT "
+            + " * from "
+            + TestsConstants.TEST_INDEX
+            + " "
+            + " where floor(split(address,' ')[0]+0) > 805 limit 1000  ";
 
     assertThat(executeQuery(query).query("/hits/total"), equalTo(223));
   }
@@ -534,42 +530,45 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   @Test
   public void concat_ws_fields() throws Exception {
 
-    //here is a bug,csv field with spa
-    String query = "SELECT " +
-        " concat_ws('-',age,address) as combine,address from " +
-        TEST_INDEX_ACCOUNT + " " +
-        " limit 10  ";
-    assertThat(
-        executeQuery(query),
-        hitAny(kvString("/fields/combine/0", containsString("-")))
-    );
+    // here is a bug,csv field with spa
+    String query =
+        "SELECT "
+            + " concat_ws('-',age,address) as combine,address from "
+            + TEST_INDEX_ACCOUNT
+            + " "
+            + " limit 10  ";
+    assertThat(executeQuery(query), hitAny(kvString("/fields/combine/0", containsString("-"))));
   }
 
   @Test
   public void functionLogs() throws Exception {
-    String query = "SELECT log10(100) as a, log(1) as b, log(2, 4) as c, log2(8) as d from "
-        + TEST_INDEX_ACCOUNT + " limit 1";
+    String query =
+        "SELECT log10(100) as a, log(1) as b, log(2, 4) as c, log2(8) as d from "
+            + TEST_INDEX_ACCOUNT
+            + " limit 1";
 
     assertThat(
         executeQuery(query),
-        hitAny(both(kvDouble("/fields/a/0", equalTo(Math.log10(100))))
-            .and(kvDouble("/fields/b/0", equalTo(Math.log(1))))
-            .and(kvDouble("/fields/c/0", closeTo(Math.log(4) / Math.log(2), 0.0001)))
-            .and(kvDouble("/fields/d/0", closeTo(Math.log(8) / Math.log(2), 0.0001))))
-    );
+        hitAny(
+            both(kvDouble("/fields/a/0", equalTo(Math.log10(100))))
+                .and(kvDouble("/fields/b/0", equalTo(Math.log(1))))
+                .and(kvDouble("/fields/c/0", closeTo(Math.log(4) / Math.log(2), 0.0001)))
+                .and(kvDouble("/fields/d/0", closeTo(Math.log(8) / Math.log(2), 0.0001)))));
   }
 
   @Test
   public void functionPow() throws Exception {
-    String query = "SELECT pow(account_number, 2) as key," +
-        "abs(age - 60) as new_age from " + TEST_INDEX_ACCOUNT +
-        " WHERE firstname = 'Virginia' and lastname='Ayala' limit 1";
+    String query =
+        "SELECT pow(account_number, 2) as key,"
+            + "abs(age - 60) as new_age from "
+            + TEST_INDEX_ACCOUNT
+            + " WHERE firstname = 'Virginia' and lastname='Ayala' limit 1";
 
     assertThat(
         executeQuery(query),
-        hitAny(both(kvDouble("/fields/new_age/0", equalTo(21.0)))
-            .and(kvDouble("/fields/key/0", equalTo(625.0))))
-    );
+        hitAny(
+            both(kvDouble("/fields/new_age/0", equalTo(21.0)))
+                .and(kvDouble("/fields/key/0", equalTo(625.0)))));
   }
 
   @Test
@@ -577,96 +576,88 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     assertThat(
         executeQuery(
             "SELECT substring('sampleName', 1, 4) AS substring FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/substring/0", equalTo("samp")))
-    );
+        hitAny(kvString("/fields/substring/0", equalTo("samp"))));
 
     assertThat(
         executeQuery(
             "SELECT substring('sampleName', 0, 20) AS substring FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/substring/0", equalTo("sampleName")))
-    );
+        hitAny(kvString("/fields/substring/0", equalTo("sampleName"))));
   }
 
   @Test
   public void operatorLength() throws IOException {
     assertThat(
-        executeQuery("SELECT LENGTH(lastname) FROM " + TEST_INDEX_ACCOUNT
+        executeQuery(
+            "SELECT LENGTH(lastname) FROM "
+                + TEST_INDEX_ACCOUNT
                 + " WHERE lastname IS NOT NULL GROUP BY LENGTH(lastname) ORDER BY LENGTH(lastname)",
             "jdbc"),
-        containsString("\"type\": \"integer\"")
-    );
+        containsString("\"type\": \"integer\""));
 
     assertThat(
         executeQuery("SELECT LENGTH('sampleName') AS length FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/length/0", equalTo(10)))
-    );
-
+        hitAny(kvInt("/fields/length/0", equalTo(10))));
   }
 
   @Test
   public void operatorReplace() {
     String query = "SELECT REPLACE('elastic', 'el', 'fant') FROM " + TEST_INDEX_ACCOUNT;
-    assertThat(
-        executeQuery(query, "jdbc"),
-        containsString("fantastic")
-    );
+    assertThat(executeQuery(query, "jdbc"), containsString("fantastic"));
   }
 
-  @Ignore("The LOCATE function is not implemented in new SQL engine. https://github"
-      + ".com/opensearch-project/sql/issues/74")
+  @Ignore(
+      "The LOCATE function is not implemented in new SQL engine. https://github"
+          + ".com/opensearch-project/sql/issues/74")
   public void operatorLocate() throws IOException {
-    String query = "SELECT LOCATE('a', lastname, 0) FROM " + TEST_INDEX_ACCOUNT
-        +
-        " WHERE lastname IS NOT NULL GROUP BY LOCATE('a', lastname, 0) ORDER BY LOCATE('a', lastname, 0)";
-    assertThat(
-        executeQuery(query, "jdbc"), containsString("\"type\": \"integer\"")
-    );
+    String query =
+        "SELECT LOCATE('a', lastname, 0) FROM "
+            + TEST_INDEX_ACCOUNT
+            + " WHERE lastname IS NOT NULL GROUP BY LOCATE('a', lastname, 0) ORDER BY LOCATE('a',"
+            + " lastname, 0)";
+    assertThat(executeQuery(query, "jdbc"), containsString("\"type\": \"integer\""));
 
     assertThat(
         executeQuery("SELECT LOCATE('a', 'sampleName', 3) AS locate FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/locate/0", equalTo(8)))
-    );
+        hitAny(kvInt("/fields/locate/0", equalTo(8))));
     assertThat(
         executeQuery("SELECT LOCATE('a', 'sampleName') AS locate FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/locate/0", equalTo(2)))
-    );
+        hitAny(kvInt("/fields/locate/0", equalTo(2))));
   }
 
   @Test
   public void rtrim() throws IOException {
     assertThat(
         executeQuery("SELECT RTRIM(' sampleName  ') AS rtrim FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/rtrim/0", equalTo(" sampleName")))
-    );
+        hitAny(kvString("/fields/rtrim/0", equalTo(" sampleName"))));
   }
 
   @Test
   public void ltrim() throws IOException {
     assertThat(
         executeQuery("SELECT LTRIM(' sampleName  ') AS ltrim FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/ltrim/0", equalTo("sampleName  ")))
-    );
+        hitAny(kvString("/fields/ltrim/0", equalTo("sampleName  "))));
   }
 
-  @Ignore("The ASCII function is not implemented in new SQL engine. https://github"
-      + ".com/opensearch-project/sql/issues/73")
+  @Ignore(
+      "The ASCII function is not implemented in new SQL engine. https://github"
+          + ".com/opensearch-project/sql/issues/73")
   public void ascii() throws IOException {
     assertThat(
-        executeQuery("SELECT ASCII(lastname) FROM " + TEST_INDEX_ACCOUNT
-                +
-                " WHERE lastname IS NOT NULL GROUP BY ASCII(lastname) ORDER BY ASCII(lastname) LIMIT 5",
+        executeQuery(
+            "SELECT ASCII(lastname) FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE lastname IS NOT NULL GROUP BY ASCII(lastname) ORDER BY ASCII(lastname)"
+                + " LIMIT 5",
             "jdbc"),
-        containsString("\"type\": \"integer\"")
-    );
+        containsString("\"type\": \"integer\""));
     assertThat(
         executeQuery("SELECT ASCII('sampleName') AS ascii FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/ascii/0", equalTo(115)))
-    );
+        hitAny(kvInt("/fields/ascii/0", equalTo(115))));
   }
 
   /**
-   * The following tests for LEFT and RIGHT are ignored because the OpenSearch client fails to parse "LEFT"/"RIGHT" in
-   * the integTest
+   * The following tests for LEFT and RIGHT are ignored because the OpenSearch client fails to parse
+   * "LEFT"/"RIGHT" in the integTest
    */
   @Ignore
   @Test
@@ -674,13 +665,11 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     assertThat(
         executeQuery(
             "SELECT LEFT('sample', 2) AS left FROM " + TEST_INDEX_ACCOUNT + " ORDER BY left"),
-        hitAny(kvString("/fields/left/0", equalTo("sa")))
-    );
+        hitAny(kvString("/fields/left/0", equalTo("sa"))));
     assertThat(
         executeQuery(
             "SELECT LEFT('sample', 20) AS left FROM " + TEST_INDEX_ACCOUNT + " ORDER BY left"),
-        hitAny(kvString("/fields/left/0", equalTo("sample")))
-    );
+        hitAny(kvString("/fields/left/0", equalTo("sample"))));
   }
 
   @Ignore
@@ -689,20 +678,20 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     assertThat(
         executeQuery(
             "SELECT RIGHT('elastic', 3) AS right FROM " + TEST_INDEX_ACCOUNT + " ORDER BY right"),
-        hitAny(kvString("/fields/right/0", equalTo("tic")))
-    );
+        hitAny(kvString("/fields/right/0", equalTo("tic"))));
     assertThat(
         executeQuery(
             "SELECT RIGHT('elastic', 20) AS right FROM " + TEST_INDEX_ACCOUNT + " ORDER BY right"),
-        hitAny(kvString("/fields/right/0", equalTo("elastic")))
-    );
+        hitAny(kvString("/fields/right/0", equalTo("elastic"))));
   }
 
   @Test
   public void ifFuncShouldPassJDBC() {
-    JSONObject response = executeJdbcRequest(
-        "SELECT IF(age > 30, 'True', 'False') AS Ages FROM " + TEST_INDEX_ACCOUNT
-            + " WHERE age IS NOT NULL GROUP BY Ages");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT IF(age > 30, 'True', 'False') AS Ages FROM "
+                + TEST_INDEX_ACCOUNT
+                + " WHERE age IS NOT NULL GROUP BY Ages");
     assertEquals("IF(age > 30, 'True', 'False')", response.query("/schema/0/name"));
     assertEquals("Ages", response.query("/schema/0/alias"));
     assertEquals("keyword", response.query("/schema/0/type"));
@@ -712,35 +701,33 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   public void ifFuncWithBinaryComparisonAsConditionTest() throws IOException {
     assertThat(
         executeQuery("SELECT IF(2 > 0, 'hello', 'world') AS ifTrue FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/ifTrue/0", equalTo("hello")))
-    );
+        hitAny(kvString("/fields/ifTrue/0", equalTo("hello"))));
     assertThat(
         executeQuery("SELECT IF(2 = 0, 'hello', 'world') AS ifFalse FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/ifFalse/0", equalTo("world")))
-    );
+        hitAny(kvString("/fields/ifFalse/0", equalTo("world"))));
   }
 
   @Test
   public void ifFuncWithBooleanExprInputAsConditionTest() throws IOException {
     assertThat(
         executeQuery("SELECT IF(true, 1, 0) AS ifBoolean FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/ifBoolean/0", equalTo(1)))
-    );
+        hitAny(kvInt("/fields/ifBoolean/0", equalTo(1))));
   }
 
   @Test
   public void ifFuncWithNullInputAsConditionTest() throws IOException {
     assertThat(
         executeQuery("SELECT IF(null, 1, 0) AS ifNull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/ifNull/0", equalTo(0)))
-    );
+        hitAny(kvInt("/fields/ifNull/0", equalTo(0))));
   }
 
   @Test
   public void ifnullShouldPassJDBC() throws IOException {
-    JSONObject response = executeJdbcRequest(
-        "SELECT IFNULL(lastname, 'unknown') AS name FROM " + TEST_INDEX_ACCOUNT
-            + " GROUP BY name");
+    JSONObject response =
+        executeJdbcRequest(
+            "SELECT IFNULL(lastname, 'unknown') AS name FROM "
+                + TEST_INDEX_ACCOUNT
+                + " GROUP BY name");
     assertEquals("IFNULL(lastname, 'unknown')", response.query("/schema/0/name"));
     assertEquals("name", response.query("/schema/0/alias"));
     assertEquals("keyword", response.query("/schema/0/type"));
@@ -750,27 +737,23 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   public void ifnullWithNotNullInputTest() throws IOException {
     assertThat(
         executeQuery("SELECT IFNULL('sample', 'IsNull') AS ifnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/ifnull/0", equalTo("sample")))
-    );
+        hitAny(kvString("/fields/ifnull/0", equalTo("sample"))));
   }
 
   @Test
   public void ifnullWithNullInputTest() throws IOException {
     assertThat(
         executeQuery("SELECT IFNULL(null, 10) AS ifnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/ifnull/0", equalTo(10)))
-    );
+        hitAny(kvInt("/fields/ifnull/0", equalTo(10))));
     assertThat(
         executeQuery("SELECT IFNULL('', 10) AS ifnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvString("/fields/ifnull/0", equalTo("")))
-    );
+        hitAny(kvString("/fields/ifnull/0", equalTo(""))));
   }
 
   @Test
   public void isnullShouldPassJDBC() {
     JSONObject response =
-        executeJdbcRequest(
-            "SELECT ISNULL(lastname) AS name FROM " + TEST_INDEX_ACCOUNT);
+        executeJdbcRequest("SELECT ISNULL(lastname) AS name FROM " + TEST_INDEX_ACCOUNT);
     assertEquals("ISNULL(lastname)", response.query("/schema/0/name"));
     assertEquals("name", response.query("/schema/0/alias"));
     assertEquals("boolean", response.query("/schema/0/type"));
@@ -780,61 +763,57 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   public void isnullWithNotNullInputTest() throws IOException {
     assertThat(
         executeQuery("SELECT ISNULL('elastic') AS isnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/isnull/0", equalTo(0)))
-    );
+        hitAny(kvInt("/fields/isnull/0", equalTo(0))));
     assertThat(
         executeQuery("SELECT ISNULL('') AS isnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/isnull/0", equalTo(0)))
-    );
+        hitAny(kvInt("/fields/isnull/0", equalTo(0))));
   }
 
   @Test
   public void isnullWithNullInputTest() throws IOException {
     assertThat(
         executeQuery("SELECT ISNULL(null) AS isnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/isnull/0", equalTo(1)))
-    );
+        hitAny(kvInt("/fields/isnull/0", equalTo(1))));
   }
 
   @Test
   public void isnullWithMathExpr() throws IOException {
     assertThat(
         executeQuery("SELECT ISNULL(1+1) AS isnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/isnull/0", equalTo(0)))
-    );
+        hitAny(kvInt("/fields/isnull/0", equalTo(0))));
     assertThat(
         executeQuery("SELECT ISNULL(1+1*1/0) AS isnull FROM " + TEST_INDEX_ACCOUNT),
-        hitAny(kvInt("/fields/isnull/0", equalTo(1)))
-    );
+        hitAny(kvInt("/fields/isnull/0", equalTo(1))));
   }
 
   /**
    * Ignore this test case because painless doesn't allowlist String.split function.
    *
-   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
+   * @see <a
+   *     href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
    */
   @Ignore
   public void split_field() throws Exception {
 
-    //here is a bug,csv field with spa
-    String query = "SELECT " +
-        " split(address,' ')[0],age from " +
-        TestsConstants.TEST_INDEX + " where address is not null " +
-        " limit 10  ";
+    // here is a bug,csv field with spa
+    String query =
+        "SELECT "
+            + " split(address,' ')[0],age from "
+            + TestsConstants.TEST_INDEX
+            + " where address is not null "
+            + " limit 10  ";
   }
 
   @Test
   public void literal() throws Exception {
-    String query = "SELECT 10 " +
-        "from " + TEST_INDEX_ACCOUNT + " limit 1";
+    String query = "SELECT 10 " + "from " + TEST_INDEX_ACCOUNT + " limit 1";
     final SearchHit[] hits = query(query).getHits();
     assertThat(hits[0].getFields(), hasValue(contains(10)));
   }
 
   @Test
   public void literalWithDoubleValue() throws Exception {
-    String query = "SELECT 10.0 " +
-        "from " + TEST_INDEX_ACCOUNT + " limit 1";
+    String query = "SELECT 10.0 " + "from " + TEST_INDEX_ACCOUNT + " limit 1";
 
     final SearchHit[] hits = query(query).getHits();
     assertThat(hits[0].getFields(), hasValue(contains(10.0)));
@@ -842,8 +821,7 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void literalWithAlias() throws Exception {
-    String query = "SELECT 10 as key " +
-        "from " + TEST_INDEX_ACCOUNT + " limit 1";
+    String query = "SELECT 10 as key " + "from " + TEST_INDEX_ACCOUNT + " limit 1";
     final SearchHit[] hits = query(query).getHits();
 
     assertThat(hits.length, is(1));
@@ -852,8 +830,7 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
   @Test
   public void literalMultiField() throws Exception {
-    String query = "SELECT 1, 2 " +
-        "from " + TEST_INDEX_ACCOUNT + " limit 1";
+    String query = "SELECT 1, 2 " + "from " + TEST_INDEX_ACCOUNT + " limit 1";
     final SearchHit[] hits = query(query).getHits();
 
     assertThat(hits.length, is(1));
@@ -863,10 +840,11 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
   private SearchHits query(String query) throws IOException {
     final String rsp = executeQueryWithStringOutput(query);
 
-    final XContentParser parser = new JsonXContentParser(
-        NamedXContentRegistry.EMPTY,
-        LoggingDeprecationHandler.INSTANCE,
-        new JsonFactory().createParser(rsp));
+    final XContentParser parser =
+        new JsonXContentParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            new JsonFactory().createParser(rsp));
     return SearchResponse.fromXContent(parser).getHits();
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -68,9 +67,7 @@ import org.opensearch.client.RestClient;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 
-/**
- * OpenSearch Rest integration test base for SQL testing
- */
+/** OpenSearch Rest integration test base for SQL testing */
 public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
 
   public static final String PERSISTENT = "persistent";
@@ -102,12 +99,14 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
   }
 
   /**
+   * <pre>
    * We need to be able to dump the jacoco coverage before cluster is shut down.
    * The new internal testing framework removed some of the gradle tasks we were listening to
    * to choose a good time to do it. This will dump the executionData to file after each test.
    * TODO: This is also currently just overwriting integTest.exec with the updated execData without
    * resetting after writing each time. This can be improved to either write an exec file per test
    * or by letting jacoco append to the file
+   * </pre>
    */
   public interface IProxy {
     byte[] getExecutionData(boolean reset);
@@ -128,10 +127,12 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
 
     String serverUrl = "service:jmx:rmi:///jndi/rmi://127.0.0.1:7777/jmxrmi";
     try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(serverUrl))) {
-      IProxy proxy = MBeanServerInvocationHandler.newProxyInstance(
-          connector.getMBeanServerConnection(), new ObjectName("org.jacoco:type=Runtime"),
-          IProxy.class,
-          false);
+      IProxy proxy =
+          MBeanServerInvocationHandler.newProxyInstance(
+              connector.getMBeanServerConnection(),
+              new ObjectName("org.jacoco:type=Runtime"),
+              IProxy.class,
+              false);
 
       Path path = Paths.get(jacocoBuildPath + "/integTest.exec");
       Files.write(path, proxy.getExecutionData(false));
@@ -141,9 +142,9 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
   }
 
   /**
-   * As JUnit JavaDoc says:
-   * "The @AfterClass methods declared in superclasses will be run after those of the current class."
-   * So this method is supposed to run before closeClients() in parent class.
+   * As JUnit JavaDoc says: "The @AfterClass methods declared in superclasses will be run after
+   * those of the current class." So this method is supposed to run before closeClients() in parent
+   * class.
    */
   @AfterClass
   public static void cleanUpIndices() throws IOException {
@@ -155,13 +156,16 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
 
   protected void setQuerySizeLimit(Integer limit) throws IOException {
     updateClusterSettings(
-        new ClusterSetting("transient", Settings.Key.QUERY_SIZE_LIMIT.getKeyValue(), limit.toString()));
+        new ClusterSetting(
+            "transient", Settings.Key.QUERY_SIZE_LIMIT.getKeyValue(), limit.toString()));
   }
 
   protected void resetQuerySizeLimit() throws IOException {
     updateClusterSettings(
-        new ClusterSetting("transient", Settings.Key.QUERY_SIZE_LIMIT.getKeyValue(), DEFAULT_QUERY_SIZE_LIMIT
-            .toString()));
+        new ClusterSetting(
+            "transient",
+            Settings.Key.QUERY_SIZE_LIMIT.getKeyValue(),
+            DEFAULT_QUERY_SIZE_LIMIT.toString()));
   }
 
   protected static void wipeAllClusterSettings() throws IOException {
@@ -178,19 +182,16 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
   }
 
   protected void resetMaxResultWindow(String indexName) throws IOException {
-    updateIndexSettings(indexName,
-        "{ \"index\": { \"max_result_window\": " + DEFAULT_MAX_RESULT_WINDOW + " } }");
+    updateIndexSettings(
+        indexName, "{ \"index\": { \"max_result_window\": " + DEFAULT_MAX_RESULT_WINDOW + " } }");
   }
 
-  /**
-   * Provide for each test to load test index, data and other setup work
-   */
-  protected void init() throws Exception {
-  }
+  /** Provide for each test to load test index, data and other setup work */
+  protected void init() throws Exception {}
 
   /**
-   * Make it thread-safe in case tests are running in parallel but does not guarantee
-   * if test like DeleteIT that mutates cluster running in parallel.
+   * Make it thread-safe in case tests are running in parallel but does not guarantee if test like
+   * DeleteIT that mutates cluster running in parallel.
    */
   protected synchronized void loadIndex(Index index, RestClient client) throws IOException {
     String indexName = index.getName();
@@ -304,8 +305,9 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
       Assert.fail(utf8CharsetName + " not available");
     }
 
-    final String requestUrl = String.format(Locale.ROOT, "%s?sql=%s&format=%s", QUERY_API_ENDPOINT,
-        urlEncodedQuery, "json");
+    final String requestUrl =
+        String.format(
+            Locale.ROOT, "%s?sql=%s&format=%s", QUERY_API_ENDPOINT, urlEncodedQuery, "json");
     return new Request("GET", requestUrl);
   }
 
@@ -344,7 +346,8 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return executeRequest(sqlRequest);
   }
 
-  protected static String executeRequest(final Request request, RestClient client) throws IOException {
+  protected static String executeRequest(final Request request, RestClient client)
+      throws IOException {
     Response response = client.performRequest(request);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     return getResponseBody(response);
@@ -373,10 +376,12 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return new JSONObject(executeRequest(sqlRequest));
   }
 
-  protected static JSONObject updateClusterSettings(ClusterSetting setting, RestClient client) throws IOException {
+  protected static JSONObject updateClusterSettings(ClusterSetting setting, RestClient client)
+      throws IOException {
     Request request = new Request("PUT", "/_cluster/settings");
-    String persistentSetting = String.format(Locale.ROOT,
-        "{\"%s\": {\"%s\": %s}}", setting.type, setting.name, setting.value);
+    String persistentSetting =
+        String.format(
+            Locale.ROOT, "{\"%s\": {\"%s\": %s}}", setting.type, setting.name, setting.value);
     request.setJsonEntity(persistentSetting);
     RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
     restOptionsBuilder.addHeader("Content-Type", "application/json");
@@ -413,11 +418,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
 
     @Override
     public String toString() {
-      return "ClusterSetting{" +
-          "type='" + type + '\'' +
-          ", path='" + name + '\'' +
-          ", value='" + value + '\'' +
-          '}';
+      return String.format("ClusterSetting{type='%s', path='%s', value='%s'}", type, name, value);
     }
   }
 
@@ -438,10 +439,8 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
   }
 
   protected String makeRequest(String query, int fetch_size) {
-    return String.format("{\n" +
-        "  \"fetch_size\": \"%s\",\n" +
-        "  \"query\": \"%s\"\n" +
-        "}", fetch_size, query);
+    return String.format(
+            "{ \"fetch_size\": \"%s\", \"query\": \"%s\" }", fetch_size, query);
   }
 
   protected String makeFetchLessRequest(String query) {
@@ -500,7 +499,6 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return request;
   }
 
-
   protected static Request getDeleteDataSourceRequest(String name) {
     Request request = new Request("DELETE", "/_plugins/_query/_datasources" + "/" + name);
     RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
@@ -509,175 +507,196 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return request;
   }
 
-  /**
-   * Enum for associating test index with relevant mapping and data.
-   */
+  /** Enum for associating test index with relevant mapping and data. */
   public enum Index {
-    ONLINE(TestsConstants.TEST_INDEX_ONLINE,
-        "online",
-        null,
-        "src/test/resources/online.json"),
-    ACCOUNT(TestsConstants.TEST_INDEX_ACCOUNT,
+    ONLINE(TestsConstants.TEST_INDEX_ONLINE, "online", null, "src/test/resources/online.json"),
+    ACCOUNT(
+        TestsConstants.TEST_INDEX_ACCOUNT,
         "account",
         getAccountIndexMapping(),
         "src/test/resources/accounts.json"),
-    PHRASE(TestsConstants.TEST_INDEX_PHRASE,
+    PHRASE(
+        TestsConstants.TEST_INDEX_PHRASE,
         "phrase",
         getPhraseIndexMapping(),
         "src/test/resources/phrases.json"),
-    DOG(TestsConstants.TEST_INDEX_DOG,
-        "dog",
-        getDogIndexMapping(),
-        "src/test/resources/dogs.json"),
-    DOGS2(TestsConstants.TEST_INDEX_DOG2,
+    DOG(TestsConstants.TEST_INDEX_DOG, "dog", getDogIndexMapping(), "src/test/resources/dogs.json"),
+    DOGS2(
+        TestsConstants.TEST_INDEX_DOG2,
         "dog",
         getDogs2IndexMapping(),
         "src/test/resources/dogs2.json"),
-    DOGS3(TestsConstants.TEST_INDEX_DOG3,
+    DOGS3(
+        TestsConstants.TEST_INDEX_DOG3,
         "dog",
         getDogs3IndexMapping(),
         "src/test/resources/dogs3.json"),
-    DOGSSUBQUERY(TestsConstants.TEST_INDEX_DOGSUBQUERY,
+    DOGSSUBQUERY(
+        TestsConstants.TEST_INDEX_DOGSUBQUERY,
         "dog",
         getDogIndexMapping(),
         "src/test/resources/dogsubquery.json"),
-    PEOPLE(TestsConstants.TEST_INDEX_PEOPLE,
-        "people",
-        null,
-        "src/test/resources/peoples.json"),
-    PEOPLE2(TestsConstants.TEST_INDEX_PEOPLE2,
+    PEOPLE(TestsConstants.TEST_INDEX_PEOPLE, "people", null, "src/test/resources/peoples.json"),
+    PEOPLE2(
+        TestsConstants.TEST_INDEX_PEOPLE2,
         "people",
         getPeople2IndexMapping(),
         "src/test/resources/people2.json"),
-    GAME_OF_THRONES(TestsConstants.TEST_INDEX_GAME_OF_THRONES,
+    GAME_OF_THRONES(
+        TestsConstants.TEST_INDEX_GAME_OF_THRONES,
         "gotCharacters",
         getGameOfThronesIndexMapping(),
         "src/test/resources/game_of_thrones_complex.json"),
-    SYSTEM(TestsConstants.TEST_INDEX_SYSTEM,
-        "systems",
-        null,
-        "src/test/resources/systems.json"),
-    ODBC(TestsConstants.TEST_INDEX_ODBC,
+    SYSTEM(TestsConstants.TEST_INDEX_SYSTEM, "systems", null, "src/test/resources/systems.json"),
+    ODBC(
+        TestsConstants.TEST_INDEX_ODBC,
         "odbc",
         getOdbcIndexMapping(),
         "src/test/resources/odbc-date-formats.json"),
-    LOCATION(TestsConstants.TEST_INDEX_LOCATION,
+    LOCATION(
+        TestsConstants.TEST_INDEX_LOCATION,
         "location",
         getLocationIndexMapping(),
         "src/test/resources/locations.json"),
-    LOCATION_TWO(TestsConstants.TEST_INDEX_LOCATION2,
+    LOCATION_TWO(
+        TestsConstants.TEST_INDEX_LOCATION2,
         "location2",
         getLocationIndexMapping(),
         "src/test/resources/locations2.json"),
-    NESTED(TestsConstants.TEST_INDEX_NESTED_TYPE,
+    NESTED(
+        TestsConstants.TEST_INDEX_NESTED_TYPE,
         "nestedType",
         getNestedTypeIndexMapping(),
         "src/test/resources/nested_objects.json"),
-    NESTED_WITHOUT_ARRAYS(TestsConstants.TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS,
+    NESTED_WITHOUT_ARRAYS(
+        TestsConstants.TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS,
         "nestedTypeWithoutArrays",
         getNestedTypeIndexMapping(),
         "src/test/resources/nested_objects_without_arrays.json"),
-    NESTED_WITH_QUOTES(TestsConstants.TEST_INDEX_NESTED_WITH_QUOTES,
+    NESTED_WITH_QUOTES(
+        TestsConstants.TEST_INDEX_NESTED_WITH_QUOTES,
         "nestedType",
         getNestedTypeIndexMapping(),
         "src/test/resources/nested_objects_quotes_in_values.json"),
-    EMPLOYEE_NESTED(TestsConstants.TEST_INDEX_EMPLOYEE_NESTED,
+    EMPLOYEE_NESTED(
+        TestsConstants.TEST_INDEX_EMPLOYEE_NESTED,
         "_doc",
         getEmployeeNestedTypeIndexMapping(),
         "src/test/resources/employee_nested.json"),
-    JOIN(TestsConstants.TEST_INDEX_JOIN_TYPE,
+    JOIN(
+        TestsConstants.TEST_INDEX_JOIN_TYPE,
         "joinType",
         getJoinTypeIndexMapping(),
         "src/test/resources/join_objects.json"),
-    UNEXPANDED_OBJECT(TestsConstants.TEST_INDEX_UNEXPANDED_OBJECT,
+    UNEXPANDED_OBJECT(
+        TestsConstants.TEST_INDEX_UNEXPANDED_OBJECT,
         "unexpandedObject",
         getUnexpandedObjectIndexMapping(),
         "src/test/resources/unexpanded_objects.json"),
-    BANK(TestsConstants.TEST_INDEX_BANK,
+    BANK(
+        TestsConstants.TEST_INDEX_BANK,
         "account",
         getBankIndexMapping(),
         "src/test/resources/bank.json"),
-    BANK_TWO(TestsConstants.TEST_INDEX_BANK_TWO,
+    BANK_TWO(
+        TestsConstants.TEST_INDEX_BANK_TWO,
         "account_two",
         getBankIndexMapping(),
         "src/test/resources/bank_two.json"),
-    BANK_WITH_NULL_VALUES(TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES,
+    BANK_WITH_NULL_VALUES(
+        TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES,
         "account_null",
         getBankWithNullValuesIndexMapping(),
         "src/test/resources/bank_with_null_values.json"),
-    BANK_WITH_STRING_VALUES(TestsConstants.TEST_INDEX_STRINGS,
+    BANK_WITH_STRING_VALUES(
+        TestsConstants.TEST_INDEX_STRINGS,
         "strings",
         getStringIndexMapping(),
         "src/test/resources/strings.json"),
-    BANK_CSV_SANITIZE(TestsConstants.TEST_INDEX_BANK_CSV_SANITIZE,
+    BANK_CSV_SANITIZE(
+        TestsConstants.TEST_INDEX_BANK_CSV_SANITIZE,
         "account",
         getBankIndexMapping(),
         "src/test/resources/bank_csv_sanitize.json"),
-    BANK_RAW_SANITIZE(TestsConstants.TEST_INDEX_BANK_RAW_SANITIZE,
-            "account",
-            getBankIndexMapping(),
-            "src/test/resources/bank_raw_sanitize.json"),
-    ORDER(TestsConstants.TEST_INDEX_ORDER,
+    BANK_RAW_SANITIZE(
+        TestsConstants.TEST_INDEX_BANK_RAW_SANITIZE,
+        "account",
+        getBankIndexMapping(),
+        "src/test/resources/bank_raw_sanitize.json"),
+    ORDER(
+        TestsConstants.TEST_INDEX_ORDER,
         "_doc",
         getOrderIndexMapping(),
         "src/test/resources/order.json"),
-    WEBLOG(TestsConstants.TEST_INDEX_WEBLOG,
+    WEBLOG(
+        TestsConstants.TEST_INDEX_WEBLOG,
         "weblog",
         getWeblogsIndexMapping(),
         "src/test/resources/weblogs.json"),
-    DATE(TestsConstants.TEST_INDEX_DATE,
+    DATE(
+        TestsConstants.TEST_INDEX_DATE,
         "dates",
         getDateIndexMapping(),
         "src/test/resources/dates.json"),
-    DATETIME(TestsConstants.TEST_INDEX_DATE_TIME,
+    DATETIME(
+        TestsConstants.TEST_INDEX_DATE_TIME,
         "_doc",
         getDateTimeIndexMapping(),
         "src/test/resources/datetime.json"),
-    NESTED_SIMPLE(TestsConstants.TEST_INDEX_NESTED_SIMPLE,
+    NESTED_SIMPLE(
+        TestsConstants.TEST_INDEX_NESTED_SIMPLE,
         "_doc",
         getNestedSimpleIndexMapping(),
         "src/test/resources/nested_simple.json"),
-    DEEP_NESTED(TestsConstants.TEST_INDEX_DEEP_NESTED,
+    DEEP_NESTED(
+        TestsConstants.TEST_INDEX_DEEP_NESTED,
         "_doc",
         getDeepNestedIndexMapping(),
         "src/test/resources/deep_nested_index_data.json"),
-    DATA_TYPE_NUMERIC(TestsConstants.TEST_INDEX_DATATYPE_NUMERIC,
+    DATA_TYPE_NUMERIC(
+        TestsConstants.TEST_INDEX_DATATYPE_NUMERIC,
         "_doc",
         getDataTypeNumericIndexMapping(),
         "src/test/resources/datatypes_numeric.json"),
-    DATA_TYPE_NONNUMERIC(TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC,
+    DATA_TYPE_NONNUMERIC(
+        TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC,
         "_doc",
         getDataTypeNonnumericIndexMapping(),
         "src/test/resources/datatypes.json"),
-    BEER(TestsConstants.TEST_INDEX_BEER,
-        "beer",
-        null,
-        "src/test/resources/beer.stackexchange.json"),
-    NULL_MISSING(TestsConstants.TEST_INDEX_NULL_MISSING,
+    BEER(
+        TestsConstants.TEST_INDEX_BEER, "beer", null, "src/test/resources/beer.stackexchange.json"),
+    NULL_MISSING(
+        TestsConstants.TEST_INDEX_NULL_MISSING,
         "null_missing",
         getMappingFile("null_missing_index_mapping.json"),
         "src/test/resources/null_missing.json"),
-    CALCS(TestsConstants.TEST_INDEX_CALCS,
+    CALCS(
+        TestsConstants.TEST_INDEX_CALCS,
         "calcs",
         getMappingFile("calcs_index_mappings.json"),
         "src/test/resources/calcs.json"),
-    DATE_FORMATS(TestsConstants.TEST_INDEX_DATE_FORMATS,
+    DATE_FORMATS(
+        TestsConstants.TEST_INDEX_DATE_FORMATS,
         "date_formats",
         getMappingFile("date_formats_index_mapping.json"),
         "src/test/resources/date_formats.json"),
-    WILDCARD(TestsConstants.TEST_INDEX_WILDCARD,
+    WILDCARD(
+        TestsConstants.TEST_INDEX_WILDCARD,
         "wildcard",
         getMappingFile("wildcard_index_mappings.json"),
         "src/test/resources/wildcard.json"),
-    DATASOURCES(TestsConstants.DATASOURCES,
+    DATASOURCES(
+        TestsConstants.DATASOURCES,
         "datasource",
         getMappingFile("datasources_index_mappings.json"),
         "src/test/resources/datasources.json"),
-    MULTI_NESTED(TestsConstants.TEST_INDEX_MULTI_NESTED_TYPE,
+    MULTI_NESTED(
+        TestsConstants.TEST_INDEX_MULTI_NESTED_TYPE,
         "multi_nested",
         getMappingFile("multi_nested.json"),
         "src/test/resources/multi_nested_objects.json"),
-    NESTED_WITH_NULLS(TestsConstants.TEST_INDEX_NESTED_WITH_NULLS,
+    NESTED_WITH_NULLS(
+        TestsConstants.TEST_INDEX_NESTED_WITH_NULLS,
         "multi_nested",
         getNestedTypeIndexMapping(),
         "src/test/resources/nested_with_nulls.json");
@@ -709,7 +728,5 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     public String getDataSet() {
       return this.dataSet;
     }
-
-
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/ShowIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/ShowIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -20,7 +19,8 @@ public class ShowIT extends SQLIntegTestCase {
 
   @Override
   protected void init() {
-    // Note: not using the existing TEST_INDEX_* indices, since underscore in the names causes issues
+    // Note: not using the existing TEST_INDEX_* indices, since underscore in the names causes
+    // issues
     createEmptyIndexIfNotExist("abcdefg");
     createEmptyIndexIfNotExist("abcdefghijk");
     createEmptyIndexIfNotExist("abcdijk");

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SourceFieldIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SourceFieldIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.legacy;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
@@ -31,32 +30,44 @@ public class SourceFieldIT extends SQLIntegTestCase {
 
   @Test
   public void includeTest() throws IOException {
-    SearchHits response = query(String.format(
-        "SELECT include('*name','*ge'),include('b*'),include('*ddre*'),include('gender') FROM %s LIMIT 1000",
-        TEST_INDEX_ACCOUNT));
+    SearchHits response =
+        query(
+            String.format(
+                "SELECT include('*name','*ge'),include('b*'),include('*ddre*'),include('gender')"
+                    + " FROM %s LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
     for (SearchHit hit : response.getHits()) {
       Set<String> keySet = hit.getSourceAsMap().keySet();
       for (String field : keySet) {
-        Assert.assertTrue(field.endsWith("name") || field.endsWith("ge") || field.startsWith("b") ||
-            field.contains("ddre") || field.equals("gender"));
+        Assert.assertTrue(
+            field.endsWith("name")
+                || field.endsWith("ge")
+                || field.startsWith("b")
+                || field.contains("ddre")
+                || field.equals("gender"));
       }
     }
-
   }
 
   @Test
   public void excludeTest() throws IOException {
 
-    SearchHits response = query(String.format(
-        "SELECT exclude('*name','*ge'),exclude('b*'),exclude('*ddre*'),exclude('gender') FROM %s LIMIT 1000",
-        TEST_INDEX_ACCOUNT));
+    SearchHits response =
+        query(
+            String.format(
+                "SELECT exclude('*name','*ge'),exclude('b*'),exclude('*ddre*'),exclude('gender')"
+                    + " FROM %s LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
 
     for (SearchHit hit : response.getHits()) {
       Set<String> keySet = hit.getSourceAsMap().keySet();
       for (String field : keySet) {
         Assert.assertFalse(
-            field.endsWith("name") || field.endsWith("ge") || field.startsWith("b") ||
-                field.contains("ddre") || field.equals("gender"));
+            field.endsWith("name")
+                || field.endsWith("ge")
+                || field.startsWith("b")
+                || field.contains("ddre")
+                || field.equals("gender"));
       }
     }
   }
@@ -64,15 +75,18 @@ public class SourceFieldIT extends SQLIntegTestCase {
   @Test
   public void allTest() throws IOException {
 
-    SearchHits response = query(String.format(
-        "SELECT exclude('*name','*ge'),include('b*'),exclude('*ddre*'),include('gender') FROM %s LIMIT 1000",
-        TEST_INDEX_ACCOUNT));
+    SearchHits response =
+        query(
+            String.format(
+                "SELECT exclude('*name','*ge'),include('b*'),exclude('*ddre*'),include('gender')"
+                    + " FROM %s LIMIT 1000",
+                TEST_INDEX_ACCOUNT));
 
     for (SearchHit hit : response.getHits()) {
       Set<String> keySet = hit.getSourceAsMap().keySet();
       for (String field : keySet) {
-        Assert
-            .assertFalse(field.endsWith("name") || field.endsWith("ge") || field.contains("ddre"));
+        Assert.assertFalse(
+            field.endsWith("name") || field.endsWith("ge") || field.contains("ddre"));
         Assert.assertTrue(field.startsWith("b") || field.equals("gender"));
       }
     }
@@ -81,11 +95,11 @@ public class SourceFieldIT extends SQLIntegTestCase {
   private SearchHits query(String query) throws IOException {
     final JSONObject jsonObject = executeQuery(query);
 
-    final XContentParser parser = new JsonXContentParser(
-        NamedXContentRegistry.EMPTY,
-        LoggingDeprecationHandler.INSTANCE,
-        new JsonFactory().createParser(jsonObject.toString()));
+    final XContentParser parser =
+        new JsonXContentParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            new JsonFactory().createParser(jsonObject.toString()));
     return SearchResponse.fromXContent(parser).getHits();
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/NowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/NowLikeFunctionIT.java
@@ -72,8 +72,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
       @Name("constValue") Boolean constValue,
       @Name("referenceGetter") Supplier<Temporal> referenceGetter,
       @Name("parser") BiFunction<CharSequence, DateTimeFormatter, Temporal> parser,
-      @Name("serializationPatternStr") String serializationPatternStr
-  ) {
+      @Name("serializationPatternStr") String serializationPatternStr) {
     this.name = name;
     this.hasFsp = hasFsp;
     this.hasShortcut = hasShortcut;
@@ -85,56 +84,104 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s")
   public static Iterable<Object[]> compareTwoDates() {
-    return Arrays.asList($$(
-        $("now", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("current_timestamp", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("localtimestamp", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("localtime", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("sysdate", true, false, false,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("curtime", false, false, false,
-            (Supplier<Temporal>) LocalTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
-            "HH:mm:ss"),
-        $("current_time", false, false, false,
-            (Supplier<Temporal>) LocalTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
-            "HH:mm:ss"),
-        $("curdate", false, false, false,
-            (Supplier<Temporal>) LocalDate::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
-            "uuuu-MM-dd"),
-        $("current_date", false, false, false,
-            (Supplier<Temporal>) LocalDate::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
-            "uuuu-MM-dd"),
-        $("utc_date", false, false, true,
-            (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalDate()),
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
-            "uuuu-MM-dd"),
-        $("utc_time", false, false, true,
-            (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalTime()),
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
-            "HH:mm:ss"),
-        $("utc_timestamp", false, false, true,
-            (Supplier<Temporal>) (org.opensearch.sql.sql.NowLikeFunctionIT::utcDateTimeNow),
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss")
-    ));
+    return Arrays.asList(
+        $$(
+            $(
+                "now",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "current_timestamp",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "localtimestamp",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "localtime",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "sysdate",
+                true,
+                false,
+                false,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "curtime",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
+                "HH:mm:ss"),
+            $(
+                "current_time",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
+                "HH:mm:ss"),
+            $(
+                "curdate",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalDate::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
+                "uuuu-MM-dd"),
+            $(
+                "current_date",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalDate::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
+                "uuuu-MM-dd"),
+            $(
+                "utc_date",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalDate()),
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
+                "uuuu-MM-dd"),
+            $(
+                "utc_time",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalTime()),
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
+                "HH:mm:ss"),
+            $(
+                "utc_timestamp",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) (org.opensearch.sql.sql.NowLikeFunctionIT::utcDateTimeNow),
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss")));
   }
 
   private long getDiff(Temporal sample, Temporal reference) {
@@ -146,7 +193,8 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testNowLikeFunctions() throws IOException {
-    var serializationPattern = new DateTimeFormatterBuilder()
+    var serializationPattern =
+        new DateTimeFormatterBuilder()
             .appendPattern(serializationPatternStr)
             .optionalStart()
             .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
@@ -156,42 +204,57 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
     double delta = 2d; // acceptable time diff, secs
     if (reference instanceof LocalDate)
       delta = 1d; // Max date delta could be 1 if test runs on the very edge of two days
-                  // We ignore probability of a test run on edge of month or year to simplify the checks
+    // We ignore probability of a test run on edge of month or year to simplify the checks
 
-    var calls = new ArrayList<String>() {{
-      add(name + "()");
-    }};
-    if (hasShortcut)
-      calls.add(name);
-    if (hasFsp)
-      calls.add(name + "(0)");
+    var calls =
+        new ArrayList<String>() {
+          {
+            add(name + "()");
+          }
+        };
+    if (hasShortcut) calls.add(name);
+    if (hasFsp) calls.add(name + "(0)");
 
     // Column order is: func(), func, func(0)
     //                   shortcut ^    fsp ^
     // Query looks like:
     //    source=people2 | eval `now()`=now() | fields `now()`;
-    JSONObject result = executeQuery("source=" + TEST_INDEX_PEOPLE2
-        + " | eval " + calls.stream().map(c -> String.format("`%s`=%s", c, c)).collect(Collectors.joining(","))
-        + " | fields " + calls.stream().map(c -> String.format("`%s`", c)).collect(Collectors.joining(",")));
+    JSONObject result =
+        executeQuery(
+            "source="
+                + TEST_INDEX_PEOPLE2
+                + " | eval "
+                + calls.stream()
+                    .map(c -> String.format("`%s`=%s", c, c))
+                    .collect(Collectors.joining(","))
+                + " | fields "
+                + calls.stream()
+                    .map(c -> String.format("`%s`", c))
+                    .collect(Collectors.joining(",")));
 
     var rows = result.getJSONArray("datarows");
     JSONArray firstRow = rows.getJSONArray(0);
     for (int i = 0; i < rows.length(); i++) {
       var row = rows.getJSONArray(i);
-      if (constValue)
-        assertTrue(firstRow.similar(row));
+      if (constValue) assertTrue(firstRow.similar(row));
 
       int column = 0;
-      assertEquals(0,
-          getDiff(reference, parser.apply(row.getString(column++), serializationPattern)), delta);
+      assertEquals(
+          0,
+          getDiff(reference, parser.apply(row.getString(column++), serializationPattern)),
+          delta);
 
       if (hasShortcut) {
-        assertEquals(0,
-            getDiff(reference, parser.apply(row.getString(column++), serializationPattern)), delta);
+        assertEquals(
+            0,
+            getDiff(reference, parser.apply(row.getString(column++), serializationPattern)),
+            delta);
       }
       if (hasFsp) {
-        assertEquals(0,
-            getDiff(reference, parser.apply(row.getString(column), serializationPattern)), delta);
+        assertEquals(
+            0,
+            getDiff(reference, parser.apply(row.getString(column), serializationPattern)),
+            delta);
       }
     }
   }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ObjectFieldOperateIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ObjectFieldOperateIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.DEEP_NESTED;
@@ -26,55 +25,45 @@ public class ObjectFieldOperateIT extends PPLIntegTestCase {
 
   @Test
   public void select_object_field() throws IOException {
-    JSONObject result = executeQuery(
-        String.format("source=%s | "
-                + "fields city.name, city.location.latitude",
-            TEST_INDEX_DEEP_NESTED));
-    verifySchema(result,
-        schema("city.name", "string"),
-        schema("city.location.latitude", "double"));
-    verifyDataRows(result,
-        rows("Seattle", 10.5));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | " + "fields city.name, city.location.latitude",
+                TEST_INDEX_DEEP_NESTED));
+    verifySchema(result, schema("city.name", "string"), schema("city.location.latitude", "double"));
+    verifyDataRows(result, rows("Seattle", 10.5));
   }
 
   @Test
   public void compare_object_field_in_where() throws IOException {
-    JSONObject result = executeQuery(
-        String.format("source=%s "
-                + "| where city.name = 'Seattle' "
-                + "| fields city.name, city.location.latitude",
-            TEST_INDEX_DEEP_NESTED));
-    verifySchema(result,
-        schema("city.name", "string"),
-        schema("city.location.latitude", "double"));
-    verifyDataRows(result,
-        rows("Seattle", 10.5));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s "
+                    + "| where city.name = 'Seattle' "
+                    + "| fields city.name, city.location.latitude",
+                TEST_INDEX_DEEP_NESTED));
+    verifySchema(result, schema("city.name", "string"), schema("city.location.latitude", "double"));
+    verifyDataRows(result, rows("Seattle", 10.5));
   }
 
   @Test
   public void group_object_field_in_stats() throws IOException {
-    JSONObject result = executeQuery(
-        String.format("source=%s "
-                + "| stats count() by city.name",
-            TEST_INDEX_DEEP_NESTED));
-    verifySchema(result,
-        schema("count()", "integer"),
-        schema("city.name", "string"));
-    verifyDataRows(result,
-        rows(1, "Seattle"));
+    JSONObject result =
+        executeQuery(
+            String.format("source=%s " + "| stats count() by city.name", TEST_INDEX_DEEP_NESTED));
+    verifySchema(result, schema("count()", "integer"), schema("city.name", "string"));
+    verifyDataRows(result, rows(1, "Seattle"));
   }
 
   @Test
   public void sort_by_object_field() throws IOException {
-    JSONObject result = executeQuery(
-        String.format("source=%s "
-                + "| sort city.name"
-                + "| fields city.name, city.location.latitude",
-            TEST_INDEX_DEEP_NESTED));
-    verifySchema(result,
-        schema("city.name", "string"),
-        schema("city.location.latitude", "double"));
-    verifyDataRows(result,
-        rows("Seattle", 10.5));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s " + "| sort city.name" + "| fields city.name, city.location.latitude",
+                TEST_INDEX_DEEP_NESTED));
+    verifySchema(result, schema("city.name", "string"), schema("city.location.latitude", "double"));
+    verifyDataRows(result, rows("Seattle", 10.5));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/OperatorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/OperatorIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
@@ -26,40 +25,28 @@ public class OperatorIT extends PPLIntegTestCase {
   @Test
   public void testAddOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s | where age = 31 + 1 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s | where age = 31 + 1 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32));
   }
 
   @Test
   public void testSubtractOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s | where age = 33 - 1 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s | where age = 33 - 1 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32));
   }
 
   @Test
   public void testMultiplyOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s | where age = 16 * 2 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s | where age = 16 * 2 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32));
   }
 
   @Test
   public void testDivideOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s | where age / 2 = 16 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s | where age / 2 = 16 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32), rows(33));
   }
 
@@ -67,9 +54,7 @@ public class OperatorIT extends PPLIntegTestCase {
   public void testModuleOperator() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format(
-                "source=%s | where age %s 32 = 0 | fields age",
-                TEST_INDEX_BANK, "%"));
+            String.format("source=%s | where age %s 32 = 0 | fields age", TEST_INDEX_BANK, "%"));
     verifyDataRows(result, rows(32));
   }
 
@@ -78,11 +63,9 @@ public class OperatorIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | eval f = age + 0 | fields f",
-                TEST_INDEX_BANK_WITH_NULL_VALUES));
+                "source=%s | eval f = age + 0 | fields f", TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(
-        result, rows(32), rows(36), rows(28), rows(33), rows(36), rows(JSONObject.NULL),
-        rows(34));
+        result, rows(32), rows(36), rows(28), rows(33), rows(36), rows(JSONObject.NULL), rows(34));
   }
 
   @Test
@@ -92,8 +75,14 @@ public class OperatorIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | eval f = balance * 1 | fields f", TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(
-        result, rows(39225), rows(32838), rows(4180), rows(48086), rows(JSONObject.NULL),
-        rows(JSONObject.NULL), rows(JSONObject.NULL));
+        result,
+        rows(39225),
+        rows(32838),
+        rows(4180),
+        rows(48086),
+        rows(JSONObject.NULL),
+        rows(JSONObject.NULL),
+        rows(JSONObject.NULL));
   }
 
   @Test
@@ -101,8 +90,7 @@ public class OperatorIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where (age+2) * 3 / 2 - 1 = 50 | fields age",
-                TEST_INDEX_BANK));
+                "source=%s | where (age+2) * 3 / 2 - 1 = 50 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32));
   }
 
@@ -127,14 +115,12 @@ public class OperatorIT extends PPLIntegTestCase {
   public void testOrOperator() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format(
-                "source=%s | where age=32 or age=34 | fields age", TEST_INDEX_BANK));
+            String.format("source=%s | where age=32 or age=34 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32), rows(34));
 
     result =
         executeQuery(
-            String.format(
-                "source=%s | where age=34 or age=32| fields age", TEST_INDEX_BANK));
+            String.format("source=%s | where age=34 or age=32| fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32), rows(34));
   }
 
@@ -158,92 +144,64 @@ public class OperatorIT extends PPLIntegTestCase {
   @Test
   public void testNotOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s not age > 32 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s not age > 32 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(28), rows(32));
   }
 
   @Test
   public void testEqualOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s age = 32 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s age = 32 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32));
 
-    result =
-        executeQuery(
-            String.format(
-                "source=%s 32 = age | fields age",
-                TEST_INDEX_BANK));
+    result = executeQuery(String.format("source=%s 32 = age | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(32));
   }
 
   @Test
   public void testNotEqualOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s age != 32 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s age != 32 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(28), rows(33), rows(34), rows(36), rows(36), rows(39));
 
-    result =
-        executeQuery(
-            String.format(
-                "source=%s 32 != age | fields age",
-                TEST_INDEX_BANK));
+    result = executeQuery(String.format("source=%s 32 != age | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(28), rows(33), rows(34), rows(36), rows(36), rows(39));
   }
 
   @Test
   public void testLessOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s age < 32 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s age < 32 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(28));
   }
 
   @Test
   public void testLteOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s age <= 32 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s age <= 32 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(28), rows(32));
   }
 
   @Test
   public void testGreaterOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s age > 36 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s age > 36 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(39));
   }
 
   @Test
   public void testGteOperator() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s age >= 36 | fields age",
-                TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s age >= 36 | fields age", TEST_INDEX_BANK));
     verifyDataRows(result, rows(36), rows(36), rows(39));
   }
 
   @Test
   public void testLikeFunction() throws IOException {
     JSONObject result =
-        executeQuery(String.format("source=%s like(firstname, 'Hatti_') | fields firstname",
-            TEST_INDEX_BANK));
+        executeQuery(
+            String.format(
+                "source=%s like(firstname, 'Hatti_') | fields firstname", TEST_INDEX_BANK));
     verifyDataRows(result, rows("Hattie"));
   }
 
@@ -251,8 +209,8 @@ public class OperatorIT extends PPLIntegTestCase {
   public void testBinaryPredicateWithNullValue() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format("source=%s | where age >= 36 | fields age",
-                TEST_INDEX_BANK_WITH_NULL_VALUES));
+            String.format(
+                "source=%s | where age >= 36 | fields age", TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(result, rows(36), rows(36));
   }
 
@@ -260,7 +218,8 @@ public class OperatorIT extends PPLIntegTestCase {
   public void testBinaryPredicateWithMissingValue() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format("source=%s | where balance > 40000 | fields balance",
+            String.format(
+                "source=%s | where balance > 40000 | fields balance",
                 TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(result, rows(48086));
   }
@@ -269,12 +228,13 @@ public class OperatorIT extends PPLIntegTestCase {
       String query, String... errorMsgs) {
     try {
       executeQuery(query);
-      fail("Expected to throw ExpressionEvaluationException, but none was thrown for query: "
-          + query);
+      fail(
+          "Expected to throw ExpressionEvaluationException, but none was thrown for query: "
+              + query);
     } catch (ResponseException e) {
       String errorMsg = e.getMessage();
       assertTrue(errorMsg.contains("ExpressionEvaluationException"));
-      for (String msg: errorMsgs) {
+      for (String msg : errorMsgs) {
         assertTrue(errorMsg.contains(msg));
       }
     } catch (IOException e) {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
@@ -20,9 +19,7 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
-/**
- * OpenSearch Rest integration test base for PPL testing.
- */
+/** OpenSearch Rest integration test base for PPL testing. */
 public abstract class PPLIntegTestCase extends SQLIntegTestCase {
 
   protected JSONObject executeQuery(String query) throws IOException {
@@ -42,8 +39,10 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
   }
 
   protected String executeCsvQuery(String query, boolean sanitize) throws IOException {
-    Request request = buildRequest(query,
-        QUERY_API_ENDPOINT + String.format(Locale.ROOT, "?format=csv&sanitize=%b", sanitize));
+    Request request =
+        buildRequest(
+            query,
+            QUERY_API_ENDPOINT + String.format(Locale.ROOT, "?format=csv&sanitize=%b", sanitize));
     Response response = client().performRequest(request);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     return getResponseBody(response, true);
@@ -65,8 +64,9 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
 
   protected static JSONObject updateClusterSettings(ClusterSetting setting) throws IOException {
     Request request = new Request("PUT", "/_cluster/settings");
-    String persistentSetting = String.format(Locale.ROOT,
-        "{\"%s\": {\"%s\": %s}}", setting.type, setting.name, setting.value);
+    String persistentSetting =
+        String.format(
+            Locale.ROOT, "{\"%s\": {\"%s\": %s}}", setting.type, setting.name, setting.value);
     request.setJsonEntity(persistentSetting);
     RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
     restOptionsBuilder.addHeader("Content-Type", "application/json");
@@ -91,11 +91,7 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
 
     @Override
     public String toString() {
-      return "ClusterSetting{"
-          + "type='" + type + '\''
-          + ", path='" + name + '\''
-          + ", value='" + value + '\''
-          + '}';
+      return String.format("ClusterSetting{type='%s', path='%s', value'%s'}", type, name, value);
     }
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLPluginIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLPluginIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -28,8 +27,7 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.sql.util.TestUtils;
 
 public class PPLPluginIT extends PPLIntegTestCase {
-  @Rule
-  public ExpectedException exceptionRule = ExpectedException.none();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   private static final String PERSISTENT = "persistent";
 
@@ -86,9 +84,11 @@ public class PPLPluginIT extends PPLIntegTestCase {
     assertThat(result.getInt("status"), equalTo(400));
     JSONObject error = result.getJSONObject("error");
     assertThat(error.getString("reason"), equalTo("Invalid Query"));
-    assertThat(error.getString("details"), equalTo(
-        "Either plugins.ppl.enabled or rest.action.multi.allow_explicit_index setting is "
-            + "false"));
+    assertThat(
+        error.getString("details"),
+        equalTo(
+            "Either plugins.ppl.enabled or rest.action.multi.allow_explicit_index setting is "
+                + "false"));
     assertThat(error.getString("type"), equalTo("IllegalAccessException"));
 
     // reset the setting

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ParseCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ParseCommandIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
@@ -23,9 +22,10 @@ public class ParseCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testParseCommand() throws IOException {
-    JSONObject result = executeQuery(
-        String.format("source=%s | parse email '.+@(?<host>.+)' | fields email, host",
-            TEST_INDEX_BANK));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | parse email '.+@(?<host>.+)' | fields email, host", TEST_INDEX_BANK));
     verifyOrder(
         result,
         rows("amberduke@pyrami.com", "pyrami.com"),
@@ -39,8 +39,10 @@ public class ParseCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testParseCommandReplaceOriginalField() throws IOException {
-    JSONObject result = executeQuery(
-        String.format("source=%s | parse email '.+@(?<email>.+)' | fields email", TEST_INDEX_BANK));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | parse email '.+@(?<email>.+)' | fields email", TEST_INDEX_BANK));
     verifyOrder(
         result,
         rows("pyrami.com"),
@@ -54,8 +56,12 @@ public class ParseCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testParseCommandWithOtherRunTimeFields() throws IOException {
-    JSONObject result = executeQuery(String.format("source=%s | parse email '.+@(?<host>.+)' | "
-        + "eval eval_result=1 | fields host, eval_result", TEST_INDEX_BANK));
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | parse email '.+@(?<host>.+)' | "
+                    + "eval eval_result=1 | fields host, eval_result",
+                TEST_INDEX_BANK));
     verifyOrder(
         result,
         rows("pyrami.com", 1),

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PositionFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PositionFunctionIT.java
@@ -13,87 +13,83 @@ import java.io.IOException;
 import org.junit.Test;
 
 public class PositionFunctionIT extends PPLIntegTestCase {
-    @Override
-    public void init() throws IOException {
-        loadIndex(Index.CALCS);
-    }
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.CALCS);
+  }
 
-    @Test
-    public void test_position_function() throws IOException {
-        String query = "source=" + TEST_INDEX_CALCS
-                + " | eval f=position('ON', str1) | fields f";
+  @Test
+  public void test_position_function() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS + " | eval f=position('ON', str1) | fields f";
 
-        var result = executeQuery(query);
+    var result = executeQuery(query);
 
-        assertEquals(17, result.getInt("total"));
-        verifyDataRows(result,
-                rows(7), rows(7),
-                rows(2), rows(0),
-                rows(0), rows(0),
-                rows(0), rows(0),
-                rows(0), rows(0),
-                rows(0), rows(0),
-                rows(0), rows(0),
-                rows(0), rows(0),
-                rows(0));
-    }
+    assertEquals(17, result.getInt("total"));
+    verifyDataRows(
+        result, rows(7), rows(7), rows(2), rows(0), rows(0), rows(0), rows(0), rows(0), rows(0),
+        rows(0), rows(0), rows(0), rows(0), rows(0), rows(0), rows(0), rows(0));
+  }
 
-    @Test
-    public void test_position_function_with_fields_only() throws IOException {
-        String query = "source=" + TEST_INDEX_CALCS
-                + " | eval f=position(str3 IN str2) | where str2 IN ('one', 'two', 'three')| fields f";
+  @Test
+  public void test_position_function_with_fields_only() throws IOException {
+    String query =
+        "source="
+            + TEST_INDEX_CALCS
+            + " | eval f=position(str3 IN str2) | where str2 IN ('one', 'two', 'three')| fields f";
 
-        var result = executeQuery(query);
+    var result = executeQuery(query);
 
-        assertEquals(3, result.getInt("total"));
-        verifyDataRows(result, rows(3), rows(0), rows(4));
-    }
+    assertEquals(3, result.getInt("total"));
+    verifyDataRows(result, rows(3), rows(0), rows(4));
+  }
 
-    @Test
-    public void test_position_function_with_string_literals() throws IOException {
-        String query = "source=" + TEST_INDEX_CALCS
-                + " | eval f=position('world' IN 'hello world') | where str2='one' | fields f";
+  @Test
+  public void test_position_function_with_string_literals() throws IOException {
+    String query =
+        "source="
+            + TEST_INDEX_CALCS
+            + " | eval f=position('world' IN 'hello world') | where str2='one' | fields f";
 
-        var result = executeQuery(query);
+    var result = executeQuery(query);
 
-        assertEquals(1, result.getInt("total"));
-        verifyDataRows(result, rows(7));
-    }
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows(7));
+  }
 
-    @Test
-    public void test_position_function_with_nulls() throws IOException {
-        String query = "source=" + TEST_INDEX_CALCS
-                + " | eval f=position('ee' IN str2) | where isnull(str2) | fields str2,f";
+  @Test
+  public void test_position_function_with_nulls() throws IOException {
+    String query =
+        "source="
+            + TEST_INDEX_CALCS
+            + " | eval f=position('ee' IN str2) | where isnull(str2) | fields str2,f";
 
-        var result = executeQuery(query);
+    var result = executeQuery(query);
 
-        assertEquals(4, result.getInt("total"));
-        verifyDataRows(result,
-                rows(null, null),
-                rows(null, null),
-                rows(null, null),
-                rows(null, null));
-    }
+    assertEquals(4, result.getInt("total"));
+    verifyDataRows(result, rows(null, null), rows(null, null), rows(null, null), rows(null, null));
+  }
 
-    @Test
-    public void test_position_function_with_function_as_arg() throws IOException {
-        String query = "source=" + TEST_INDEX_CALCS
-                + " | eval f=position(upper(str3) IN str1) | where like(str1, 'BINDING SUPPLIES') | fields f";
+  @Test
+  public void test_position_function_with_function_as_arg() throws IOException {
+    String query =
+        "source="
+            + TEST_INDEX_CALCS
+            + " | eval f=position(upper(str3) IN str1) | where like(str1, 'BINDING SUPPLIES') |"
+            + " fields f";
 
-        var result = executeQuery(query);
+    var result = executeQuery(query);
 
-        assertEquals(1, result.getInt("total"));
-        verifyDataRows(result, rows(15));
-    }
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows(15));
+  }
 
-    @Test
-    public void test_position_function_with_function_in_where_clause() throws IOException {
-        String query = "source=" + TEST_INDEX_CALCS
-                + " | where position(str3 IN str2)=1 | fields str2";
+  @Test
+  public void test_position_function_with_function_in_where_clause() throws IOException {
+    String query = "source=" + TEST_INDEX_CALCS + " | where position(str3 IN str2)=1 | fields str2";
 
-        var result = executeQuery(query);
+    var result = executeQuery(query);
 
-        assertEquals(2, result.getInt("total"));
-        verifyDataRows(result, rows("eight"), rows("eleven"));
-    }
+    assertEquals(2, result.getInt("total"));
+    verifyDataRows(result, rows("eight"), rows("eleven"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
@@ -40,10 +40,10 @@ import org.opensearch.sql.datasource.model.DataSourceType;
 public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
 
   /**
-   * Integ tests are dependent on self generated metrics in prometheus instance.
-   * When running individual integ tests there
-   * is no time for generation of metrics in the test prometheus instance.
-   * This method gives prometheus time to generate metrics on itself.
+   * Integ tests are dependent on self generated metrics in prometheus instance. When running
+   * individual integ tests there is no time for generation of metrics in the test prometheus
+   * instance. This method gives prometheus time to generate metrics on itself.
+   *
    * @throws InterruptedException
    */
   @BeforeClass
@@ -54,8 +54,11 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @Override
   protected void init() throws InterruptedException, IOException {
     DataSourceMetadata createDSM =
-        new DataSourceMetadata("my_prometheus", DataSourceType.PROMETHEUS,
-            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
+        new DataSourceMetadata(
+            "my_prometheus",
+            DataSourceType.PROMETHEUS,
+            ImmutableList.of(),
+            ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
     Request createRequest = getCreateDataSourceRequest(createDSM);
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());
@@ -71,15 +74,15 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @Test
   @SneakyThrows
   public void testSourceMetricCommand() {
-    JSONObject response =
-        executeQuery("source=my_prometheus.prometheus_http_requests_total");
-    verifySchema(response,
+    JSONObject response = executeQuery("source=my_prometheus.prometheus_http_requests_total");
+    verifySchema(
+        response,
         schema(VALUE, "double"),
-        schema(TIMESTAMP,  "timestamp"),
-        schema("handler",  "string"),
-        schema("code",  "string"),
-        schema("instance",  "string"),
-        schema("job",  "string"));
+        schema(TIMESTAMP, "timestamp"),
+        schema("handler", "string"),
+        schema("code", "string"),
+        schema("instance", "string"),
+        schema("job", "string"));
     Assertions.assertTrue(response.getInt("size") > 0);
     Assertions.assertEquals(6, response.getJSONArray("datarows").getJSONArray(0).length());
     JSONArray firstRow = response.getJSONArray("datarows").getJSONArray(0);
@@ -93,19 +96,20 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @SneakyThrows
   public void testSourceMetricCommandWithTimestamp() {
     SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    String query = "source=my_prometheus.prometheus_http_requests_total | where @timestamp > '"
-        + format.format(new Date(System.currentTimeMillis() - 3600 * 1000))
-        + "'  | sort + @timestamp | head 5";
+    String query =
+        "source=my_prometheus.prometheus_http_requests_total | where @timestamp > '"
+            + format.format(new Date(System.currentTimeMillis() - 3600 * 1000))
+            + "'  | sort + @timestamp | head 5";
 
-    JSONObject response =
-        executeQuery(query);
-    verifySchema(response,
+    JSONObject response = executeQuery(query);
+    verifySchema(
+        response,
         schema(VALUE, "double"),
-        schema(TIMESTAMP,  "timestamp"),
-        schema("handler",  "string"),
-        schema("code",  "string"),
-        schema("instance",  "string"),
-        schema("job",  "string"));
+        schema(TIMESTAMP, "timestamp"),
+        schema("handler", "string"),
+        schema("code", "string"),
+        schema("instance", "string"),
+        schema("job", "string"));
     // <TODO>Currently, data is not injected into prometheus,
     // so asserting on result is not possible. Verifying only schema.
   }
@@ -114,9 +118,12 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @SneakyThrows
   public void testMetricAvgAggregationCommand() {
     JSONObject response =
-        executeQuery("source=`my_prometheus`.`prometheus_http_requests_total` | stats avg(@value) as `agg` by span(@timestamp, 15s), `handler`, `job`");
-    verifySchema(response,
-        schema("agg",  "double"),
+        executeQuery(
+            "source=`my_prometheus`.`prometheus_http_requests_total` | stats avg(@value) as `agg`"
+                + " by span(@timestamp, 15s), `handler`, `job`");
+    verifySchema(
+        response,
+        schema("agg", "double"),
         schema("span(@timestamp,15s)", "timestamp"),
         schema("handler", "string"),
         schema("job", "string"));
@@ -133,9 +140,12 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @SneakyThrows
   public void testMetricAvgAggregationCommandWithAlias() {
     JSONObject response =
-        executeQuery("source=my_prometheus.prometheus_http_requests_total | stats avg(@value) as agg by span(@timestamp, 15s), `handler`, job");
-    verifySchema(response,
-        schema("agg",  "double"),
+        executeQuery(
+            "source=my_prometheus.prometheus_http_requests_total | stats avg(@value) as agg by"
+                + " span(@timestamp, 15s), `handler`, job");
+    verifySchema(
+        response,
+        schema("agg", "double"),
         schema("span(@timestamp,15s)", "timestamp"),
         schema("handler", "string"),
         schema("job", "string"));
@@ -148,15 +158,15 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
     }
   }
 
-
   @Test
   @SneakyThrows
   public void testMetricMaxAggregationCommand() {
     JSONObject response =
-        executeQuery("source=my_prometheus.prometheus_http_requests_total | stats max(@value) by span(@timestamp, 15s)");
-    verifySchema(response,
-        schema("max(@value)",  "double"),
-        schema("span(@timestamp,15s)", "timestamp"));
+        executeQuery(
+            "source=my_prometheus.prometheus_http_requests_total | stats max(@value) by"
+                + " span(@timestamp, 15s)");
+    verifySchema(
+        response, schema("max(@value)", "double"), schema("span(@timestamp,15s)", "timestamp"));
     Assertions.assertTrue(response.getInt("size") > 0);
     Assertions.assertEquals(2, response.getJSONArray("datarows").getJSONArray(0).length());
     JSONArray firstRow = response.getJSONArray("datarows").getJSONArray(0);
@@ -166,14 +176,16 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
     }
   }
 
-
   @Test
   @SneakyThrows
   public void testMetricMinAggregationCommand() {
     JSONObject response =
-        executeQuery("source=my_prometheus.prometheus_http_requests_total | stats min(@value) by span(@timestamp, 15s), handler");
-    verifySchema(response,
-        schema("min(@value)",  "double"),
+        executeQuery(
+            "source=my_prometheus.prometheus_http_requests_total | stats min(@value) by"
+                + " span(@timestamp, 15s), handler");
+    verifySchema(
+        response,
+        schema("min(@value)", "double"),
         schema("span(@timestamp,15s)", "timestamp"),
         schema("handler", "string"));
     Assertions.assertTrue(response.getInt("size") > 0);
@@ -189,9 +201,12 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @SneakyThrows
   public void testMetricCountAggregationCommand() {
     JSONObject response =
-        executeQuery("source=my_prometheus.prometheus_http_requests_total | stats count() by span(@timestamp, 15s), handler, job");
-    verifySchema(response,
-        schema("count()",  "integer"),
+        executeQuery(
+            "source=my_prometheus.prometheus_http_requests_total | stats count() by"
+                + " span(@timestamp, 15s), handler, job");
+    verifySchema(
+        response,
+        schema("count()", "integer"),
         schema("span(@timestamp,15s)", "timestamp"),
         schema("handler", "string"),
         schema("job", "string"));
@@ -208,9 +223,12 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @SneakyThrows
   public void testMetricSumAggregationCommand() {
     JSONObject response =
-        executeQuery("source=my_prometheus.prometheus_http_requests_total | stats sum(@value) by span(@timestamp, 15s), handler, job");
-    verifySchema(response,
-        schema("sum(@value)",  "double"),
+        executeQuery(
+            "source=my_prometheus.prometheus_http_requests_total | stats sum(@value) by"
+                + " span(@timestamp, 15s), handler, job");
+    verifySchema(
+        response,
+        schema("sum(@value)", "double"),
         schema("span(@timestamp,15s)", "timestamp"),
         schema("handler", "string"),
         schema("job", "string"));
@@ -223,18 +241,21 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
     }
   }
 
-
   @Test
   @SneakyThrows
   public void testQueryRange() {
     long currentTimestamp = new Date().getTime();
     JSONObject response =
-        executeQuery("source=my_prometheus.query_range('prometheus_http_requests_total',"
-            + ((currentTimestamp/1000)-3600) + "," + currentTimestamp/1000 + ", " + "'14'" + ")" );
-    verifySchema(response,
-        schema(LABELS,  "struct"),
-        schema(VALUE, "array"),
-        schema(TIMESTAMP,  "array"));
+        executeQuery(
+            "source=my_prometheus.query_range('prometheus_http_requests_total',"
+                + ((currentTimestamp / 1000) - 3600)
+                + ","
+                + currentTimestamp / 1000
+                + ", "
+                + "'14'"
+                + ")");
+    verifySchema(
+        response, schema(LABELS, "struct"), schema(VALUE, "array"), schema(TIMESTAMP, "array"));
     Assertions.assertTrue(response.getInt("size") > 0);
   }
 
@@ -243,25 +264,23 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
     String expected = loadFromFile("expectedOutput/ppl/explain_query_range.json");
     assertJsonEquals(
         expected,
-        explainQueryToString("source = my_prometheus"
-            + ".query_range('prometheus_http_requests_total',1689281439,1689291439,14)")
-    );
+        explainQueryToString(
+            "source = my_prometheus"
+                + ".query_range('prometheus_http_requests_total',1689281439,1689291439,14)"));
   }
 
-    @Test
+  @Test
   public void testExplainForQueryExemplars() throws Exception {
     String expected = loadFromFile("expectedOutput/ppl/explain_query_exemplars.json");
     assertJsonEquals(
         expected,
-        explainQueryToString("source = my_prometheus."
-            + "query_exemplars('app_ads_ad_requests_total',1689228292,1689232299)")
-    );
+        explainQueryToString(
+            "source = my_prometheus."
+                + "query_exemplars('app_ads_ad_requests_total',1689228292,1689232299)"));
   }
 
   String loadFromFile(String filename) throws Exception {
     URI uri = Resources.getResource(filename).toURI();
     return new String(Files.readAllBytes(Paths.get(uri)));
   }
-
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/QueryAnalysisIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/QueryAnalysisIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
@@ -79,10 +78,7 @@ public class QueryAnalysisIT extends PPLIntegTestCase {
     queryShouldPassSyntaxAndSemanticCheck(query);
   }
 
-  /**
-   * Commands that fail syntax analysis should throw
-   * {@link SyntaxCheckException}.
-   */
+  /** Commands that fail syntax analysis should throw {@link SyntaxCheckException}. */
   @Test
   public void queryNotStartingWithSearchCommandShouldFailSyntaxCheck() {
     String query = "fields firstname";
@@ -107,14 +103,12 @@ public class QueryAnalysisIT extends PPLIntegTestCase {
     queryShouldThrowSyntaxException(query, "Failed to parse query due to offending symbol");
   }
 
-  /**
-   * Commands that fail semantic analysis should throw {@link SemanticCheckException}.
-   */
+  /** Commands that fail semantic analysis should throw {@link SemanticCheckException}. */
   @Test
   public void nonexistentFieldShouldFailSemanticCheck() {
     String query = String.format("search source=%s | fields name", TEST_INDEX_ACCOUNT);
-    queryShouldThrowSemanticException(query, "can't resolve Symbol(namespace=FIELD_NAME, "
-        + "name=name) in type env");
+    queryShouldThrowSemanticException(
+        query, "can't resolve Symbol(namespace=FIELD_NAME, " + "name=name) in type env");
   }
 
   private void queryShouldPassSyntaxAndSemanticCheck(String query) {
@@ -134,7 +128,7 @@ public class QueryAnalysisIT extends PPLIntegTestCase {
     } catch (ResponseException e) {
       String errorMsg = e.getMessage();
       assertTrue(errorMsg.contains("SyntaxCheckException"));
-      for (String msg: messages) {
+      for (String msg : messages) {
         assertTrue(errorMsg.contains(msg));
       }
     } catch (IOException e) {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/QueryStringIT.java
@@ -27,22 +27,29 @@ public class QueryStringIT extends PPLIntegTestCase {
 
   @Test
   public void mandatory_params_test() throws IOException {
-    String query = "source=" + TEST_INDEX_BEER + " | where query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
+    String query =
+        "source="
+            + TEST_INDEX_BEER
+            + " | where query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
     JSONObject result = executeQuery(query);
     assertEquals(16, result.getInt("total"));
   }
 
   @Test
   public void all_params_test() throws IOException {
-    String query = "source=" + TEST_INDEX_BEER + " | where query_string(['Body', Tags, Title], 'taste beer',"
-        + "allow_leading_wildcard=true, enable_position_increments=true, escape=false,"
-        + "fuzziness= 1, fuzzy_rewrite='constant_score', max_determinized_states = 10000,"
-        + "analyzer='english', analyze_wildcard = false, quote_field_suffix = '.exact',"
-        + "auto_generate_synonyms_phrase_query=true, boost = 0.77,"
-        + "quote_analyzer='standard', phrase_slop=0, rewrite='constant_score', type='best_fields',"
-        + "tie_breaker=0.3, time_zone='Canada/Pacific', default_operator='or',"
-        + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
-        + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7)";
+    String query =
+        "source="
+            + TEST_INDEX_BEER
+            + " | where query_string(['Body', Tags, Title], 'taste"
+            + " beer',allow_leading_wildcard=true, enable_position_increments=true,"
+            + " escape=false,fuzziness= 1, fuzzy_rewrite='constant_score', max_determinized_states"
+            + " = 10000,analyzer='english', analyze_wildcard = false, quote_field_suffix ="
+            + " '.exact',auto_generate_synonyms_phrase_query=true, boost ="
+            + " 0.77,quote_analyzer='standard', phrase_slop=0, rewrite='constant_score',"
+            + " type='best_fields',tie_breaker=0.3, time_zone='Canada/Pacific',"
+            + " default_operator='or',fuzzy_transpositions = false, lenient = true,"
+            + " fuzzy_max_expansions = 25,minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length"
+            + " = 7)";
     JSONObject result = executeQuery(query);
     assertEquals(49, result.getInt("total"));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/RareCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/RareCommandIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
@@ -30,12 +29,8 @@ public class RareCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testRareWithoutGroup() throws IOException {
-    JSONObject result =
-        executeQuery(String.format("source=%s | rare gender", TEST_INDEX_ACCOUNT));
-    verifyDataRows(
-        result,
-        rows("F"),
-        rows("M"));
+    JSONObject result = executeQuery(String.format("source=%s | rare gender", TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("F"), rows("M"));
   }
 
   @Test
@@ -65,6 +60,4 @@ public class RareCommandIT extends PPLIntegTestCase {
         rows("M", "KY"),
         rows("M", "IN"));
   }
-
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/RelevanceFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/RelevanceFunctionIT.java
@@ -18,11 +18,11 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void test_wildcard_simple_query_string() throws IOException {
-    String query1 = "SOURCE=" + TEST_INDEX_BEER
-        + " | WHERE simple_query_string(['Tags'], 'taste') | fields Id";
+    String query1 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE simple_query_string(['Tags'], 'taste') | fields Id";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE=" + TEST_INDEX_BEER
-        + " | WHERE simple_query_string(['T*'], 'taste') | fields Id";
+    String query2 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE simple_query_string(['T*'], 'taste') | fields Id";
     var result2 = executeQuery(query2);
     assertNotEquals(result2.getInt("total"), result1.getInt("total"));
   }
@@ -33,11 +33,15 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
    */
   @Test
   public void verify_flags_in_simple_query_string() throws IOException {
-    String query1 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE simple_query_string(['Body'], '-free', flags='NONE|PREFIX|ESCAPE')";
+    String query1 =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE simple_query_string(['Body'], '-free', flags='NONE|PREFIX|ESCAPE')";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE simple_query_string([Body], '-free', flags='NOT|AND|OR')";
+    String query2 =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE simple_query_string([Body], '-free', flags='NOT|AND|OR')";
     var result2 = executeQuery(query2);
     assertNotEquals(result2.getInt("total"), result1.getInt("total"));
 
@@ -53,11 +57,11 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
    */
   @Test
   public void verify_escape_in_query_string() throws IOException {
-    String query1 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE query_string([Title], '?', escape=true);";
+    String query1 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE query_string([Title], '?', escape=true);";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE query_string([Title], '?', escape=false);";
+    String query2 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE query_string([Title], '?', escape=false);";
     var result2 = executeQuery(query2);
     assertEquals(0, result1.getInt("total"));
     assertEquals(8, result2.getInt("total"));
@@ -70,11 +74,15 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
    */
   @Test
   public void verify_default_operator_in_query_string() throws IOException {
-    String query1 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE query_string([Title], 'beer taste', default_operator='OR')";
+    String query1 =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE query_string([Title], 'beer taste', default_operator='OR')";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE query_string([Title], 'beer taste', default_operator='AND')";
+    String query2 =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE query_string([Title], 'beer taste', default_operator='AND')";
     var result2 = executeQuery(query2);
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));
@@ -82,11 +90,15 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void verify_default_operator_in_simple_query_string() throws IOException {
-    String query1 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE simple_query_string([Title], 'beer taste', default_operator='OR')";
+    String query1 =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE simple_query_string([Title], 'beer taste', default_operator='OR')";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE simple_query_string([Title], 'beer taste', default_operator='AND')";
+    String query2 =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE simple_query_string([Title], 'beer taste', default_operator='AND')";
     var result2 = executeQuery(query2);
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));
@@ -94,11 +106,11 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void verify_default_operator_in_multi_match() throws IOException {
-    String query1 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE multi_match([Title], 'beer taste', operator='OR')";
+    String query1 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE multi_match([Title], 'beer taste', operator='OR')";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE multi_match([Title], 'beer taste', operator='AND')";
+    String query2 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE multi_match([Title], 'beer taste', operator='AND')";
     var result2 = executeQuery(query2);
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));
@@ -106,11 +118,11 @@ public class RelevanceFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void verify_operator_in_match() throws IOException {
-    String query1 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE match(Title, 'beer taste', operator='OR')";
+    String query1 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE match(Title, 'beer taste', operator='OR')";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE="
-        + TEST_INDEX_BEER + " | WHERE match(Title, 'beer taste', operator='AND')";
+    String query2 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE match(Title, 'beer taste', operator='AND')";
     var result2 = executeQuery(query2);
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/RenameCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/RenameCommandIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
@@ -43,7 +42,9 @@ public class RenameCommandIT extends PPLIntegTestCase {
     verifyColumn(result, columnName("FIRSTNAME"), columnName("AGE"));
   }
 
-  @Ignore("Wildcard is unsupported yet. Enable once https://github.com/opensearch-project/sql/issues/787 is resolved.")
+  @Ignore(
+      "Wildcard is unsupported yet. Enable once"
+          + " https://github.com/opensearch-project/sql/issues/787 is resolved.")
   @Test
   public void testRenameWildcardFields() throws IOException {
     JSONObject result = executeQuery("source=" + TEST_INDEX_ACCOUNT + " | rename %name as %NAME");

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ResourceMonitorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ResourceMonitorIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
@@ -31,11 +30,11 @@ public class ResourceMonitorIT extends PPLIntegTestCase {
         new ClusterSetting("persistent", Settings.Key.QUERY_MEMORY_LIMIT.getKeyValue(), "1%"));
     String query = String.format("search source=%s age=20", TEST_INDEX_DOG);
 
-    ResponseException exception =
-        expectThrows(ResponseException.class, () -> executeQuery(query));
+    ResponseException exception = expectThrows(ResponseException.class, () -> executeQuery(query));
     assertEquals(503, exception.getResponse().getStatusLine().getStatusCode());
-    assertThat(exception.getMessage(), Matchers.containsString("resource is not enough to run the"
-        + " query, quit."));
+    assertThat(
+        exception.getMessage(),
+        Matchers.containsString("resource is not enough to run the" + " query, quit."));
 
     // update plugins.ppl.query.memory_limit to default value 85%
     updateClusterSettings(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SettingsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SettingsIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
@@ -26,17 +25,13 @@ public class SettingsIT extends PPLIntegTestCase {
   public void testQuerySizeLimit() throws IOException {
     // Default setting, fetch 200 rows from source
     JSONObject result =
-        executeQuery(
-            String.format(
-                "search source=%s age>35 | fields firstname", TEST_INDEX_BANK));
+        executeQuery(String.format("search source=%s age>35 | fields firstname", TEST_INDEX_BANK));
     verifyDataRows(result, rows("Hattie"), rows("Elinor"), rows("Virginia"));
 
     // Fetch 1 rows from source
     setQuerySizeLimit(1);
     result =
-        executeQuery(
-            String.format(
-                "search source=%s age>35 | fields firstname", TEST_INDEX_BANK));
+        executeQuery(String.format("search source=%s age>35 | fields firstname", TEST_INDEX_BANK));
     verifyDataRows(result, rows("Hattie"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
@@ -28,10 +28,10 @@ import org.opensearch.sql.datasource.model.DataSourceType;
 public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
 
   /**
-   * Integ tests are dependent on self generated metrics in prometheus instance.
-   * When running individual integ tests there
-   * is no time for generation of metrics in the test prometheus instance.
-   * This method gives prometheus time to generate metrics on itself.
+   * Integ tests are dependent on self generated metrics in prometheus instance. When running
+   * individual integ tests there is no time for generation of metrics in the test prometheus
+   * instance. This method gives prometheus time to generate metrics on itself.
+   *
    * @throws InterruptedException
    */
   @BeforeClass
@@ -42,8 +42,11 @@ public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
   @Override
   protected void init() throws InterruptedException, IOException {
     DataSourceMetadata createDSM =
-        new DataSourceMetadata("my_prometheus", DataSourceType.PROMETHEUS,
-            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
+        new DataSourceMetadata(
+            "my_prometheus",
+            DataSourceType.PROMETHEUS,
+            ImmutableList.of(),
+            ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
     Request createRequest = getCreateDataSourceRequest(createDSM);
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());
@@ -59,26 +62,14 @@ public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
   @Test
   public void testShowDataSourcesCommands() throws IOException {
     JSONObject result = executeQuery("show datasources");
-    verifyDataRows(result,
-        rows("my_prometheus", "PROMETHEUS"),
-        rows("@opensearch", "OPENSEARCH"));
-    verifyColumn(
-        result,
-        columnName("DATASOURCE_NAME"),
-        columnName("CONNECTOR_TYPE")
-    );
+    verifyDataRows(result, rows("my_prometheus", "PROMETHEUS"), rows("@opensearch", "OPENSEARCH"));
+    verifyColumn(result, columnName("DATASOURCE_NAME"), columnName("CONNECTOR_TYPE"));
   }
 
   @Test
   public void testShowDataSourcesCommandsWithWhereClause() throws IOException {
     JSONObject result = executeQuery("show datasources | where CONNECTOR_TYPE='PROMETHEUS'");
-    verifyDataRows(result,
-        rows("my_prometheus", "PROMETHEUS"));
-    verifyColumn(
-        result,
-        columnName("DATASOURCE_NAME"),
-        columnName("CONNECTOR_TYPE")
-    );
+    verifyDataRows(result, rows("my_prometheus", "PROMETHEUS"));
+    verifyColumn(result, columnName("DATASOURCE_NAME"), columnName("CONNECTOR_TYPE"));
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SimpleQueryStringIT.java
@@ -19,36 +19,42 @@ public class SimpleQueryStringIT extends PPLIntegTestCase {
 
   @Test
   public void test_simple_query_string() throws IOException {
-    String query = "SOURCE=" + TEST_INDEX_BEER
-        + " | WHERE simple_query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste') | fields Id";
+    String query =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE simple_query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste') |"
+            + " fields Id";
     var result = executeQuery(query);
     assertEquals(16, result.getInt("total"));
   }
 
   @Test
   public void test_simple_query_string_all_params() throws IOException {
-    String query = "SOURCE=" + TEST_INDEX_BEER
-        + " | WHERE simple_query_string(['Body', Tags, Title], 'taste beer', default_operator='or',"
-        + "analyzer=english, analyze_wildcard = false, quote_field_suffix = '.exact',"
-        + "auto_generate_synonyms_phrase_query=true, boost = 0.77, flags='PREFIX',"
-        + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
-        + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7) | fields Id";
+    String query =
+        "SOURCE="
+            + TEST_INDEX_BEER
+            + " | WHERE simple_query_string(['Body', Tags, Title], 'taste beer',"
+            + " default_operator='or',analyzer=english, analyze_wildcard = false,"
+            + " quote_field_suffix = '.exact',auto_generate_synonyms_phrase_query=true, boost ="
+            + " 0.77, flags='PREFIX',fuzzy_transpositions = false, lenient = true,"
+            + " fuzzy_max_expansions = 25,minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length"
+            + " = 7) | fields Id";
     var result = executeQuery(query);
     assertEquals(49, result.getInt("total"));
   }
 
   @Test
   public void test_wildcard_simple_query_string() throws IOException {
-    String query1 = "SOURCE=" + TEST_INDEX_BEER
-        + " | WHERE simple_query_string(['Tags'], 'taste') | fields Id";
+    String query1 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE simple_query_string(['Tags'], 'taste') | fields Id";
     var result1 = executeQuery(query1);
-    String query2 = "SOURCE=" + TEST_INDEX_BEER
-        + " | WHERE simple_query_string(['T*'], 'taste') | fields Id";
+    String query2 =
+        "SOURCE=" + TEST_INDEX_BEER + " | WHERE simple_query_string(['T*'], 'taste') | fields Id";
     var result2 = executeQuery(query2);
     assertNotEquals(result2.getInt("total"), result1.getInt("total"));
 
-    String query3 = "source=" + TEST_INDEX_BEER
-        + " | where simple_query_string(['*Date'], '2014-01-22')";
+    String query3 =
+        "source=" + TEST_INDEX_BEER + " | where simple_query_string(['*Date'], '2014-01-22')";
     JSONObject result3 = executeQuery(query3);
     assertEquals(10, result3.getInt("total"));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -37,11 +37,13 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void nested_function_with_array_of_nested_field_test() {
-    String query = "SELECT nested(message.info), nested(comment.data) FROM " + TEST_INDEX_NESTED_TYPE;
+    String query =
+        "SELECT nested(message.info), nested(comment.data) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("c", "ab"),
         rows("a", "ab"),
         rows("b", "aa"),
@@ -52,17 +54,20 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void nested_function_in_select_test() {
-    String query = "SELECT nested(message.info), nested(comment.data), "
-        + "nested(message.dayOfWeek) FROM "
-        + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+    String query =
+        "SELECT nested(message.info), nested(comment.data), "
+            + "nested(message.dayOfWeek) FROM "
+            + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(5, result.getInt("total"));
-    verifySchema(result,
+    verifySchema(
+        result,
         schema("nested(message.info)", null, "keyword"),
         schema("nested(comment.data)", null, "keyword"),
         schema("nested(message.dayOfWeek)", null, "long"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("a", "ab", 1),
         rows("b", "aa", 2),
         rows("c", "aa", 1),
@@ -74,8 +79,8 @@ public class NestedIT extends SQLIntegTestCase {
   // gets resolved
   @Disabled // TODO fix me when aggregation is supported
   public void nested_function_in_an_aggregate_function_in_select_test() {
-    String query = "SELECT sum(nested(message.dayOfWeek)) FROM " +
-        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+    String query =
+        "SELECT sum(nested(message.dayOfWeek)) FROM " + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
     JSONObject result = executeJdbcRequest(query);
     verifyDataRows(result, rows(14));
   }
@@ -83,60 +88,48 @@ public class NestedIT extends SQLIntegTestCase {
   // TODO Enable me when nested aggregation is supported
   @Disabled
   public void nested_function_with_arrays_in_an_aggregate_function_in_select_test() {
-    String query = "SELECT sum(nested(message.dayOfWeek)) FROM " +
-        TEST_INDEX_NESTED_TYPE;
+    String query = "SELECT sum(nested(message.dayOfWeek)) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
     verifyDataRows(result, rows(19));
   }
 
   @Test
   public void nested_function_in_a_function_in_select_test() {
-    String query = "SELECT upper(nested(message.info)) FROM " +
-        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+    String query =
+        "SELECT upper(nested(message.info)) FROM " + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
     JSONObject result = executeJdbcRequest(query);
 
-    verifyDataRows(result,
-        rows("A"),
-        rows("B"),
-        rows("C"),
-        rows("C"),
-        rows("ZZ"));
+    verifyDataRows(result, rows("A"), rows("B"), rows("C"), rows("C"), rows("ZZ"));
   }
 
   @Test
   public void nested_all_function_in_a_function_in_select_test() {
-    String query = "SELECT nested(message.*) FROM " +
-        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " WHERE nested(message.info) = 'a'";
+    String query =
+        "SELECT nested(message.*) FROM "
+            + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS
+            + " WHERE nested(message.info) = 'a'";
     JSONObject result = executeJdbcRequest(query);
     verifyDataRows(result, rows("e", 1, "a"));
   }
 
   @Test
   public void invalid_multiple_nested_all_function_in_a_function_in_select_test() {
-    String query = "SELECT nested(message.*), nested(message.info) FROM " +
-        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
-    RuntimeException result = assertThrows(
-        RuntimeException.class,
-        () -> executeJdbcRequest(query)
-    );
+    String query =
+        "SELECT nested(message.*), nested(message.info) FROM "
+            + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+    RuntimeException result = assertThrows(RuntimeException.class, () -> executeJdbcRequest(query));
     assertTrue(
         result.getMessage().contains("IllegalArgumentException")
-        && result.getMessage().contains("Multiple entries with same key")
-    );
+            && result.getMessage().contains("Multiple entries with same key"));
   }
 
   @Test
   public void nested_all_function_with_limit_test() {
-    String query = "SELECT nested(message.*) FROM " +
-        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " LIMIT 3";
+    String query =
+        "SELECT nested(message.*) FROM " + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " LIMIT 3";
     JSONObject result = executeJdbcRequest(query);
-    verifyDataRows(result,
-        rows("e", 1, "a"),
-        rows("f", 2, "b"),
-        rows("g", 1, "c")
-    );
+    verifyDataRows(result, rows("e", 1, "a"), rows("f", 2, "b"), rows("g", 1, "c"));
   }
-
 
   @Test
   public void nested_function_with_array_of_multi_nested_field_test() {
@@ -144,23 +137,18 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
-        rows("e"),
-        rows("f"),
-        rows("g"),
-        rows("h"),
-        rows("p"),
-        rows("yy"));
+    verifyDataRows(result, rows("e"), rows("f"), rows("g"), rows("h"), rows("p"), rows("yy"));
   }
 
   @Test
   public void nested_function_with_null_and_missing_fields_test() {
-    String query = "SELECT nested(message.info), nested(comment.data) FROM "
-        + TEST_INDEX_NESTED_WITH_NULLS;
+    String query =
+        "SELECT nested(message.info), nested(comment.data) FROM " + TEST_INDEX_NESTED_WITH_NULLS;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(10, result.getInt("total"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows(null, "hh"),
         rows("b", "aa"),
         rows("c", "aa"),
@@ -176,12 +164,14 @@ public class NestedIT extends SQLIntegTestCase {
   @Test
   public void nested_function_multiple_fields_with_matched_and_mismatched_paths_test() {
     String query =
-        "SELECT nested(message.author), nested(message.dayOfWeek), nested(message.info), nested(comment.data), "
-            + "nested(comment.likes) FROM " + TEST_INDEX_NESTED_TYPE;
+        "SELECT nested(message.author), nested(message.dayOfWeek), nested(message.info),"
+            + " nested(comment.data), nested(comment.likes) FROM "
+            + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("e", 1, "a", "ab", 3),
         rows("f", 2, "b", "aa", 2),
         rows("g", 1, "c", "aa", 3),
@@ -192,12 +182,12 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void nested_function_mixed_with_non_nested_type_test() {
-    String query =
-        "SELECT nested(message.info), someField FROM " + TEST_INDEX_NESTED_TYPE;
+    String query = "SELECT nested(message.info), someField FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("a", "b"),
         rows("b", "a"),
         rows("c", "a"),
@@ -209,46 +199,38 @@ public class NestedIT extends SQLIntegTestCase {
   @Test
   public void nested_function_with_order_by_clause() {
     String query =
-        "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
+        "SELECT nested(message.info) FROM "
+            + TEST_INDEX_NESTED_TYPE
             + " ORDER BY nested(message.info)";
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
-        rows("a"),
-        rows("c"),
-        rows("a"),
-        rows("b"),
-        rows("c"),
-        rows("zz"));
+    verifyDataRows(result, rows("a"), rows("c"), rows("a"), rows("b"), rows("c"), rows("zz"));
   }
 
   @Test
   public void nested_function_with_order_by_clause_desc() {
     String query =
-        "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
+        "SELECT nested(message.info) FROM "
+            + TEST_INDEX_NESTED_TYPE
             + " ORDER BY nested(message.info, message) DESC";
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
-        rows("zz"),
-        rows("c"),
-        rows("c"),
-        rows("a"),
-        rows("b"),
-        rows("a"));
+    verifyDataRows(result, rows("zz"), rows("c"), rows("c"), rows("a"), rows("b"), rows("a"));
   }
 
   @Test
   public void nested_function_and_field_with_order_by_clause() {
     String query =
-        "SELECT nested(message.info), myNum FROM " + TEST_INDEX_NESTED_TYPE
+        "SELECT nested(message.info), myNum FROM "
+            + TEST_INDEX_NESTED_TYPE
             + " ORDER BY nested(message.info, message), myNum";
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("a", 1),
         rows("c", 4),
         rows("a", 4),
@@ -266,9 +248,12 @@ public class NestedIT extends SQLIntegTestCase {
         "SELECT count(*) FROM " + TEST_INDEX_NESTED_TYPE + " GROUP BY nested(message.info)";
     JSONObject result = executeJdbcRequest(query);
 
-    assertTrue(result.getJSONObject("error").get("details").toString().contains(
-        "Aggregation type nested is not yet implemented"
-    ));
+    assertTrue(
+        result
+            .getJSONObject("error")
+            .get("details")
+            .toString()
+            .contains("Aggregation type nested is not yet implemented"));
   }
 
   // Nested function in HAVING clause is not yet implemented for JDBC format. This test ensures
@@ -277,12 +262,19 @@ public class NestedIT extends SQLIntegTestCase {
   @Test
   public void nested_function_with_having_clause() {
     String query =
-        "SELECT count(*) FROM " + TEST_INDEX_NESTED_TYPE + " GROUP BY myNum HAVING nested(comment.likes) > 7";
+        "SELECT count(*) FROM "
+            + TEST_INDEX_NESTED_TYPE
+            + " GROUP BY myNum HAVING nested(comment.likes) > 7";
     JSONObject result = executeJdbcRequest(query);
 
-    assertTrue(result.getJSONObject("error").get("details").toString().contains(
-        "For more details, please send request for Json format to see the raw response from OpenSearch engine."
-    ));
+    assertTrue(
+        result
+            .getJSONObject("error")
+            .get("details")
+            .toString()
+            .contains(
+                "For more details, please send request for Json format to see the raw response from"
+                    + " OpenSearch engine."));
   }
 
   @Test
@@ -292,13 +284,11 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifyDataRows(result,
-        rows("a",
-            new JSONObject(Map.of("south", 3, "west", "ab")), "ab"),
-        rows("b",
-            new JSONObject(Map.of("south", 5, "west", "ff")), "ff"),
-        rows("c",
-            new JSONObject(Map.of("south", 3, "west", "ll")), "ll"),
+    verifyDataRows(
+        result,
+        rows("a", new JSONObject(Map.of("south", 3, "west", "ab")), "ab"),
+        rows("b", new JSONObject(Map.of("south", 5, "west", "ff")), "ff"),
+        rows("c", new JSONObject(Map.of("south", 3, "west", "ll")), "ll"),
         rows("d", null, null),
         rows("i", null, null),
         rows("zz", null, null));
@@ -308,11 +298,13 @@ public class NestedIT extends SQLIntegTestCase {
   public void nested_function_with_relevance_query() {
     String query =
         "SELECT nested(message.info), highlight(someField) FROM "
-            + TEST_INDEX_NESTED_TYPE + " WHERE match(someField, 'b')";
+            + TEST_INDEX_NESTED_TYPE
+            + " WHERE match(someField, 'b')";
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(3, result.getInt("total"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("a", new JSONArray(List.of("<em>b</em>"))),
         rows("c", new JSONArray(List.of("<em>b</em>"))),
         rows("a", new JSONArray(List.of("<em>b</em>"))));
@@ -322,60 +314,68 @@ public class NestedIT extends SQLIntegTestCase {
   public void nested_with_non_nested_type_test() {
     String query = "SELECT nested(someField) FROM " + TEST_INDEX_NESTED_TYPE;
 
-    Exception exception = assertThrows(RuntimeException.class,
-        () -> executeJdbcRequest(query));
-    assertTrue(exception.getMessage().contains(
-            "{\n" +
-            "  \"error\": {\n" +
-            "    \"reason\": \"Invalid SQL query\",\n" +
-            "    \"details\": \"Illegal nested field name: someField\",\n" +
-            "    \"type\": \"IllegalArgumentException\"\n" +
-            "  },\n" +
-            "  \"status\": 400\n" +
-            "}"
-    ));
+    Exception exception = assertThrows(RuntimeException.class, () -> executeJdbcRequest(query));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "{\n"
+                    + "  \"error\": {\n"
+                    + "    \"reason\": \"Invalid SQL query\",\n"
+                    + "    \"details\": \"Illegal nested field name: someField\",\n"
+                    + "    \"type\": \"IllegalArgumentException\"\n"
+                    + "  },\n"
+                    + "  \"status\": 400\n"
+                    + "}"));
   }
 
   @Test
   public void nested_missing_path() {
     String query = "SELECT nested(message.invalid) FROM " + TEST_INDEX_MULTI_NESTED_TYPE;
 
-    Exception exception = assertThrows(RuntimeException.class,
-        () -> executeJdbcRequest(query));
-    assertTrue(exception.getMessage().contains("" +
-        "{\n" +
-        "  \"error\": {\n" +
-        "    \"reason\": \"Invalid SQL query\",\n" +
-        "    \"details\": \"can't resolve Symbol(namespace=FIELD_NAME, name=message.invalid) in type env\",\n" +
-        "    \"type\": \"SemanticCheckException\"\n" +
-        "  },\n" +
-        "  \"status\": 400\n" +
-        "}"
-    ));
+    Exception exception = assertThrows(RuntimeException.class, () -> executeJdbcRequest(query));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "{\n"
+                    + "  \"error\": {\n"
+                    + "    \"reason\": \"Invalid SQL query\",\n"
+                    + "    \"details\": \"can't resolve Symbol(namespace=FIELD_NAME,"
+                    + " name=message.invalid) in type env\",\n"
+                    + "    \"type\": \"SemanticCheckException\"\n"
+                    + "  },\n"
+                    + "  \"status\": 400\n"
+                    + "}"));
   }
 
   @Test
   public void nested_missing_path_argument() {
-    String query = "SELECT nested(message.author.name, invalid) FROM " + TEST_INDEX_MULTI_NESTED_TYPE;
+    String query =
+        "SELECT nested(message.author.name, invalid) FROM " + TEST_INDEX_MULTI_NESTED_TYPE;
 
-    Exception exception = assertThrows(RuntimeException.class,
-        () -> executeJdbcRequest(query));
-    assertTrue(exception.getMessage().contains("" +
-        "{\n" +
-        "  \"error\": {\n" +
-        "    \"reason\": \"Invalid SQL query\",\n" +
-        "    \"details\": \"can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env\",\n" +
-        "    \"type\": \"SemanticCheckException\"\n" +
-        "  },\n" +
-        "  \"status\": 400\n" +
-        "}"
-    ));
+    Exception exception = assertThrows(RuntimeException.class, () -> executeJdbcRequest(query));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "{\n"
+                    + "  \"error\": {\n"
+                    + "    \"reason\": \"Invalid SQL query\",\n"
+                    + "    \"details\": \"can't resolve Symbol(namespace=FIELD_NAME, name=invalid)"
+                    + " in type env\",\n"
+                    + "    \"type\": \"SemanticCheckException\"\n"
+                    + "  },\n"
+                    + "  \"status\": 400\n"
+                    + "}"));
   }
 
   @Test
   public void test_nested_where_with_and_conditional() {
-    String query = "SELECT nested(message.info), nested(message.author) FROM " + TEST_INDEX_NESTED_TYPE
-        + " WHERE nested(message, message.info = 'a' AND message.author = 'e')";
+    String query =
+        "SELECT nested(message.info), nested(message.author) FROM "
+            + TEST_INDEX_NESTED_TYPE
+            + " WHERE nested(message, message.info = 'a' AND message.author = 'e')";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(1, result.getInt("total"));
     verifyDataRows(result, rows("a", "e"));
@@ -383,22 +383,19 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void test_nested_in_select_and_where_as_predicate_expression() {
-    String query = "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
-        + " WHERE nested(message.info) = 'a'";
+    String query =
+        "SELECT nested(message.info) FROM "
+            + TEST_INDEX_NESTED_TYPE
+            + " WHERE nested(message.info) = 'a'";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(3, result.getInt("total"));
-    verifyDataRows(
-        result,
-        rows("a"),
-        rows("c"),
-        rows("a")
-    );
+    verifyDataRows(result, rows("a"), rows("c"), rows("a"));
   }
 
   @Test
   public void test_nested_in_where_as_predicate_expression() {
-    String query = "SELECT message.info FROM " + TEST_INDEX_NESTED_TYPE
-        + " WHERE nested(message.info) = 'a'";
+    String query =
+        "SELECT message.info FROM " + TEST_INDEX_NESTED_TYPE + " WHERE nested(message.info) = 'a'";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(2, result.getInt("total"));
     // Only first index of array is returned. Second index has 'a'
@@ -407,8 +404,10 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void test_nested_in_where_as_predicate_expression_with_like() {
-    String query = "SELECT message.info FROM " + TEST_INDEX_NESTED_TYPE
-        + " WHERE nested(message.info) LIKE 'a'";
+    String query =
+        "SELECT message.info FROM "
+            + TEST_INDEX_NESTED_TYPE
+            + " WHERE nested(message.info) LIKE 'a'";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(2, result.getInt("total"));
     // Only first index of array is returned. Second index has 'a'
@@ -417,21 +416,22 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void test_nested_in_where_as_predicate_expression_with_multiple_conditions() {
-    String query = "SELECT message.info, comment.data, message.dayOfWeek FROM " + TEST_INDEX_NESTED_TYPE
-        + " WHERE nested(message.info) = 'zz' OR nested(comment.data) = 'ab' AND nested(message.dayOfWeek) >= 4";
+    String query =
+        "SELECT message.info, comment.data, message.dayOfWeek FROM "
+            + TEST_INDEX_NESTED_TYPE
+            + " WHERE nested(message.info) = 'zz' OR nested(comment.data) = 'ab' AND"
+            + " nested(message.dayOfWeek) >= 4";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(2, result.getInt("total"));
-    verifyDataRows(
-        result,
-        rows("c", "ab", 4),
-        rows("zz", "aa", 6)
-    );
+    verifyDataRows(result, rows("c", "ab", 4), rows("zz", "aa", 6));
   }
 
   @Test
   public void test_nested_in_where_as_predicate_expression_with_relevance_query() {
-    String query = "SELECT comment.likes, someField FROM " + TEST_INDEX_NESTED_TYPE
-        + " WHERE nested(comment.likes) = 10 AND match(someField, 'a')";
+    String query =
+        "SELECT comment.likes, someField FROM "
+            + TEST_INDEX_NESTED_TYPE
+            + " WHERE nested(comment.likes) = 10 AND match(someField, 'a')";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(1, result.getInt("total"));
     verifyDataRows(result, rows(10, "a"));
@@ -443,11 +443,13 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifySchema(result,
+    verifySchema(
+        result,
         schema("nested(message.author)", null, "keyword"),
         schema("nested(message.dayOfWeek)", null, "long"),
         schema("nested(message.info)", null, "keyword"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("e", 1, "a"),
         rows("f", 2, "b"),
         rows("g", 1, "c"),
@@ -458,17 +460,18 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void nested_function_all_subfields_and_specified_subfield() {
-    String query = "SELECT nested(message.*), nested(comment.data) FROM "
-        + TEST_INDEX_NESTED_TYPE;
+    String query = "SELECT nested(message.*), nested(comment.data) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifySchema(result,
+    verifySchema(
+        result,
         schema("nested(message.author)", null, "keyword"),
         schema("nested(message.dayOfWeek)", null, "long"),
         schema("nested(message.info)", null, "keyword"),
         schema("nested(comment.data)", null, "keyword"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("e", 1, "a", "ab"),
         rows("f", 2, "b", "aa"),
         rows("g", 1, "c", "aa"),
@@ -479,15 +482,16 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void nested_function_all_deep_nested_subfields() {
-    String query = "SELECT nested(message.author.address.*) FROM "
-        + TEST_INDEX_MULTI_NESTED_TYPE;
+    String query = "SELECT nested(message.author.address.*) FROM " + TEST_INDEX_MULTI_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifySchema(result,
+    verifySchema(
+        result,
         schema("nested(message.author.address.number)", null, "integer"),
         schema("nested(message.author.address.street)", null, "keyword"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows(1, "bc"),
         rows(2, "ab"),
         rows(3, "sk"),
@@ -498,18 +502,19 @@ public class NestedIT extends SQLIntegTestCase {
 
   @Test
   public void nested_function_all_subfields_for_two_nested_fields() {
-    String query = "SELECT nested(message.*), nested(comment.*) FROM "
-        + TEST_INDEX_NESTED_TYPE;
+    String query = "SELECT nested(message.*), nested(comment.*) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifySchema(result,
+    verifySchema(
+        result,
         schema("nested(message.author)", null, "keyword"),
         schema("nested(message.dayOfWeek)", null, "long"),
         schema("nested(message.info)", null, "keyword"),
         schema("nested(comment.data)", null, "keyword"),
         schema("nested(comment.likes)", null, "long"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("e", 1, "a", "ab", 3),
         rows("f", 2, "b", "aa", 2),
         rows("g", 1, "c", "aa", 3),
@@ -524,12 +529,14 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(6, result.getInt("total"));
-    verifySchema(result,
+    verifySchema(
+        result,
         schema("nested(message.author)", null, "keyword"),
         schema("nested(message.dayOfWeek)", null, "long"),
         schema("nested(message.info)", null, "keyword"),
         schema("myNum", null, "long"));
-    verifyDataRows(result,
+    verifyDataRows(
+        result,
         rows("e", 1, "a", 1),
         rows("f", 2, "b", 2),
         rows("g", 1, "c", 3),
@@ -544,17 +551,15 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(11, result.getInt("total"));
-    verifySchema(result,
-        schema("nested(address.moveInDate)", null, "object")
-    );
-    verifyDataRows(result,
-        rows(new JSONObject(Map.of("dateAndTime","1984-04-12 09:07:42"))),
-        rows(new JSONArray(
-            List.of(
-                Map.of("dateAndTime", "2023-05-03 08:07:42"),
-                Map.of("dateAndTime", "2001-11-11 04:07:44"))
-            )
-        ),
+    verifySchema(result, schema("nested(address.moveInDate)", null, "object"));
+    verifyDataRows(
+        result,
+        rows(new JSONObject(Map.of("dateAndTime", "1984-04-12 09:07:42"))),
+        rows(
+            new JSONArray(
+                List.of(
+                    Map.of("dateAndTime", "2023-05-03 08:07:42"),
+                    Map.of("dateAndTime", "2001-11-11 04:07:44")))),
         rows(new JSONObject(Map.of("dateAndTime", "1966-03-19 03:04:55"))),
         rows(new JSONObject(Map.of("dateAndTime", "2011-06-01 01:01:42"))),
         rows(new JSONObject(Map.of("dateAndTime", "1901-08-11 04:03:33"))),
@@ -563,30 +568,27 @@ public class NestedIT extends SQLIntegTestCase {
         rows(new JSONObject(Map.of("dateAndTime", "1977-07-13 09:04:41"))),
         rows(new JSONObject(Map.of("dateAndTime", "1933-12-12 05:05:45"))),
         rows(new JSONObject(Map.of("dateAndTime", "1909-06-17 01:04:21"))),
-        rows(new JSONArray(
-            List.of(
-                Map.of("dateAndTime", "2001-11-11 04:07:44"))
-            )
-        )
-    );
+        rows(new JSONArray(List.of(Map.of("dateAndTime", "2001-11-11 04:07:44")))));
   }
 
   @Test
   public void nested_function_all_subfields_in_wrong_clause() {
     String query = "SELECT * FROM " + TEST_INDEX_NESTED_TYPE + " ORDER BY nested(message.*)";
 
-    Exception exception = assertThrows(RuntimeException.class, () ->
-        executeJdbcRequest(query));
+    Exception exception = assertThrows(RuntimeException.class, () -> executeJdbcRequest(query));
 
-    assertTrue(exception.getMessage().contains("" +
-        "{\n" +
-        "  \"error\": {\n" +
-        "    \"reason\": \"There was internal problem at backend\",\n" +
-        "    \"details\": \"Invalid use of expression nested(message.*)\",\n" +
-        "    \"type\": \"UnsupportedOperationException\"\n" +
-        "  },\n" +
-        "  \"status\": 503\n" +
-        "}"
-    ));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                ""
+                    + "{\n"
+                    + "  \"error\": {\n"
+                    + "    \"reason\": \"There was internal problem at backend\",\n"
+                    + "    \"details\": \"Invalid use of expression nested(message.*)\",\n"
+                    + "    \"type\": \"UnsupportedOperationException\"\n"
+                    + "  },\n"
+                    + "  \"status\": 503\n"
+                    + "}"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NowLikeFunctionIT.java
@@ -77,8 +77,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
       @Name("constValue") Boolean constValue,
       @Name("referenceGetter") Supplier<Temporal> referenceGetter,
       @Name("parser") BiFunction<CharSequence, DateTimeFormatter, Temporal> parser,
-      @Name("serializationPatternStr") String serializationPatternStr
-  ) {
+      @Name("serializationPatternStr") String serializationPatternStr) {
     this.name = name;
     this.hasFsp = hasFsp;
     this.hasShortcut = hasShortcut;
@@ -90,56 +89,104 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s")
   public static Iterable<Object[]> compareTwoDates() {
-    return Arrays.asList($$(
-        $("now", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("current_timestamp", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("localtimestamp", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("localtime", false, false, true,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("sysdate", true, false, false,
-            (Supplier<Temporal>) LocalDateTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss"),
-        $("curtime", false, false, false,
-            (Supplier<Temporal>) LocalTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
-            "HH:mm:ss"),
-        $("current_time", false, false, false,
-            (Supplier<Temporal>) LocalTime::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
-            "HH:mm:ss"),
-        $("curdate", false, false, false,
-            (Supplier<Temporal>) LocalDate::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
-            "uuuu-MM-dd"),
-        $("current_date", false, false, false,
-            (Supplier<Temporal>) LocalDate::now,
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
-            "uuuu-MM-dd"),
-        $("utc_date", false, false, true,
-            (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalDate()),
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
-            "uuuu-MM-dd"),
-        $("utc_time", false, false, true,
-            (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalTime()),
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
-            "HH:mm:ss"),
-        $("utc_timestamp", false, false, true,
-            (Supplier<Temporal>) (NowLikeFunctionIT::utcDateTimeNow),
-            (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
-            "uuuu-MM-dd HH:mm:ss")
-    ));
+    return Arrays.asList(
+        $$(
+            $(
+                "now",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "current_timestamp",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "localtimestamp",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "localtime",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "sysdate",
+                true,
+                false,
+                false,
+                (Supplier<Temporal>) LocalDateTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss"),
+            $(
+                "curtime",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
+                "HH:mm:ss"),
+            $(
+                "current_time",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalTime::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
+                "HH:mm:ss"),
+            $(
+                "curdate",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalDate::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
+                "uuuu-MM-dd"),
+            $(
+                "current_date",
+                false,
+                false,
+                false,
+                (Supplier<Temporal>) LocalDate::now,
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
+                "uuuu-MM-dd"),
+            $(
+                "utc_date",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalDate()),
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
+                "uuuu-MM-dd"),
+            $(
+                "utc_time",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) (() -> utcDateTimeNow().toLocalTime()),
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
+                "HH:mm:ss"),
+            $(
+                "utc_timestamp",
+                false,
+                false,
+                true,
+                (Supplier<Temporal>) (NowLikeFunctionIT::utcDateTimeNow),
+                (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
+                "uuuu-MM-dd HH:mm:ss")));
   }
 
   private long getDiff(Temporal sample, Temporal reference) {
@@ -150,14 +197,14 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
   }
 
   public static LocalDateTime utcDateTimeNow() {
-    ZonedDateTime zonedDateTime =
-        LocalDateTime.now().atZone(TimeZone.getDefault().toZoneId());
+    ZonedDateTime zonedDateTime = LocalDateTime.now().atZone(TimeZone.getDefault().toZoneId());
     return zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime();
   }
 
   @Test
   public void testNowLikeFunctions() throws IOException {
-    var serializationPattern = new DateTimeFormatterBuilder()
+    var serializationPattern =
+        new DateTimeFormatterBuilder()
             .appendPattern(serializationPatternStr)
             .optionalStart()
             .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
@@ -167,15 +214,16 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
     double delta = 2d; // acceptable time diff, secs
     if (reference instanceof LocalDate)
       delta = 1d; // Max date delta could be 1 if test runs on the very edge of two days
-                  // We ignore probability of a test run on edge of month or year to simplify the checks
+    // We ignore probability of a test run on edge of month or year to simplify the checks
 
-    var calls = new ArrayList<String>() {{
-      add(name + "()");
-    }};
-    if (hasShortcut)
-      calls.add(name);
-    if (hasFsp)
-      calls.add(name + "(0)");
+    var calls =
+        new ArrayList<String>() {
+          {
+            add(name + "()");
+          }
+        };
+    if (hasShortcut) calls.add(name);
+    if (hasFsp) calls.add(name + "(0)");
 
     // Column order is: func(), func, func(0)
     //                   shortcut ^    fsp ^
@@ -185,20 +233,25 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
     JSONArray firstRow = rows.getJSONArray(0);
     for (int i = 0; i < rows.length(); i++) {
       var row = rows.getJSONArray(i);
-      if (constValue)
-        assertTrue(firstRow.similar(row));
+      if (constValue) assertTrue(firstRow.similar(row));
 
       int column = 0;
-      assertEquals(0,
-          getDiff(reference, parser.apply(row.getString(column++), serializationPattern)), delta);
+      assertEquals(
+          0,
+          getDiff(reference, parser.apply(row.getString(column++), serializationPattern)),
+          delta);
 
       if (hasShortcut) {
-        assertEquals(0,
-            getDiff(reference, parser.apply(row.getString(column++), serializationPattern)), delta);
+        assertEquals(
+            0,
+            getDiff(reference, parser.apply(row.getString(column++), serializationPattern)),
+            delta);
       }
       if (hasFsp) {
-        assertEquals(0,
-            getDiff(reference, parser.apply(row.getString(column), serializationPattern)), delta);
+        assertEquals(
+            0,
+            getDiff(reference, parser.apply(row.getString(column), serializationPattern)),
+            delta);
       }
     }
   }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NullLiteralIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NullLiteralIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.util.MatcherUtils.rows;
@@ -34,28 +33,22 @@ public class NullLiteralIT extends SQLIntegTestCase {
 
   @Test
   public void testNullLiteralInOperator() {
-    verifyDataRows(
-        query("SELECT NULL = NULL, NULL AND TRUE"),
-        rows(null, null));
+    verifyDataRows(query("SELECT NULL = NULL, NULL AND TRUE"), rows(null, null));
   }
 
   @Test
   public void testNullLiteralInFunction() {
-    verifyDataRows(
-        query("SELECT ABS(NULL), POW(2, FLOOR(NULL))"),
-        rows(null, null));
+    verifyDataRows(query("SELECT ABS(NULL), POW(2, FLOOR(NULL))"), rows(null, null));
   }
 
   @Test
   public void testNullLiteralInInterval() {
     verifyDataRows(
         query("SELECT INTERVAL NULL DAY, INTERVAL 60 * 60 * 24 * (NULL - FLOOR(NULL)) SECOND"),
-        rows(null, null)
-    );
+        rows(null, null));
   }
 
   private JSONObject query(String sql) {
     return new JSONObject(executeQuery(sql, "jdbc"));
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationBlackboxIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationBlackboxIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.sql;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
@@ -27,8 +26,7 @@ public class PaginationBlackboxIT extends SQLIntegTestCase {
   private final Index index;
   private final Integer pageSize;
 
-  public PaginationBlackboxIT(@Name("index") Index index,
-                              @Name("pageSize") Integer pageSize) {
+  public PaginationBlackboxIT(@Name("index") Index index, @Name("pageSize") Integer pageSize) {
     this.index = index;
     this.pageSize = pageSize;
   }
@@ -45,7 +43,7 @@ public class PaginationBlackboxIT extends SQLIntegTestCase {
     var testData = new ArrayList<Object[]>();
     for (var index : indices) {
       for (var pageSize : pageSizes) {
-        testData.add(new Object[] { index, pageSize });
+        testData.add(new Object[] {index, pageSize});
       }
     }
     return testData;
@@ -64,14 +62,19 @@ public class PaginationBlackboxIT extends SQLIntegTestCase {
 
     var responseCounter = 1;
     this.logger.info(testReportPrefix + "first response");
-    response = new JSONObject(executeFetchQuery(
-      String.format("select * from %s", index.getName()), pageSize, "jdbc"));
+    response =
+        new JSONObject(
+            executeFetchQuery(
+                String.format("select * from %s", index.getName()), pageSize, "jdbc"));
 
-    var cursor = response.has("cursor")? response.getString("cursor") : "";
+    var cursor = response.has("cursor") ? response.getString("cursor") : "";
     do {
-      this.logger.info(testReportPrefix
-        + String.format("subsequent response %d/%d", responseCounter++, (indexSize / pageSize) + 1));
-      assertTrue("Paged response schema doesn't match to non-paged",
+      this.logger.info(
+          testReportPrefix
+              + String.format(
+                  "subsequent response %d/%d", responseCounter++, (indexSize / pageSize) + 1));
+      assertTrue(
+          "Paged response schema doesn't match to non-paged",
           schema.similar(response.getJSONArray("schema")));
 
       rowsReturned += response.getInt("size");
@@ -88,13 +91,17 @@ public class PaginationBlackboxIT extends SQLIntegTestCase {
         cursor = "";
       }
 
-    } while(!cursor.isEmpty());
-    assertTrue("Paged response schema doesn't match to non-paged",
+    } while (!cursor.isEmpty());
+    assertTrue(
+        "Paged response schema doesn't match to non-paged",
         schema.similar(response.getJSONArray("schema")));
 
-    assertEquals(testReportPrefix + "Paged responses return another row count that non-paged",
-        indexSize, rowsReturned);
-    assertTrue(testReportPrefix + "Paged accumulated result has other rows than non-paged",
+    assertEquals(
+        testReportPrefix + "Paged responses return another row count that non-paged",
+        indexSize,
+        rowsReturned);
+    assertTrue(
+        testReportPrefix + "Paged accumulated result has other rows than non-paged",
         rows.similar(rowsPaged));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
@@ -36,23 +36,24 @@ public class PaginationFallbackIT extends SQLIntegTestCase {
 
   @Test
   public void testSelectWithOpenSearchFuncInFilter() throws IOException {
-    var response = executeQueryTemplate(
-        "SELECT * FROM %s WHERE `11` = match_phrase('96')", TEST_INDEX_ONLINE);
+    var response =
+        executeQueryTemplate("SELECT * FROM %s WHERE `11` = match_phrase('96')", TEST_INDEX_ONLINE);
     verifyIsV2Cursor(response);
   }
 
   @Test
   public void testSelectWithHighlight() throws IOException {
-    var response = executeQueryTemplate(
-        "SELECT highlight(`11`) FROM %s WHERE match_query(`11`, '96')", TEST_INDEX_ONLINE);
+    var response =
+        executeQueryTemplate(
+            "SELECT highlight(`11`) FROM %s WHERE match_query(`11`, '96')", TEST_INDEX_ONLINE);
 
     verifyIsV2Cursor(response);
   }
 
   @Test
   public void testSelectWithFullTextSearch() throws IOException {
-    var response = executeQueryTemplate(
-        "SELECT * FROM %s WHERE match_phrase(`11`, '96')", TEST_INDEX_ONLINE);
+    var response =
+        executeQueryTemplate("SELECT * FROM %s WHERE match_phrase(`11`, '96')", TEST_INDEX_ONLINE);
     verifyIsV2Cursor(response);
   }
 
@@ -64,8 +65,7 @@ public class PaginationFallbackIT extends SQLIntegTestCase {
 
   @Test
   public void testSelectFromDataSource() throws IOException {
-    var response = executeQueryTemplate("SELECT * FROM @opensearch.%s",
-        TEST_INDEX_ONLINE);
+    var response = executeQueryTemplate("SELECT * FROM @opensearch.%s", TEST_INDEX_ONLINE);
     verifyIsV2Cursor(response);
   }
 
@@ -77,31 +77,29 @@ public class PaginationFallbackIT extends SQLIntegTestCase {
 
   @Test
   public void testSubquery() throws IOException {
-    var response = executeQueryTemplate("SELECT `107` from (SELECT * FROM %s)",
-        TEST_INDEX_ONLINE);
+    var response = executeQueryTemplate("SELECT `107` from (SELECT * FROM %s)", TEST_INDEX_ONLINE);
     verifyIsV1Cursor(response);
   }
 
   @Test
   public void testSelectExpression() throws IOException {
-    var response = executeQueryTemplate("SELECT 1 + 1 - `107` from %s",
-        TEST_INDEX_ONLINE);
+    var response = executeQueryTemplate("SELECT 1 + 1 - `107` from %s", TEST_INDEX_ONLINE);
     verifyIsV2Cursor(response);
   }
 
   @Test
   public void testGroupBy() throws IOException {
     // GROUP BY is not paged by either engine.
-     var response = executeQueryTemplate("SELECT * FROM %s GROUP BY `107`",
-      TEST_INDEX_ONLINE);
+    var response = executeQueryTemplate("SELECT * FROM %s GROUP BY `107`", TEST_INDEX_ONLINE);
     TestUtils.verifyNoCursor(response);
   }
 
   @Test
   public void testGroupByHaving() throws IOException {
     // GROUP BY is not paged by either engine.
-    var response = executeQueryTemplate("SELECT * FROM %s GROUP BY `107` HAVING `107` > 400",
-        TEST_INDEX_ONLINE);
+    var response =
+        executeQueryTemplate(
+            "SELECT * FROM %s GROUP BY `107` HAVING `107` > 400", TEST_INDEX_ONLINE);
     TestUtils.verifyNoCursor(response);
   }
 
@@ -113,15 +111,13 @@ public class PaginationFallbackIT extends SQLIntegTestCase {
 
   @Test
   public void testLimitOffset() throws IOException {
-    var response = executeQueryTemplate("SELECT * FROM %s LIMIT 8 OFFSET 4",
-        TEST_INDEX_ONLINE);
+    var response = executeQueryTemplate("SELECT * FROM %s LIMIT 8 OFFSET 4", TEST_INDEX_ONLINE);
     verifyIsV1Cursor(response);
   }
 
   @Test
   public void testOrderBy() throws IOException {
-    var response = executeQueryTemplate("SELECT * FROM %s ORDER By `107`",
-        TEST_INDEX_ONLINE);
+    var response = executeQueryTemplate("SELECT * FROM %s ORDER By `107`", TEST_INDEX_ONLINE);
     verifyIsV2Cursor(response);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -73,12 +73,16 @@ public class PaginationIT extends SQLIntegTestCase {
     ResponseException exception =
         expectThrows(ResponseException.class, () -> executeCursorQuery(cursor));
     response = new JSONObject(TestUtils.getResponseBody(exception.getResponse()));
-    assertEquals(response.getJSONObject("error").getString("reason"),
+    assertEquals(
+        response.getJSONObject("error").getString("reason"),
         "Error occurred in OpenSearch engine: all shards failed");
-    assertTrue(response.getJSONObject("error").getString("details")
-        .contains("SearchContextMissingException[No search context found for id"));
-    assertEquals(response.getJSONObject("error").getString("type"),
-        "SearchPhaseExecutionException");
+    assertTrue(
+        response
+            .getJSONObject("error")
+            .getString("details")
+            .contains("SearchContextMissingException[No search context found for id"));
+    assertEquals(
+        response.getJSONObject("error").getString("type"), "SearchPhaseExecutionException");
 
     wipeAllClusterSettings();
   }
@@ -106,12 +110,16 @@ public class PaginationIT extends SQLIntegTestCase {
     ResponseException exception =
         expectThrows(ResponseException.class, () -> executeCursorQuery(cursor));
     response = new JSONObject(TestUtils.getResponseBody(exception.getResponse()));
-    assertEquals(response.getJSONObject("error").getString("reason"),
+    assertEquals(
+        response.getJSONObject("error").getString("reason"),
         "Error occurred in OpenSearch engine: all shards failed");
-    assertTrue(response.getJSONObject("error").getString("details")
-        .contains("SearchContextMissingException[No search context found for id"));
-    assertEquals(response.getJSONObject("error").getString("type"),
-        "SearchPhaseExecutionException");
+    assertTrue(
+        response
+            .getJSONObject("error")
+            .getString("details")
+            .contains("SearchContextMissingException[No search context found for id"));
+    assertEquals(
+        response.getJSONObject("error").getString("type"), "SearchPhaseExecutionException");
   }
 
   @Test
@@ -134,7 +142,8 @@ public class PaginationIT extends SQLIntegTestCase {
     var cursor = response.getString("cursor");
     do {
       assertTrue(cursor.isEmpty() || cursor.startsWith("n:"));
-      assertTrue("Paged response schema doesn't match to non-paged",
+      assertTrue(
+          "Paged response schema doesn't match to non-paged",
           schema.similar(response.getJSONArray("schema")));
 
       rowsReturnedAsc += response.getInt("size");
@@ -151,7 +160,7 @@ public class PaginationIT extends SQLIntegTestCase {
         cursor = "";
       }
 
-    } while(!cursor.isEmpty());
+    } while (!cursor.isEmpty());
 
     query = String.format("SELECT * from %s ORDER BY num1 DESC", TEST_INDEX_CALCS);
     response = new JSONObject(executeFetchQuery(query, 7, "jdbc"));
@@ -160,7 +169,8 @@ public class PaginationIT extends SQLIntegTestCase {
     cursor = response.getString("cursor");
     do {
       assertTrue(cursor.isEmpty() || cursor.startsWith("n:"));
-      assertTrue("Paged response schema doesn't match to non-paged",
+      assertTrue(
+          "Paged response schema doesn't match to non-paged",
           schema.similar(response.getJSONArray("schema")));
 
       rowsReturnedDesc += response.getInt("size");
@@ -177,19 +187,22 @@ public class PaginationIT extends SQLIntegTestCase {
         cursor = "";
       }
 
-    } while(!cursor.isEmpty());
+    } while (!cursor.isEmpty());
 
-    assertEquals("Paged responses return another row count that non-paged",
-        indexSize, rowsReturnedAsc);
-    assertEquals("Paged responses return another row count that non-paged",
-        indexSize, rowsReturnedDesc);
-    assertTrue("Paged accumulated result has other rows than non-paged",
+    assertEquals(
+        "Paged responses return another row count that non-paged", indexSize, rowsReturnedAsc);
+    assertEquals(
+        "Paged responses return another row count that non-paged", indexSize, rowsReturnedDesc);
+    assertTrue(
+        "Paged accumulated result has other rows than non-paged",
         rows.toList().containsAll(rowsPagedAsc.toList()));
-    assertTrue("Paged accumulated result has other rows than non-paged",
+    assertTrue(
+        "Paged accumulated result has other rows than non-paged",
         rows.toList().containsAll(rowsPagedDesc.toList()));
 
     for (int row = 0; row < indexSize; row++) {
-      assertTrue(String.format("Row %d: row order is incorrect", row),
+      assertTrue(
+          String.format("Row %d: row order is incorrect", row),
           rowsPagedAsc.getJSONArray(row).similar(rowsPagedDesc.getJSONArray(indexSize - row - 1)));
     }
   }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationWindowIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationWindowIT.java
@@ -40,10 +40,11 @@ public class PaginationWindowIT extends SQLIntegTestCase {
     } while (response.has("cursor"));
     numRows += response.getJSONArray("datarows").length();
 
-    var countRows = executeJdbcRequest("SELECT COUNT(*) FROM " + TEST_INDEX_PHRASE)
-        .getJSONArray("datarows")
-        .getJSONArray(0)
-        .get(0);
+    var countRows =
+        executeJdbcRequest("SELECT COUNT(*) FROM " + TEST_INDEX_PHRASE)
+            .getJSONArray("datarows")
+            .getJSONArray(0)
+            .get(0);
     assertEquals(countRows, numRows);
   }
 
@@ -62,10 +63,11 @@ public class PaginationWindowIT extends SQLIntegTestCase {
       response = executeCursorQuery(cursor);
     } while (response.has("cursor"));
     numRows += response.getJSONArray("datarows").length();
-    var countRows = executeJdbcRequest("SELECT COUNT(*) FROM " + TEST_INDEX_PHRASE)
-        .getJSONArray("datarows")
-        .getJSONArray(0)
-        .get(0);
+    var countRows =
+        executeJdbcRequest("SELECT COUNT(*) FROM " + TEST_INDEX_PHRASE)
+            .getJSONArray("datarows")
+            .getJSONArray(0)
+            .get(0);
     assertEquals(countRows, numRows);
     assertTrue(numRows > querySizeLimit);
   }
@@ -74,12 +76,10 @@ public class PaginationWindowIT extends SQLIntegTestCase {
   public void testQuerySizeLimitDoesNotEffectPageSize() throws IOException {
     setQuerySizeLimit(3);
     setMaxResultWindow(TEST_INDEX_PHRASE, 4);
-    var response
-        = executeQueryTemplate("SELECT * FROM %s", TEST_INDEX_PHRASE, 4);
+    var response = executeQueryTemplate("SELECT * FROM %s", TEST_INDEX_PHRASE, 4);
     assertEquals(4, response.getInt("size"));
 
-    var response2
-        = executeQueryTemplate("SELECT * FROM %s", TEST_INDEX_PHRASE, 2);
+    var response2 = executeQueryTemplate("SELECT * FROM %s", TEST_INDEX_PHRASE, 2);
     assertEquals(2, response2.getInt("size"));
   }
 
@@ -87,11 +87,9 @@ public class PaginationWindowIT extends SQLIntegTestCase {
   public void testFetchSizeLargerThanResultWindowFails() throws IOException {
     final int window = 2;
     setMaxResultWindow(TEST_INDEX_PHRASE, 2);
-    assertThrows(ResponseException.class,
-        () -> executeQueryTemplate("SELECT * FROM %s",
-            TEST_INDEX_PHRASE, window + 1));
+    assertThrows(
+        ResponseException.class,
+        () -> executeQueryTemplate("SELECT * FROM %s", TEST_INDEX_PHRASE, window + 1));
     resetMaxResultWindow(TEST_INDEX_PHRASE);
   }
-
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PositionFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PositionFunctionIT.java
@@ -26,19 +26,29 @@ public class PositionFunctionIT extends SQLIntegTestCase {
   @Test
   public void position_function_test() {
     String query = "SELECT firstname, position('a' IN firstname) FROM %s";
-    JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_PEOPLE2));
+    JSONObject response =
+        executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_PEOPLE2));
 
-    verifySchema(response, schema("firstname", null, "keyword"),
-            schema("position('a' IN firstname)", null, "integer"));
+    verifySchema(
+        response,
+        schema("firstname", null, "keyword"),
+        schema("position('a' IN firstname)", null, "integer"));
     assertEquals(12, response.getInt("total"));
 
-    verifyDataRows(response,
-            rows("Daenerys", 2), rows("Hattie", 2),
-            rows("Nanette", 2), rows("Dale", 2),
-            rows("Elinor", 0), rows("Virginia", 8),
-            rows("Dillard", 5), rows("Mcgee", 0),
-            rows("Aurelia", 7), rows("Fulton", 0),
-            rows("Burton", 0), rows("Josie", 0));
+    verifyDataRows(
+        response,
+        rows("Daenerys", 2),
+        rows("Hattie", 2),
+        rows("Nanette", 2),
+        rows("Dale", 2),
+        rows("Elinor", 0),
+        rows("Virginia", 8),
+        rows("Dillard", 5),
+        rows("Mcgee", 0),
+        rows("Aurelia", 7),
+        rows("Fulton", 0),
+        rows("Burton", 0),
+        rows("Josie", 0));
   }
 
   @Test
@@ -46,20 +56,31 @@ public class PositionFunctionIT extends SQLIntegTestCase {
     String query = "SELECT str2, position('ee' IN str2) FROM %s";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_CALCS));
 
-    verifySchema(response, schema("str2", null, "keyword"),
-            schema("position('ee' IN str2)", null, "integer"));
+    verifySchema(
+        response,
+        schema("str2", null, "keyword"),
+        schema("position('ee' IN str2)", null, "integer"));
     assertEquals(17, response.getInt("total"));
 
-    verifyDataRows(response,
-            rows("one", 0), rows("two", 0),
-            rows("three", 4), rows(null, null),
-            rows("five", 0), rows("six", 0),
-            rows(null, null), rows("eight", 0),
-            rows("nine", 0), rows("ten", 0),
-            rows("eleven", 0), rows("twelve", 0),
-            rows(null, null), rows("fourteen", 6),
-            rows("fifteen", 5), rows("sixteen", 5),
-            rows(null, null));
+    verifyDataRows(
+        response,
+        rows("one", 0),
+        rows("two", 0),
+        rows("three", 4),
+        rows(null, null),
+        rows("five", 0),
+        rows("six", 0),
+        rows(null, null),
+        rows("eight", 0),
+        rows("nine", 0),
+        rows("ten", 0),
+        rows("eleven", 0),
+        rows("twelve", 0),
+        rows(null, null),
+        rows("fourteen", 6),
+        rows("fifteen", 5),
+        rows("sixteen", 5),
+        rows(null, null));
   }
 
   @Test
@@ -86,7 +107,8 @@ public class PositionFunctionIT extends SQLIntegTestCase {
 
   @Test
   public void position_function_with_function_as_arg_test() {
-    String query = "SELECT position(upper(str3) IN str1) FROM %s WHERE str1 LIKE 'BINDING SUPPLIES'";
+    String query =
+        "SELECT position(upper(str3) IN str1) FROM %s WHERE str1 LIKE 'BINDING SUPPLIES'";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_CALCS));
 
     verifySchema(response, schema("position(upper(str3) IN str1)", null, "integer"));
@@ -110,17 +132,21 @@ public class PositionFunctionIT extends SQLIntegTestCase {
   public void position_function_with_null_args_test() {
     String query1 = "SELECT str2, position(null IN str2) FROM %s WHERE str2 IN ('one')";
     String query2 = "SELECT str2, position(str2 IN null) FROM %s WHERE str2 IN ('one')";
-    JSONObject response1 = executeJdbcRequest(String.format(query1, TestsConstants.TEST_INDEX_CALCS));
-    JSONObject response2 = executeJdbcRequest(String.format(query2, TestsConstants.TEST_INDEX_CALCS));
+    JSONObject response1 =
+        executeJdbcRequest(String.format(query1, TestsConstants.TEST_INDEX_CALCS));
+    JSONObject response2 =
+        executeJdbcRequest(String.format(query2, TestsConstants.TEST_INDEX_CALCS));
 
-    verifySchema(response1,
-            schema("str2", null, "keyword"),
-            schema("position(null IN str2)", null, "integer"));
+    verifySchema(
+        response1,
+        schema("str2", null, "keyword"),
+        schema("position(null IN str2)", null, "integer"));
     assertEquals(1, response1.getInt("total"));
 
-    verifySchema(response2,
-            schema("str2", null, "keyword"),
-            schema("position(str2 IN null)", null, "integer"));
+    verifySchema(
+        response2,
+        schema("str2", null, "keyword"),
+        schema("position(str2 IN null)", null, "integer"));
     assertEquals(1, response2.getInt("total"));
 
     verifyDataRows(response1, rows("one", null));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PreparedStatementIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PreparedStatementIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.sql;
 
 import org.json.JSONObject;
@@ -20,16 +19,21 @@ public class PreparedStatementIT extends SQLIntegTestCase {
 
   @Test
   public void testPreparedStatement() {
-    JSONObject response = new JSONObject(
-        executeQuery(String.format("{\n"
-            + "  \"query\": \"SELECT state FROM %s WHERE state = ? GROUP BY state\",\n"
-            + "  \"parameters\": [\n"
-            + "    {\n"
-            + "      \"type\": \"string\",\n"
-            + "      \"value\": \"WA\"\n"
-            + "    }\n"
-            + " ]\n"
-            + "}", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc"));
+    JSONObject response =
+        new JSONObject(
+            executeQuery(
+                String.format(
+                    "{\n"
+                        + "  \"query\": \"SELECT state FROM %s WHERE state = ? GROUP BY state\",\n"
+                        + "  \"parameters\": [\n"
+                        + "    {\n"
+                        + "      \"type\": \"string\",\n"
+                        + "      \"value\": \"WA\"\n"
+                        + "    }\n"
+                        + " ]\n"
+                        + "}",
+                    TestsConstants.TEST_INDEX_ACCOUNT),
+                "jdbc"));
 
     assertFalse(response.getJSONArray("datarows").isEmpty());
   }
@@ -39,5 +43,4 @@ public class PreparedStatementIT extends SQLIntegTestCase {
     // Avoid wrap with "query" again
     return query;
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryIT.java
@@ -13,72 +13,80 @@ import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 public class QueryIT extends SQLIntegTestCase {
-    @Override
-    public void init() throws IOException {
-        loadIndex(Index.BEER);
-    }
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.BEER);
+  }
 
-    @Test
-    public void all_fields_test() throws IOException {
-        String query = "SELECT * FROM "
-                + TEST_INDEX_BEER + " WHERE query('*:taste')";
-        JSONObject result = executeJdbcRequest(query);
-        assertEquals(16, result.getInt("total"));
-    }
+  @Test
+  public void all_fields_test() throws IOException {
+    String query = "SELECT * FROM " + TEST_INDEX_BEER + " WHERE query('*:taste')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(16, result.getInt("total"));
+  }
 
-    @Test
-    public void mandatory_params_test() throws IOException {
-        String query = "SELECT Id FROM "
-                + TEST_INDEX_BEER + " WHERE query('Tags:taste OR Body:taste')";
-        JSONObject result = executeJdbcRequest(query);
-        assertEquals(16, result.getInt("total"));
-    }
+  @Test
+  public void mandatory_params_test() throws IOException {
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query('Tags:taste OR Body:taste')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(16, result.getInt("total"));
+  }
 
-    @Test
-    public void all_params_test() throws IOException {
-        String query = "SELECT Id FROM " + TEST_INDEX_BEER
-                + " WHERE query('Tags:taste', escape=false,"
-                + "allow_leading_wildcard=true, enable_position_increments=true,"
-                + "fuzziness= 1, fuzzy_rewrite='constant_score', max_determinized_states = 10000,"
-                + "analyzer='standard', analyze_wildcard = false, quote_field_suffix = '.exact',"
-                + "auto_generate_synonyms_phrase_query=true, boost = 0.77,"
-                + "quote_analyzer='standard', phrase_slop=0, rewrite='constant_score', type='best_fields',"
-                + "tie_breaker=0.3, time_zone='Canada/Pacific', default_operator='or',"
-                + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
-                + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7);";
-        JSONObject result = executeJdbcRequest(query);
-        assertEquals(8, result.getInt("total"));
-    }
+  @Test
+  public void all_params_test() throws IOException {
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE query('Tags:taste',"
+            + " escape=false,allow_leading_wildcard=true,"
+            + " enable_position_increments=true,"
+            + " fuzziness= 1,"
+            + " fuzzy_rewrite='constant_score',"
+            + " max_determinized_states = 10000,"
+            + " analyzer='standard',"
+            + " analyze_wildcard = false,"
+            + " quote_field_suffix = '.exact',"
+            + " auto_generate_synonyms_phrase_query=true,"
+            + " boost = 0.77,"
+            + " quote_analyzer='standard',"
+            + " phrase_slop=0,"
+            + " rewrite='constant_score',"
+            + " type='best_fields',"
+            + " tie_breaker=0.3,"
+            + " time_zone='Canada/Pacific',"
+            + " default_operator='or',"
+            + " fuzzy_transpositions = false,"
+            + " lenient = true,"
+            + " fuzzy_max_expansions = 25,"
+            + " minimum_should_match = '2<-25% 9<-3',"
+            + " fuzzy_prefix_length = 7);";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(8, result.getInt("total"));
+  }
 
-    @Test
-    public void wildcard_test() throws IOException {
-        String query1 = "SELECT Id FROM "
-                + TEST_INDEX_BEER + " WHERE query('Tags:taste')";
-        JSONObject result1 = executeJdbcRequest(query1);
-        String query2 = "SELECT Id FROM "
-                + TEST_INDEX_BEER + " WHERE query('*:taste')";
-        JSONObject result2 = executeJdbcRequest(query2);
-        assertNotEquals(result2.getInt("total"), result1.getInt("total"));
+  @Test
+  public void wildcard_test() throws IOException {
+    String query1 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query('Tags:taste')";
+    JSONObject result1 = executeJdbcRequest(query1);
+    String query2 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query('*:taste')";
+    JSONObject result2 = executeJdbcRequest(query2);
+    assertNotEquals(result2.getInt("total"), result1.getInt("total"));
 
-        String query3 = "SELECT Id FROM " + TEST_INDEX_BEER
-                + " WHERE query('Tags:tas*');";
-        JSONObject result3 = executeJdbcRequest(query3);
-        assertEquals(8, result3.getInt("total"));
+    String query3 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query('Tags:tas*');";
+    JSONObject result3 = executeJdbcRequest(query3);
+    assertEquals(8, result3.getInt("total"));
 
-        String query4 = "SELECT Id FROM " + TEST_INDEX_BEER
-                + " WHERE query('Tags:tas?e');";
-        JSONObject result4 = executeJdbcRequest(query3);
-        assertEquals(8, result4.getInt("total"));
-    }
+    String query4 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query('Tags:tas?e');";
+    JSONObject result4 = executeJdbcRequest(query3);
+    assertEquals(8, result4.getInt("total"));
+  }
 
-    @Test
-    public void query_string_and_query_return_the_same_results_test() throws IOException {
-        String query1 = "SELECT Id FROM "
-                + TEST_INDEX_BEER + " WHERE query('Tags:taste')";
-        JSONObject result1 = executeJdbcRequest(query1);
-        String query2 = "SELECT Id FROM "
-                + TEST_INDEX_BEER + " WHERE query_string(['Tags'],'taste')";
-        JSONObject result2 = executeJdbcRequest(query2);
-        assertEquals(result2.getInt("total"), result1.getInt("total"));
-    }
+  @Test
+  public void query_string_and_query_return_the_same_results_test() throws IOException {
+    String query1 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query('Tags:taste')";
+    JSONObject result1 = executeJdbcRequest(query1);
+    String query2 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query_string(['Tags'],'taste')";
+    JSONObject result2 = executeJdbcRequest(query2);
+    assertEquals(result2.getInt("total"), result1.getInt("total"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryStringIT.java
@@ -20,48 +20,65 @@ public class QueryStringIT extends SQLIntegTestCase {
 
   @Test
   public void all_fields_test() throws IOException {
-    String query = "SELECT * FROM "
-        + TEST_INDEX_BEER + " WHERE query_string(['*'], 'taste')";
+    String query = "SELECT * FROM " + TEST_INDEX_BEER + " WHERE query_string(['*'], 'taste')";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(16, result.getInt("total"));
   }
 
   @Test
   public void mandatory_params_test() throws IOException {
-    String query = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(16, result.getInt("total"));
   }
 
   @Test
   public void all_params_test() throws IOException {
-    String query = "SELECT Id FROM " + TEST_INDEX_BEER
-        + " WHERE query_string(['Body', Tags, Title], 'taste beer', escape=false,"
-        + "allow_leading_wildcard=true, enable_position_increments=true,"
-        + "fuzziness= 1, fuzzy_rewrite='constant_score', max_determinized_states = 10000,"
-        + "analyzer='english', analyze_wildcard = false, quote_field_suffix = '.exact',"
-        + "auto_generate_synonyms_phrase_query=true, boost = 0.77,"
-        + "quote_analyzer='standard', phrase_slop=0, rewrite='constant_score', type='best_fields',"
-        + "tie_breaker=0.3, time_zone='Canada/Pacific', default_operator='or',"
-        + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
-        + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7);";
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE query_string(['Body', Tags, Title],"
+            + " 'taste beer',"
+            + " escape=false,"
+            + " allow_leading_wildcard=true,"
+            + " enable_position_increments=true,"
+            + " fuzziness= 1,"
+            + " fuzzy_rewrite='constant_score',"
+            + " max_determinized_states = 10000,"
+            + " analyzer='english',"
+            + " analyze_wildcard = false,"
+            + " quote_field_suffix = '.exact',"
+            + " auto_generate_synonyms_phrase_query=true,"
+            + " boost = 0.77,"
+            + " quote_analyzer='standard',"
+            + " phrase_slop=0,"
+            + " rewrite='constant_score',"
+            + " type='best_fields',"
+            + " tie_breaker=0.3,"
+            + " time_zone='Canada/Pacific',"
+            + " default_operator='or',"
+            + " fuzzy_transpositions = false,"
+            + " lenient = true,"
+            + " fuzzy_max_expansions = 25,"
+            + " minimum_should_match = '2<-25% 9<-3',"
+            + " fuzzy_prefix_length = 7);";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(49, result.getInt("total"));
   }
 
   @Test
   public void wildcard_test() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string(['Tags'], 'taste')";
+    String query1 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query_string(['Tags'], 'taste')";
     JSONObject result1 = executeJdbcRequest(query1);
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string(['T*'], 'taste')";
+    String query2 = "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query_string(['T*'], 'taste')";
     JSONObject result2 = executeJdbcRequest(query2);
     assertNotEquals(result2.getInt("total"), result1.getInt("total"));
 
-    String query3 = "SELECT Id FROM " + TEST_INDEX_BEER
-        + " WHERE query_string(['*Date'], '2014-01-22');";
+    String query3 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query_string(['*Date'], '2014-01-22');";
     JSONObject result3 = executeJdbcRequest(query3);
     assertEquals(10, result3.getInt("total"));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.sql;
 
 import static org.hamcrest.Matchers.is;
@@ -25,28 +24,29 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 /**
- * The query validation IT only covers test for error cases that not doable in comparison test.
- * For all other tests, comparison test should be favored over manual written test like this.
+ * The query validation IT only covers test for error cases that not doable in comparison test. For
+ * all other tests, comparison test should be favored over manual written test like this.
  */
 public class QueryValidationIT extends SQLIntegTestCase {
 
-  @Rule
-  public ExpectedException exceptionRule = ExpectedException.none();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Override
   protected void init() throws Exception {
     loadIndex(Index.ACCOUNT);
   }
 
-  @Ignore("Will add this validation in analyzer later. This test should be enabled once " +
-          "https://github.com/opensearch-project/sql/issues/910 has been resolved")
+  @Ignore(
+      "Will add this validation in analyzer later. This test should be enabled once "
+          + "https://github.com/opensearch-project/sql/issues/910 has been resolved")
   @Test
   public void testNonAggregatedSelectColumnMissingInGroupByClause() throws IOException {
     expectResponseException()
         .hasStatusCode(BAD_REQUEST)
         .hasErrorType("SemanticCheckException")
-        .containsMessage("Expression [state] that contains non-aggregated column "
-                       + "is not present in group by clause")
+        .containsMessage(
+            "Expression [state] that contains non-aggregated column "
+                + "is not present in group by clause")
         .whenExecute("SELECT state FROM opensearch-sql_test_index_account GROUP BY age");
   }
 
@@ -55,8 +55,9 @@ public class QueryValidationIT extends SQLIntegTestCase {
     expectResponseException()
         .hasStatusCode(BAD_REQUEST)
         .hasErrorType("SemanticCheckException")
-        .containsMessage("Explicit GROUP BY clause is required because expression [state] "
-            + "contains non-aggregated column")
+        .containsMessage(
+            "Explicit GROUP BY clause is required because expression [state] "
+                + "contains non-aggregated column")
         .whenExecute("SELECT state, AVG(age) FROM opensearch-sql_test_index_account");
   }
 
@@ -87,8 +88,7 @@ public class QueryValidationIT extends SQLIntegTestCase {
 
   /**
    * Response exception assertion helper to assert property value in OpenSearch ResponseException
-   * and Response inside. This serves as syntax sugar to improve the readability of test
-   * code.
+   * and Response inside. This serves as syntax sugar to improve the readability of test code.
    */
   private static class ResponseExceptionAssertion {
     private final ExpectedException exceptionRule;
@@ -100,9 +100,12 @@ public class QueryValidationIT extends SQLIntegTestCase {
     }
 
     ResponseExceptionAssertion hasStatusCode(RestStatus code) {
-      exceptionRule.expect(featureValueOf("statusCode", is(code),
-          (Function<ResponseException, RestStatus>) e ->
-              RestStatus.fromCode(e.getResponse().getStatusLine().getStatusCode())));
+      exceptionRule.expect(
+          featureValueOf(
+              "statusCode",
+              is(code),
+              (Function<ResponseException, RestStatus>)
+                  e -> RestStatus.fromCode(e.getResponse().getStatusLine().getStatusCode())));
       return this;
     }
 
@@ -133,5 +136,4 @@ public class QueryValidationIT extends SQLIntegTestCase {
 
     client().performRequest(request);
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_RAW_SANITIZE;
@@ -26,21 +25,27 @@ public class RawFormatIT extends SQLIntegTestCase {
 
   @Test
   public void rawFormatWithPipeFieldTest() {
-    String result = executeQuery(
-        String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE), "raw");
-    assertEquals(StringUtils.format(
-        "firstname|lastname%n"
-            + "+Amber JOHnny|Duke Willmington+%n"
-            + "-Hattie|Bond-%n"
-            + "=Nanette|Bates=%n"
-            + "@Dale|Adams@%n"
-            + "@Elinor|\"Ratliff|||\"%n"),
+    String result =
+        executeQuery(
+            String.format(
+                Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE),
+            "raw");
+    assertEquals(
+        StringUtils.format(
+            "firstname|lastname%n"
+                + "+Amber JOHnny|Duke Willmington+%n"
+                + "-Hattie|Bond-%n"
+                + "=Nanette|Bates=%n"
+                + "@Dale|Adams@%n"
+                + "@Elinor|\"Ratliff|||\"%n"),
         result);
   }
 
   @Test
   public void contentHeaderTest() throws IOException {
-    String query = String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE);
+    String query =
+        String.format(
+            Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE);
     String requestBody = makeRequest(query);
 
     Request sqlRequest = new Request("POST", "/_plugins/_sql?format=raw");

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RelevanceFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RelevanceFunctionIT.java
@@ -24,11 +24,15 @@ public class RelevanceFunctionIT extends SQLIntegTestCase {
    */
   @Test
   public void verify_flags_in_simple_query_string() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string(['Body'], '-free', flags='NONE|PREFIX|ESCAPE')";
+    String query1 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string(['Body'], '-free', flags='NONE|PREFIX|ESCAPE')";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string([Body], '-free', flags='NOT|AND|OR')";
+    String query2 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string([Body], '-free', flags='NOT|AND|OR')";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertNotEquals(result2.getInt("total"), result1.getInt("total"));
 
@@ -44,11 +48,11 @@ public class RelevanceFunctionIT extends SQLIntegTestCase {
    */
   @Test
   public void verify_escape_in_query_string() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string([Title], '?', escape=true);";
+    String query1 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query_string([Title], '?', escape=true);";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string([Title], '?', escape=false);";
+    String query2 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE query_string([Title], '?', escape=false);";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertEquals(0, result1.getInt("total"));
     assertEquals(8, result2.getInt("total"));
@@ -61,11 +65,15 @@ public class RelevanceFunctionIT extends SQLIntegTestCase {
    */
   @Test
   public void verify_default_operator_in_query_string() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string([Title], 'beer taste', default_operator='OR')";
+    String query1 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE query_string([Title], 'beer taste', default_operator='OR')";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE query_string([Title], 'beer taste', default_operator='AND')";
+    String query2 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE query_string([Title], 'beer taste', default_operator='AND')";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));
@@ -73,11 +81,15 @@ public class RelevanceFunctionIT extends SQLIntegTestCase {
 
   @Test
   public void verify_default_operator_in_simple_query_string() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string([Title], 'beer taste', default_operator='OR')";
+    String query1 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string([Title], 'beer taste', default_operator='OR')";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string([Title], 'beer taste', default_operator='AND')";
+    String query2 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string([Title], 'beer taste', default_operator='AND')";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));
@@ -85,11 +97,15 @@ public class RelevanceFunctionIT extends SQLIntegTestCase {
 
   @Test
   public void verify_default_operator_in_multi_match() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE multi_match([Title], 'beer taste', operator='OR')";
+    String query1 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE multi_match([Title], 'beer taste', operator='OR')";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE multi_match([Title], 'beer taste', operator='AND')";
+    String query2 =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE multi_match([Title], 'beer taste', operator='AND')";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));
@@ -97,11 +113,11 @@ public class RelevanceFunctionIT extends SQLIntegTestCase {
 
   @Test
   public void verify_operator_in_match() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE match(Title, 'beer taste', operator='OR')";
+    String query1 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE match(Title, 'beer taste', operator='OR')";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE match(Title, 'beer taste', operator='AND')";
+    String query2 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE match(Title, 'beer taste', operator='AND')";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertEquals(16, result1.getInt("total"));
     assertEquals(4, result2.getInt("total"));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SQLCorrectnessIT.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.sql;
 
 import com.google.common.io.Resources;
@@ -14,14 +13,12 @@ import java.nio.file.Paths;
 import java.util.function.Function;
 import org.junit.Test;
 
-/**
- * SQL integration test automated by comparison test framework.
- */
+/** SQL integration test automated by comparison test framework. */
 public class SQLCorrectnessIT extends CorrectnessTestBase {
 
   private static final String ROOT_DIR = "correctness/";
-  private static final String[] EXPR_TEST_DIR = { "expressions" };
-  private static final String[] QUERY_TEST_DIR = { "queries", "bugfixes" };
+  private static final String[] EXPR_TEST_DIR = {"expressions"};
+  private static final String[] QUERY_TEST_DIR = {"queries", "bugfixes"};
 
   @Override
   protected void init() throws Exception {
@@ -35,32 +32,30 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
   }
 
   /**
-   * Verify queries in files in directories with a converter to preprocess query.
-   * For example, for expressions it is converted to a SELECT clause before testing.
+   * Verify queries in files in directories with a converter to preprocess query. For example, for
+   * expressions it is converted to a SELECT clause before testing.
    */
   @SuppressWarnings("UnstableApiUsage")
   private void verifyQueries(String[] dirs, Function<String, String> converter) throws Exception {
     for (String dir : dirs) {
       Path dirPath = Paths.get(Resources.getResource(ROOT_DIR + dir).toURI());
       Files.walk(dirPath)
-           .filter(Files::isRegularFile)
-           .forEach(file -> verifyQueries(file, converter));
+          .filter(Files::isRegularFile)
+          .forEach(file -> verifyQueries(file, converter));
     }
   }
 
-  /**
-   * Comment start with #
-   */
+  /** Comment start with # */
   private void verifyQueries(Path file, Function<String, String> converter) {
     try {
-      String[] queries = Files.lines(file)
-                              .filter(line -> !line.startsWith("#"))
-                              .map(converter)
-                              .toArray(String[]::new);
+      String[] queries =
+          Files.lines(file)
+              .filter(line -> !line.startsWith("#"))
+              .map(converter)
+              .toArray(String[]::new);
       verify(queries);
     } catch (IOException e) {
       throw new IllegalStateException("Failed to read file: " + file, e);
     }
   }
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/ScoreQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ScoreQueryIT.java
@@ -26,6 +26,7 @@ public class ScoreQueryIT extends SQLIntegTestCase {
   }
 
   /**
+   * <pre>
    * "query" : {
    *   "from": 0,
    *   "size": 3,
@@ -83,18 +84,24 @@ public class ScoreQueryIT extends SQLIntegTestCase {
    *   ],
    *   "track_scores": true
    * }
+   * </pre>
    * @throws IOException
    */
   @Test
   public void scoreQueryExplainTest() throws IOException {
-    final String result = explainQuery(String.format(Locale.ROOT,
-        "select address from %s " +
-            "where score(matchQuery(address, 'Douglass'), 100) " +
-            "or score(matchQuery(address, 'Hall'), 0.5) order by _score desc limit 2",
-        TestsConstants.TEST_INDEX_ACCOUNT));
-    Assert.assertThat(result, containsString("\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"Douglass\\\""));
+    final String result =
+        explainQuery(
+            String.format(
+                Locale.ROOT,
+                "select address from %s "
+                    + "where score(matchQuery(address, 'Douglass'), 100) "
+                    + "or score(matchQuery(address, 'Hall'), 0.5) order by _score desc limit 2",
+                TestsConstants.TEST_INDEX_ACCOUNT));
+    Assert.assertThat(
+        result, containsString("\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"Douglass\\\""));
     Assert.assertThat(result, containsString("\\\"boost\\\":100.0"));
-    Assert.assertThat(result, containsString("\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"Hall\\\""));
+    Assert.assertThat(
+        result, containsString("\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"Hall\\\""));
     Assert.assertThat(result, containsString("\\\"boost\\\":0.5"));
     Assert.assertThat(result, containsString("\\\"sort\\\":[{\\\"_score\\\""));
     Assert.assertThat(result, containsString("\\\"track_scores\\\":true"));
@@ -102,26 +109,32 @@ public class ScoreQueryIT extends SQLIntegTestCase {
 
   @Test
   public void scoreQueryTest() throws IOException {
-    final JSONObject result = new JSONObject(executeQuery(String.format(Locale.ROOT,
-        "select address, _score from %s " +
-            "where score(matchQuery(address, 'Douglass'), 100) " +
-            "or score(matchQuery(address, 'Hall'), 0.5) order by _score desc limit 2",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc"));
-    verifySchema(result,
-        schema("address", null, "text"),
-        schema("_score", null, "float"));
-    verifyDataRows(result,
-        rows("154 Douglass Street", 650.1515),
-        rows("565 Hall Street", 3.2507575));
+    final JSONObject result =
+        new JSONObject(
+            executeQuery(
+                String.format(
+                    Locale.ROOT,
+                    "select address, _score from %s "
+                        + "where score(matchQuery(address, 'Douglass'), 100) "
+                        + "or score(matchQuery(address, 'Hall'), 0.5) order by _score desc limit 2",
+                    TestsConstants.TEST_INDEX_ACCOUNT),
+                "jdbc"));
+    verifySchema(result, schema("address", null, "text"), schema("_score", null, "float"));
+    verifyDataRows(
+        result, rows("154 Douglass Street", 650.1515), rows("565 Hall Street", 3.2507575));
   }
 
   @Test
   public void scoreQueryDefaultBoostExplainTest() throws IOException {
-    final String result = explainQuery(String.format(Locale.ROOT,
-        "select address from %s " +
-            "where score(matchQuery(address, 'Lane')) order by _score desc limit 2",
-        TestsConstants.TEST_INDEX_ACCOUNT));
-    Assert.assertThat(result, containsString("\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"Lane\\\""));
+    final String result =
+        explainQuery(
+            String.format(
+                Locale.ROOT,
+                "select address from %s "
+                    + "where score(matchQuery(address, 'Lane')) order by _score desc limit 2",
+                TestsConstants.TEST_INDEX_ACCOUNT));
+    Assert.assertThat(
+        result, containsString("\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"Lane\\\""));
     Assert.assertThat(result, containsString("\\\"boost\\\":1.0"));
     Assert.assertThat(result, containsString("\\\"sort\\\":[{\\\"_score\\\""));
     Assert.assertThat(result, containsString("\\\"track_scores\\\":true"));
@@ -129,13 +142,16 @@ public class ScoreQueryIT extends SQLIntegTestCase {
 
   @Test
   public void scoreQueryDefaultBoostQueryTest() throws IOException {
-    final JSONObject result = new JSONObject(executeQuery(String.format(Locale.ROOT,
-        "select address, _score from %s " +
-            "where score(matchQuery(address, 'Powell')) order by _score desc limit 2",
-        TestsConstants.TEST_INDEX_ACCOUNT), "jdbc"));
-    verifySchema(result,
-        schema("address", null, "text"),
-        schema("_score", null, "float"));
+    final JSONObject result =
+        new JSONObject(
+            executeQuery(
+                String.format(
+                    Locale.ROOT,
+                    "select address, _score from %s "
+                        + "where score(matchQuery(address, 'Powell')) order by _score desc limit 2",
+                    TestsConstants.TEST_INDEX_ACCOUNT),
+                "jdbc"));
+    verifySchema(result, schema("address", null, "text"), schema("_score", null, "float"));
     verifyDataRows(result, rows("305 Powell Street", 6.501515));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -31,43 +31,60 @@ public class SimpleQueryStringIT extends SQLIntegTestCase {
 
   @Test
   public void test_mandatory_params() throws IOException {
-    String query = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
     var result = new JSONObject(executeQuery(query, "jdbc"));
     assertEquals(16, result.getInt("total"));
   }
 
   @Test
   public void test_all_params() throws IOException {
-    String query = "SELECT Id FROM " + TEST_INDEX_BEER
-        + " WHERE simple_query_string(['Body', Tags, Title], 'taste beer', default_operator='or',"
-        + "analyzer=english, analyze_wildcard = false, quote_field_suffix = '.exact',"
-        + "auto_generate_synonyms_phrase_query=true, boost = 0.77, flags='PREFIX',"
-        + "fuzzy_transpositions = false, lenient = true, fuzzy_max_expansions = 25,"
-        + "minimum_should_match = '2<-25% 9<-3', fuzzy_prefix_length = 7);";
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string(['Body', Tags, Title], "
+            + "'taste beer',"
+            + " default_operator='or',"
+            + " analyzer=english, "
+            + " analyze_wildcard = false,"
+            + " quote_field_suffix = '.exact',"
+            + " auto_generate_synonyms_phrase_query=true,"
+            + " boost = 0.77,"
+            + " flags='PREFIX',"
+            + " fuzzy_transpositions = false,"
+            + " lenient = true,"
+            + " fuzzy_max_expansions = 25,"
+            + " minimum_should_match = '2<-25% 9<-3',"
+            + " fuzzy_prefix_length = 7);";
     var result = new JSONObject(executeQuery(query, "jdbc"));
     assertEquals(49, result.getInt("total"));
   }
 
   @Test
   public void verify_wildcard_test() throws IOException {
-    String query1 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string(['Tags'], 'taste')";
+    String query1 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE simple_query_string(['Tags'], 'taste')";
     var result1 = new JSONObject(executeQuery(query1, "jdbc"));
-    String query2 = "SELECT Id FROM "
-        + TEST_INDEX_BEER + " WHERE simple_query_string(['T*'], 'taste')";
+    String query2 =
+        "SELECT Id FROM " + TEST_INDEX_BEER + " WHERE simple_query_string(['T*'], 'taste')";
     var result2 = new JSONObject(executeQuery(query2, "jdbc"));
     assertNotEquals(result2.getInt("total"), result1.getInt("total"));
 
-    String query = "SELECT Id FROM " + TEST_INDEX_BEER
-        + " WHERE simple_query_string(['*Date'], '2014-01-22');";
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
+            + " WHERE simple_query_string(['*Date'], '2014-01-22');";
     var result = new JSONObject(executeQuery(query, "jdbc"));
     assertEquals(10, result.getInt("total"));
   }
 
   @Test
   public void contentHeaderTest() throws IOException {
-    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+    String query =
+        "SELECT Id FROM "
+            + TEST_INDEX_BEER
             + " WHERE simple_query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
     String requestBody = makeRequest(query);
 


### PR DESCRIPTION
### Description
Spotless apply on integ-test (part 2 of 4 integ-test integration).
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1101
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).