### PR TITLE
Feature/acarbo json cast ppl

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/expression/Cast.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/Cast.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_FLOAT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_INT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_IP;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_JSON;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_LONG;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_SHORT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.CAST_TO_STRING;
@@ -56,6 +57,7 @@ public class Cast extends UnresolvedExpression {
           .put("timestamp", CAST_TO_TIMESTAMP.getName())
           .put("datetime", CAST_TO_DATETIME.getName())
           .put("ip", CAST_TO_IP.getName())
+          .put("json", CAST_TO_JSON.getName())
           .build();
 
   /** The source expression cast from. */

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -843,6 +843,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.CAST_TO_IP, value);
   }
 
+  public static FunctionExpression castJson(Expression value) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.CAST_TO_JSON, value);
+  }
+
   public static FunctionExpression typeof(Expression value) {
     return compile(FunctionProperties.None, BuiltinFunctionName.TYPEOF, value);
   }
@@ -971,6 +975,10 @@ public class DSL {
   public static FunctionExpression utc_timestamp(
       FunctionProperties functionProperties, Expression... args) {
     return compile(functionProperties, BuiltinFunctionName.UTC_TIMESTAMP, args);
+  }
+
+  public static FunctionExpression json_function(Expression value) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.JSON, value);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -235,6 +235,7 @@ public enum BuiltinFunctionName {
   CAST_TO_TIMESTAMP(FunctionName.of("cast_to_timestamp")),
   CAST_TO_DATETIME(FunctionName.of("cast_to_datetime")),
   CAST_TO_IP(FunctionName.of("cast_to_ip")),
+  CAST_TO_JSON(FunctionName.of("cast_to_json")),
   TYPEOF(FunctionName.of("typeof")),
 
   /** Relevance Function. */
@@ -259,7 +260,10 @@ public enum BuiltinFunctionName {
   MULTIMATCH(FunctionName.of("multimatch")),
   MULTIMATCHQUERY(FunctionName.of("multimatchquery")),
   WILDCARDQUERY(FunctionName.of("wildcardquery")),
-  WILDCARD_QUERY(FunctionName.of("wildcard_query"));
+  WILDCARD_QUERY(FunctionName.of("wildcard_query")),
+
+  /* Json Functions. */
+  JSON(FunctionName.of("json"));
 
   private final FunctionName name;
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -206,6 +206,7 @@ public enum BuiltinFunctionName {
 
   /** Json Functions. */
   JSON_VALID(FunctionName.of("json_valid")),
+  JSON(FunctionName.of("json")),
 
   /** NULL Test. */
   IS_NULL(FunctionName.of("is null")),
@@ -260,10 +261,7 @@ public enum BuiltinFunctionName {
   MULTIMATCH(FunctionName.of("multimatch")),
   MULTIMATCHQUERY(FunctionName.of("multimatchquery")),
   WILDCARDQUERY(FunctionName.of("wildcardquery")),
-  WILDCARD_QUERY(FunctionName.of("wildcard_query")),
-
-  /* Json Functions. */
-  JSON(FunctionName.of("json"));
+  WILDCARD_QUERY(FunctionName.of("wildcard_query"));
 
   private final FunctionName name;
 

--- a/core/src/main/java/org/opensearch/sql/expression/operator/convert/TypeCastOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/convert/TypeCastOperators.java
@@ -17,10 +17,12 @@ import static org.opensearch.sql.data.type.ExprCoreType.SHORT;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
 import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static org.opensearch.sql.data.type.ExprCoreType.UNDEFINED;
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.implWithProperties;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandlingWithProperties;
+import static org.opensearch.sql.utils.JsonUtils.castJson;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -57,6 +59,7 @@ public class TypeCastOperators {
     repository.register(castToDouble());
     repository.register(castToBoolean());
     repository.register(castToIp());
+    repository.register(castToJson());
     repository.register(castToDate());
     repository.register(castToTime());
     repository.register(castToTimestamp());
@@ -181,6 +184,12 @@ public class TypeCastOperators {
         BuiltinFunctionName.CAST_TO_IP.getName(),
         impl(nullMissingHandling((v) -> new ExprIpValue(v.stringValue())), IP, STRING),
         impl(nullMissingHandling((v) -> v), IP, IP));
+  }
+
+  private static DefaultFunctionResolver castToJson() {
+    return FunctionDSL.define(
+        BuiltinFunctionName.CAST_TO_JSON.getName(),
+        impl(nullMissingHandling((v) -> castJson(v.stringValue())), UNDEFINED, STRING));
   }
 
   private static DefaultFunctionResolver castToDate() {

--- a/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
@@ -1,10 +1,24 @@
 package org.opensearch.sql.utils;
 
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import lombok.experimental.UtilityClass;
+import org.opensearch.sql.data.model.ExprCollectionValue;
+import org.opensearch.sql.data.model.ExprDoubleValue;
+import org.opensearch.sql.data.model.ExprIntegerValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 @UtilityClass
 public class JsonUtils {
@@ -18,9 +32,57 @@ public class JsonUtils {
     ObjectMapper objectMapper = new ObjectMapper();
     try {
       objectMapper.readTree(jsonExprValue.stringValue());
-      return ExprValueUtils.LITERAL_TRUE;
+      return LITERAL_TRUE;
     } catch (JsonProcessingException e) {
-      return ExprValueUtils.LITERAL_FALSE;
+      return LITERAL_FALSE;
     }
+  }
+
+  /** Converts a JSON encoded string to an Expression object. */
+  public static ExprValue castJson(String json) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode jsonNode;
+    try {
+      jsonNode = objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      final String errorFormat = "JSON string '%s' is not valid. Error details: %s";
+      throw new SemanticCheckException(String.format(errorFormat, json, e.getMessage()), e);
+    }
+
+    return processJsonNode(jsonNode);
+  }
+
+  private static ExprValue processJsonNode(JsonNode jsonNode) {
+    if (jsonNode.isFloatingPointNumber()) {
+      return new ExprDoubleValue(jsonNode.asDouble());
+    }
+    if (jsonNode.isIntegralNumber()) {
+      return new ExprIntegerValue(jsonNode.asLong());
+    }
+    if (jsonNode.isBoolean()) {
+      return jsonNode.asBoolean() ? LITERAL_TRUE : LITERAL_FALSE;
+    }
+    if (jsonNode.isTextual()) {
+      return new ExprStringValue(jsonNode.asText());
+    }
+    if (jsonNode.isArray()) {
+      List<ExprValue> elements = new LinkedList<>();
+      for (var iter = jsonNode.iterator(); iter.hasNext(); ) {
+        jsonNode = iter.next();
+        elements.add(processJsonNode(jsonNode));
+      }
+      return new ExprCollectionValue(elements);
+    }
+    if (jsonNode.isObject()) {
+      Map<String, ExprValue> values = new LinkedHashMap<>();
+      for (var iter = jsonNode.fields(); iter.hasNext(); ) {
+        Map.Entry<String, JsonNode> entry = iter.next();
+        values.put(entry.getKey(), processJsonNode(entry.getValue()));
+      }
+      return ExprTupleValue.fromExprValueMap(values);
+    }
+
+    // in all other cases, return null
+    return LITERAL_NULL;
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -6,44 +6,146 @@
 package org.opensearch.sql.expression.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.model.ExprBooleanValue;
+import org.opensearch.sql.data.model.ExprCollectionValue;
+import org.opensearch.sql.data.model.ExprDoubleValue;
+import org.opensearch.sql.data.model.ExprIntegerValue;
+import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprNullValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.FunctionExpression;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonFunctionsTest {
-  private static final ExprValue JsonObject =
-      ExprValueUtils.stringValue("{\"a\":\"1\",\"b\":\"2\"}");
-  private static final ExprValue JsonArray = ExprValueUtils.stringValue("[1, 2, 3, 4]");
-  private static final ExprValue JsonScalarString = ExprValueUtils.stringValue("\"abc\"");
-  private static final ExprValue JsonEmptyString = ExprValueUtils.stringValue("");
-  private static final ExprValue JsonInvalidObject =
-      ExprValueUtils.stringValue("{\"invalid\":\"json\", \"string\"}");
-  private static final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
 
   @Test
   public void json_valid_returns_false() {
-    assertEquals(LITERAL_FALSE, execute(JsonInvalidObject));
-    assertEquals(LITERAL_FALSE, execute(JsonInvalidScalar));
+    final ExprValue JsonInvalidObject =
+        ExprValueUtils.stringValue("{\"invalid\":\"json\", \"string\"}");
+    assertEquals(LITERAL_FALSE, DSL.jsonValid(DSL.literal(JsonInvalidObject)).valueOf());
+
+    final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
+    assertEquals(LITERAL_FALSE, DSL.jsonValid(DSL.literal(JsonInvalidScalar)).valueOf());
   }
 
   @Test
   public void json_valid_returns_true() {
-    assertEquals(LITERAL_TRUE, execute(JsonObject));
-    assertEquals(LITERAL_TRUE, execute(JsonArray));
-    assertEquals(LITERAL_TRUE, execute(JsonScalarString));
-    assertEquals(LITERAL_TRUE, execute(JsonEmptyString));
+    final ExprValue JsonObject = ExprValueUtils.stringValue("{\"a\":\"1\",\"b\":\"2\"}");
+    assertEquals(LITERAL_TRUE, DSL.jsonValid(DSL.literal(JsonObject)).valueOf());
+
+    final ExprValue JsonArray = ExprValueUtils.stringValue("[1, 2, 3, 4]");
+    assertEquals(LITERAL_TRUE, DSL.jsonValid(DSL.literal(JsonArray)).valueOf());
+
+    final ExprValue JsonScalarString = ExprValueUtils.stringValue("\"abc\"");
+    assertEquals(LITERAL_TRUE, DSL.jsonValid(DSL.literal(JsonScalarString)).valueOf());
+
+    final ExprValue JsonEmptyString = ExprValueUtils.stringValue("");
+    assertEquals(LITERAL_TRUE, DSL.jsonValid(DSL.literal(JsonEmptyString)).valueOf());
   }
 
-  private ExprValue execute(ExprValue jsonString) {
-    FunctionExpression exp = DSL.jsonValid(DSL.literal(jsonString));
-    return exp.valueOf();
+  @Test
+  void json_returnsJsonObject() {
+    FunctionExpression exp;
+
+    // Setup
+    final String objectJson =
+        "{\"foo\": \"foo\", \"fuzz\": true, \"bar\": 1234, \"bar2\": 12.34, \"baz\": null, "
+            + "\"obj\": {\"internal\": \"value\"}, \"arr\": [\"string\", true, null]}";
+
+    LinkedHashMap<String, ExprValue> objectMap = new LinkedHashMap<>();
+    objectMap.put("foo", new ExprStringValue("foo"));
+    objectMap.put("fuzz", ExprBooleanValue.of(true));
+    objectMap.put("bar", new ExprLongValue(1234));
+    objectMap.put("bar2", new ExprDoubleValue(12.34));
+    objectMap.put("baz", ExprNullValue.of());
+    objectMap.put(
+        "obj", ExprTupleValue.fromExprValueMap(Map.of("internal", new ExprStringValue("value"))));
+    objectMap.put(
+        "arr",
+        new ExprCollectionValue(
+            List.of(new ExprStringValue("string"), ExprBooleanValue.of(true), ExprNullValue.of())));
+    ExprValue expectedTupleExpr = ExprTupleValue.fromExprValueMap(objectMap);
+
+    // exercise
+    exp = DSL.json_function(DSL.literal(objectJson));
+
+    // Verify
+    var value = exp.valueOf();
+    assertTrue(value instanceof ExprTupleValue);
+    assertEquals(expectedTupleExpr, value);
+  }
+
+  @Test
+  void json_returnsJsonArray() {
+    FunctionExpression exp;
+
+    // Setup
+    final String arrayJson = "[\"foo\", \"fuzz\", true, \"bar\", 1234, 12.34, null]";
+    ExprValue expectedArrayExpr =
+        new ExprCollectionValue(
+            List.of(
+                new ExprStringValue("foo"),
+                new ExprStringValue("fuzz"),
+                LITERAL_TRUE,
+                new ExprStringValue("bar"),
+                new ExprIntegerValue(1234),
+                new ExprDoubleValue(12.34),
+                LITERAL_NULL));
+
+    // exercise
+    exp = DSL.json_function(DSL.literal(arrayJson));
+
+    // Verify
+    var value = exp.valueOf();
+    assertTrue(value instanceof ExprCollectionValue);
+    assertEquals(expectedArrayExpr, value);
+  }
+
+  @Test
+  void json_returnsScalar() {
+    assertEquals(
+        new ExprStringValue("foobar"), DSL.json_function(DSL.literal("\"foobar\"")).valueOf());
+
+    assertEquals(new ExprIntegerValue(1234), DSL.json_function(DSL.literal("1234")).valueOf());
+
+    assertEquals(LITERAL_TRUE, DSL.json_function(DSL.literal("true")).valueOf());
+
+    assertEquals(LITERAL_NULL, DSL.json_function(DSL.literal("null")).valueOf());
+
+    assertEquals(LITERAL_NULL, DSL.json_function(DSL.literal("")).valueOf());
+
+    assertEquals(
+        ExprTupleValue.fromExprValueMap(Map.of()), DSL.json_function(DSL.literal("{}")).valueOf());
+  }
+
+  @Test
+  void json_returnsSemanticCheckException() {
+    // invalid type
+    assertThrows(
+        SemanticCheckException.class, () -> DSL.castJson(DSL.literal("invalid")).valueOf());
+
+    // missing bracket
+    assertThrows(SemanticCheckException.class, () -> DSL.castJson(DSL.literal("{{[}}")).valueOf());
+
+    // mnissing quote
+    assertThrows(
+        SemanticCheckException.class, () -> DSL.castJson(DSL.literal("\"missing quote")).valueOf());
   }
 }

--- a/docs/user/ppl/functions/json.rst
+++ b/docs/user/ppl/functions/json.rst
@@ -33,3 +33,28 @@ Example::
     | json empty string   |                              | True     |
     | json invalid object | {"invalid":"json", "string"} | True     |
     +---------------------+------------------------------+----------+
+
+JSON
+----------
+
+Description
+>>>>>>>>>>>
+
+Usage: `json(value)` Evaluates whether a string can be parsed as a json-encoded string and casted as an expression. Returns the JSON value if valid, null otherwise.
+
+Argument type: STRING
+
+Return type: BOOLEAN/DOUBLE/INTEGER/NULL/STRUCT/ARRAY
+
+Example::
+
+    > source=json_test | where json_valid(json_string) | eval json=json(json_string) | fields test_name, json_string, json
+    fetched rows / total rows = 4/4
+    +---------------------+------------------------------+---------------+
+    | test_name           | json_string                  | json          |
+    |---------------------|------------------------------|---------------|
+    | json object         | {"a":"1","b":"2"}            | {a:"1",b:"2"} |
+    | json array          | [1, 2, 3, 4]                 | [1,2,3,4]     |
+    | json scalar string  | "abc"                        | "abc"         |
+    | json empty string   |                              | null          |
+    +---------------------+------------------------------+---------------+

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionsIT.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
-public class JsonFunctionIT extends PPLIntegTestCase {
+public class JsonFunctionsIT extends PPLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.JSON_TEST);
@@ -48,6 +48,34 @@ public class JsonFunctionIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | where not json_valid(json_string) | fields test_name",
                 TEST_INDEX_JSON_TEST));
+    verifySchema(result, schema("test_name", null, "string"));
+    verifyDataRows(result, rows("json invalid object"));
+  }
+
+  @Test
+  public void test_cast_json() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval json=cast(json_string to json) | fields json",
+                TEST_INDEX_JSON_TEST));
+    verifySchema(result, schema("test_name", null, "string"));
+    verifyDataRows(
+        result,
+        rows("json object"),
+        rows("json array"),
+        rows("json scalar string"),
+        rows("json empty string"));
+  }
+
+  @Test
+  public void test_json() throws IOException {
+    JSONObject result;
+
+    result =
+        executeQuery(
+            String.format(
+                "source=%s | eval json=json(json_string) | fields json", TEST_INDEX_JSON_TEST));
     verifySchema(result, schema("test_name", null, "string"));
     verifyDataRows(result, rows("json invalid object"));
   }

--- a/integ-test/src/test/resources/indexDefinitions/json_test_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/json_test_index_mapping.json
@@ -1,0 +1,12 @@
+{
+  "mappings": {
+    "properties": {
+      "test_name": {
+        "type": "keyword"
+      },
+      "json_string": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -143,6 +143,7 @@ FLOAT:                              'FLOAT';
 STRING:                             'STRING';
 BOOLEAN:                            'BOOLEAN';
 IP:                                 'IP';
+JSON:                               'JSON';
 
 // SPECIAL CHARACTERS AND OPERATORS
 PIPE:                               '|';

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -143,7 +143,6 @@ FLOAT:                              'FLOAT';
 STRING:                             'STRING';
 BOOLEAN:                            'BOOLEAN';
 IP:                                 'IP';
-JSON:                               'JSON';
 
 // SPECIAL CHARACTERS AND OPERATORS
 PIPE:                               '|';
@@ -335,6 +334,7 @@ CIDRMATCH:                          'CIDRMATCH';
 
 // JSON FUNCTIONS
 JSON_VALID:                         'JSON_VALID';
+JSON:                               'JSON';
 
 // FLOWCONTROL FUNCTIONS
 IFNULL:                             'IFNULL';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -870,6 +870,7 @@ keywordsCanBeId
    | mathematicalFunctionName
    | positionFunctionName
    | conditionFunctionName
+   | jsonFunctionName
    // commands
    | SEARCH
    | DESCRIBE
@@ -969,6 +970,4 @@ keywordsCanBeId
    | SPARKLINE
    | C
    | DC
-   // JSON
-   | JSON
    ;

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -409,6 +409,7 @@ convertedDataType
    | typeName = STRING
    | typeName = BOOLEAN
    | typeName = IP
+   | typeName = JSON
    ;
 
 evalFunctionName
@@ -419,6 +420,7 @@ evalFunctionName
    | flowControlFunctionName
    | systemFunctionName
    | positionFunctionName
+   | jsonFunctionName
    ;
 
 functionArgs
@@ -700,6 +702,10 @@ positionFunctionName
    : POSITION
    ;
 
+jsonFunctionName
+   : JSON
+   ;
+
 // operators
  comparisonOperator
    : EQUAL
@@ -963,4 +969,6 @@ keywordsCanBeId
    | SPARKLINE
    | C
    | DC
+   // JSON
+   | JSON
    ;


### PR DESCRIPTION
### Description
For OpenSearch-PPL, adds the `json()` and `cast(expression as json)` functions.  Both of these functions can be used to convert a json-encoded string into an expression object.  These functions return any expression type that is valid json (object, array, or scalar).  

### Related Issues
Resolves #3209

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
