### PR TITLE
PPL: GeoIP function

### DIFF
--- a/.github/workflows/integ-tests-with-geo.yml
+++ b/.github/workflows/integ-tests-with-geo.yml
@@ -1,0 +1,89 @@
+name: GeoSpatial Plugin IT
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - 'integ-test/**'
+      - '.github/workflows/integ-tests-with-geo.yml'
+
+jobs:
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch
+
+  security-it-linux:
+    needs: Get-CI-Image-Tag
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [21]
+    runs-on: ubuntu-latest
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
+
+    steps:
+    - name: Run start commands
+      run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+      
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+
+    - name: Build with Gradle
+      run: |
+        chown -R 1000:1000 `pwd`
+        su `id -un 1000` -c "./gradlew integTestWithGeo"
+
+    - name: Upload test reports
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: test-reports-${{ matrix.os }}-${{ matrix.java }}
+        path: |
+          integ-test/build/reports/**
+          integ-test/build/testclusters/*/logs/*
+          integ-test/build/testclusters/*/config/*
+
+  security-it-windows-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macos-13 ]
+        java: [21]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+
+    - name: Build with Gradle
+      run: ./gradlew integTestWithGeo
+
+    - name: Upload test reports
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: test-reports-${{ matrix.os }}-${{ matrix.java }}
+        path: |
+          integ-test/build/reports/**
+          integ-test/build/testclusters/*/logs/*
+          integ-test/build/testclusters/*/config/*

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -969,6 +969,10 @@ public class DSL {
     return compile(functionProperties, BuiltinFunctionName.UTC_TIMESTAMP, args);
   }
 
+  public static FunctionExpression geoip(Expression... args) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.GEOIP, args);
+  }
+
   @SuppressWarnings("unchecked")
   private static <T extends FunctionImplementation> T compile(
       FunctionProperties functionProperties, BuiltinFunctionName bfn, Expression... args) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -204,6 +204,9 @@ public enum BuiltinFunctionName {
   TRIM(FunctionName.of("trim")),
   UPPER(FunctionName.of("upper")),
 
+  /** GEOSPATIAL Functions. */
+  GEOIP(FunctionName.of("geoip")),
+
   /** NULL Test. */
   IS_NULL(FunctionName.of("is null")),
   IS_NOT_NULL(FunctionName.of("is not null")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -27,6 +27,7 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.aggregation.AggregatorFunctions;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 import org.opensearch.sql.expression.datetime.IntervalClause;
+import org.opensearch.sql.expression.ip.GeoIPFunctions;
 import org.opensearch.sql.expression.ip.IPFunctions;
 import org.opensearch.sql.expression.operator.arthmetic.ArithmeticFunctions;
 import org.opensearch.sql.expression.operator.arthmetic.MathematicalFunctions;
@@ -83,6 +84,7 @@ public class BuiltinFunctionRepository {
       SystemFunctions.register(instance);
       OpenSearchFunctions.register(instance);
       IPFunctions.register(instance);
+      GeoIPFunctions.register(instance);
     }
     return instance;
   }

--- a/core/src/main/java/org/opensearch/sql/expression/ip/GeoIPFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/ip/GeoIPFunctions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.ip;
+
+import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.expression.function.FunctionDSL.define;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.DefaultFunctionResolver;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.SerializableFunction;
+
+/**
+ * Utility class to register the method signature for geoip( ) expression, concreted reallocated to
+ * `opensearch` module, as this Ip location require GeoSpatial Plugin runtime support.
+ */
+@UtilityClass
+public class GeoIPFunctions {
+
+  public void register(BuiltinFunctionRepository repository) {
+    repository.register(geoIp());
+  }
+
+  /**
+   * To register all method signatures related to geoip( ) expression under eval.
+   *
+   * @return Resolver for geoip( ) expression.
+   */
+  private DefaultFunctionResolver geoIp() {
+    return define(
+        BuiltinFunctionName.GEOIP.getName(),
+        openSearchImpl(BOOLEAN, Arrays.asList(STRING, STRING)),
+        openSearchImpl(BOOLEAN, Arrays.asList(STRING, STRING, STRING)));
+  }
+
+  /**
+   * Util method to generate probe implementation with given list of argument types, with marker
+   * class `OpenSearchFunctionExpression` to annotate this is an OpenSearch specific expression.
+   *
+   * @param returnType return type.
+   * @return Binary Function Implementation.
+   */
+  public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      openSearchImpl(ExprType returnType, List<ExprType> args) {
+    return functionName -> {
+      FunctionSignature functionSignature = new FunctionSignature(functionName, args);
+      FunctionBuilder functionBuilder =
+          (functionProperties, arguments) ->
+              new OpenSearchFunctionExpression(functionName, arguments, returnType);
+      return Pair.of(functionSignature, functionBuilder);
+    };
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/ip/OpenSearchFunctionExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/ip/OpenSearchFunctionExpression.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.expression.ip;
+
+import java.util.List;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+
+/**
+ * Marker class to identify functions only compatible with OpenSearch storage engine. Any attempt to
+ * invoke the method different from OpenSearch will result in UnsupportedOperationException.
+ */
+public class OpenSearchFunctionExpression extends FunctionExpression {
+
+  private final ExprType returnType;
+
+  public OpenSearchFunctionExpression(
+      FunctionName functionName, List<Expression> arguments, ExprType returnType) {
+    super(functionName, arguments);
+    this.returnType = returnType;
+  }
+
+  @Override
+  public ExprValue valueOf() {
+    return null;
+  }
+
+  @Override
+  public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+    throw new UnsupportedOperationException(
+        "OpenSearch runtime specific function, no default implementation available");
+  }
+
+  @Override
+  public ExprType type() {
+    return returnType;
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/ip/GeoIPFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/ip/GeoIPFunctionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.ip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+public class GeoIPFunctionTest {
+
+  // Mock value environment for testing.
+  @Mock private Environment<Expression, ExprValue> env;
+
+  @Test
+  public void geoIpDefaultImplementation() {
+    UnsupportedOperationException exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                DSL.geoip(DSL.literal("HARDCODED_DATASOURCE_NAME"), DSL.ref("ip_address", STRING))
+                    .valueOf(env));
+    assertTrue(exception.getMessage().matches(".*no default implementation available"));
+  }
+
+  @Test
+  public void testGeoipFnctionSignature() {
+    var geoip = DSL.geoip(DSL.literal("HARDCODED_DATASOURCE_NAME"), DSL.ref("ip_address", STRING));
+    assertEquals(BOOLEAN, geoip.type());
+  }
+
+  /** To make sure no logic being evaluated when no environment being passed. */
+  @Test
+  public void testDefaultValueOf() {
+    var geoip = DSL.geoip(DSL.literal("HARDCODED_DATASOURCE_NAME"), DSL.ref("ip_address", STRING));
+    assertNull(geoip.valueOf());
+  }
+}

--- a/docs/user/ppl/index.rst
+++ b/docs/user/ppl/index.rst
@@ -106,6 +106,8 @@ The query start with search command and then flowing a set of command delimited 
 
   - `IP Address Functions <functions/ip.rst>`_
 
+  - `Geo IP Address Functions <functions/geoip.rst>`_
+
 * **Optimization**
 
   - `Optimization <../../user/optimization/optimization.rst>`_

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -49,6 +49,12 @@ String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"
 
+Map dummyLoginConfig = [
+        https: "false",
+        user: "admin",
+        password: "admin"
+]
+
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -77,10 +83,23 @@ ext {
 
         return repo + "opensearch-security-${securitySnapshotVersion}.zip"
     }
-
     var projectAbsPath = projectDir.getAbsolutePath()
-    File downloadedSecurityPlugin = Paths.get(projectAbsPath, 'bin', 'opensearch-security-snapshot.zip').toFile()
+    configureGeoPlugin = { OpenSearchCluster cluster ->
+        File downloadedGeoPlugin = Paths.get(projectAbsPath, 'bin', 'opensearch-geospatial-snapshot.zip').toFile()
+        if (!downloadedGeoPlugin.exists()) {
+            download.run {
+                src getPluginDownloadLink("geospatial")
+                dest downloadedGeoPlugin
+            }
+        } else {
+            println "Geo-spatial Plugin File Already Exists"
+        }
+        cluster.plugin provider {(RegularFile) (() -> downloadedGeoPlugin)}
+    }
+
     configureSecurityPlugin = { OpenSearchCluster cluster ->
+
+        File downloadedSecurityPlugin = Paths.get(projectAbsPath, 'bin', 'opensearch-security-snapshot.zip').toFile()
 
         cluster.getNodes().forEach { node ->
             var creds = node.getCredentials()
@@ -94,7 +113,7 @@ ext {
         // add a check to avoid re-downloading multiple times during single test run
         if (!downloadedSecurityPlugin.exists()) {
             download.run {
-                src getSecurityPluginDownloadLink()
+                src getPluginDownloadLink("opensearch-security")
                 dest downloadedSecurityPlugin
             }
         } else {
@@ -239,6 +258,32 @@ def getJobSchedulerPlugin() {
     })
 }
 
+static def getAllHttpSocketURI(cluster) {
+    return cluster.nodes.stream()
+            .flatMap { node -> node.getAllHttpSocketURI().stream() }
+            .collect(Collectors.joining(","))
+}
+
+static def getAllTransportSocketURI(cluster) {
+    return cluster.nodes.stream()
+            .flatMap { node -> node.getAllTransportPortURI().stream() }
+            .collect(Collectors.joining(","))
+}
+
+def getPluginDownloadLink(pluginName) {
+    var repo = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/" +
+            pluginName + "/$opensearch_build_snapshot/"
+    var metadataFile = Paths.get(projectDir.toString(), "build", "maven-metadata.xml").toAbsolutePath().toFile()
+    download.run {
+        src repo + "maven-metadata.xml"
+        dest metadataFile
+    }
+    def metadata = new XmlParser().parse(metadataFile)
+    def PluginSnapshotVersion = metadata.versioning.snapshotVersions[0].snapshotVersion[0].value[0].text()
+    return repo + pluginName +"-${PluginSnapshotVersion}.zip"
+}
+
+
 testClusters {
     integTest {
         testDistribution = 'archive'
@@ -257,6 +302,11 @@ testClusters {
         plugin ":opensearch-sql-plugin"
     }
     remoteIntegTestWithSecurity {
+        testDistribution = 'archive'
+        plugin(getJobSchedulerPlugin())
+        plugin ":opensearch-sql-plugin"
+    }
+    integTestWithGeo {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin ":opensearch-sql-plugin"
@@ -370,21 +420,10 @@ task integTestWithSecurity(type: RestIntegTestTask) {
     doFirst {
         systemProperty 'cluster.debug', getDebug()
         getClusters().forEach { cluster ->
-
-            String allTransportSocketURI = cluster.nodes.stream().flatMap { node ->
-                node.getAllTransportPortURI().stream()
-            }.collect(Collectors.joining(","))
-            String allHttpSocketURI = cluster.nodes.stream().flatMap { node ->
-                node.getAllHttpSocketURI().stream()
-            }.collect(Collectors.joining(","))
-
-            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> allHttpSocketURI}"
-            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> allTransportSocketURI}"
+            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> getAllHttpSocketURI(cluster)}"
+            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> getAllTransportSocketURI(cluster)}"
         }
-
-        systemProperty "https", "false"
-        systemProperty "user", "admin"
-        systemProperty "password", "admin"
+        systemProperties dummyLoginConfig
     }
 
     if (System.getProperty("test.debug") != null) {
@@ -397,6 +436,48 @@ task integTestWithSecurity(type: RestIntegTestTask) {
         includeTestsMatching 'org.opensearch.sql.security.CrossClusterSearchIT'
     }
 }
+
+
+task integTestWithGeo(type: RestIntegTestTask) {
+    useCluster testClusters.remoteCluster
+
+    getClusters().forEach { cluster ->
+        configureGeoPlugin(cluster)
+    }
+
+    useJUnitPlatform()
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty 'project.root', project.projectDir.absolutePath
+    // Set default query size limit
+    systemProperty 'defaultQuerySizeLimit', '10000'
+
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst {
+        systemProperty 'cluster.debug', getDebug()
+        getClusters().forEach { cluster ->
+            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> getAllHttpSocketURI(cluster)}"
+            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> getAllTransportSocketURI(cluster)}"
+        }
+        systemProperties dummyLoginConfig
+    }
+
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+    }
+
+    // NOTE: this IT config discovers only junit5 (jupiter) tests.
+    // https://github.com/opensearch-project/sql/issues/1974
+    filter {
+        includeTestsMatching 'org.opensearch.sql.geo.PplIpEnrichmentIT'
+    }
+}
+
 
 // Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
 integTest {

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -153,8 +153,7 @@ ext {
         ].forEach { name, value ->
             cluster.setting name, value
         }
-
-        cluster.plugin provider((Callable<RegularFile>) (() -> (RegularFile) (() -> downloadedSecurityPlugin)))
+        cluster.plugin provider {(RegularFile) (() -> downloadedSecurityPlugin)}
     }
 
     bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + baseVersion + '/latest/linux/x64/tar/builds/' +
@@ -243,19 +242,11 @@ testClusters.all {
 }
 
 def getJobSchedulerPlugin() {
-    provider(new Callable<RegularFile>() {
-        @Override
-        RegularFile call() throws Exception {
-            return new RegularFile() {
-                @Override
-                File getAsFile() {
-                    return configurations.zipArchive.asFileTree.matching {
-                        include '**/opensearch-job-scheduler*'
-                    }.singleFile
-                }
-            }
-        }
-    })
+    provider { (RegularFile) (() ->
+            configurations.zipArchive.asFileTree.matching {
+                include '**/opensearch-job-scheduler*'
+            }.singleFile )
+    }
 }
 
 static def getAllHttpSocketURI(cluster) {
@@ -607,37 +598,22 @@ task comparisonTest(type: RestIntegTestTask) {
             testDistribution = "ARCHIVE"
             versions = [baseVersion, opensearch_version]
             numberOfNodes = 3
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            if (new File("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion").exists()) {
-                                project.delete(files("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion"))
-                            }
-                            project.mkdir bwcJobSchedulerPath + bwcVersion
-                            ant.get(src: bwcOpenSearchJSDownload,
-                                    dest: bwcJobSchedulerPath + bwcVersion,
-                                    httpusecaches: false)
-                            return fileTree(bwcJobSchedulerPath + bwcVersion).getSingleFile()
-                        }
+            plugin(provider { (RegularFile) ({
+                    if (new File("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion").exists()) {
+                        project.delete(files("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion"))
                     }
-                }
-            }))
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            return configurations.zipArchive.asFileTree.matching {
-                                include '**/opensearch-sql-plugin*'
-                            }.singleFile
-                        }
-                    }
-                }
-            }))
+                    project.mkdir bwcJobSchedulerPath + bwcVersion
+                    ant.get(src: bwcOpenSearchJSDownload,
+                            dest: bwcJobSchedulerPath + bwcVersion,
+                            httpusecaches: false)
+                    fileTree(bwcJobSchedulerPath + bwcVersion).getSingleFile()
+                })
+            })
+            plugin(provider { (RegularFile) (
+                configurations.zipArchive.asFileTree.matching {
+                    include '**/opensearch-sql-plugin*'
+                }.singleFile )
+            })
             setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
             setting 'http.content_type.required', 'true'
         }
@@ -646,17 +622,9 @@ task comparisonTest(type: RestIntegTestTask) {
 
 List<Provider<RegularFile>> plugins = [
         getJobSchedulerPlugin(),
-        provider(new Callable<RegularFile>() {
-            @Override
-            RegularFile call() throws Exception {
-                return new RegularFile() {
-                    @Override
-                    File getAsFile() {
-                        return fileTree(bwcFilePath + project.version).getSingleFile()
-                    }
-                }
-            }
-        })
+        provider{ (RegularFile) (
+                fileTree(bwcFilePath + project.version).getSingleFile())
+        }
 ]
 
 // Creates 2 test clusters with 3 nodes of the old version.

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -55,6 +55,12 @@ Map dummyLoginConfig = [
         password: "admin"
 ]
 
+Map dynamicLoginConfig = [
+        https: System.getProperty("https"),
+        user: System.getProperty("user"),
+        password: System.getProperty("password")
+]
+
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -261,6 +267,10 @@ static def getAllTransportSocketURI(cluster) {
             .collect(Collectors.joining(","))
 }
 
+static def getConcatClusterName(clusters) {
+    return clusters.stream().map(cluster -> cluster.getName()).collect(Collectors.joining(","))
+}
+
 def getPluginDownloadLink(pluginName) {
     var repo = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/" +
             pluginName + "/$opensearch_build_snapshot/"
@@ -337,6 +347,7 @@ task stopPrometheus(type: KillProcessTask) {
 stopPrometheus.mustRunAfter startPrometheus
 
 task integJdbcTest(type: RestIntegTestTask) {
+
     testClusters.findAll {c -> c.clusterName == "integJdbcTest"}.first().
         plugin ":opensearch-sql-plugin"
 
@@ -360,9 +371,7 @@ task integJdbcTest(type: RestIntegTestTask) {
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
 
-    systemProperty "https", System.getProperty("https")
-    systemProperty "user", System.getProperty("user")
-    systemProperty "password", System.getProperty("password")
+    systemProperties dynamicLoginConfig
 
     // Set default query size limit
     systemProperty 'defaultQuerySizeLimit', '10000'
@@ -381,11 +390,11 @@ task integJdbcTest(type: RestIntegTestTask) {
 }
 
 task integTestWithSecurity(type: RestIntegTestTask) {
+
     useCluster testClusters.integTestWithSecurity
     useCluster testClusters.remoteIntegTestWithSecurity
 
-    systemProperty "cluster.names",
-        getClusters().stream().map(cluster -> cluster.getName()).collect(Collectors.joining(","))
+    systemProperty "cluster.names", getConcatClusterName(getClusters())
 
     getClusters().forEach { cluster ->
         configureSecurityPlugin(cluster)
@@ -424,7 +433,7 @@ task integTestWithSecurity(type: RestIntegTestTask) {
     // NOTE: this IT config discovers only junit5 (jupiter) tests.
     // https://github.com/opensearch-project/sql/issues/1974
     filter {
-        includeTestsMatching 'org.opensearch.sql.security.CrossClusterSearchIT'
+        includeTestsMatching 'org.opensearch.sql.geo.PplIpEnrichmentIT'
     }
 }
 
@@ -477,15 +486,8 @@ integTest {
     // Set properties for connection to clusters and between clusters
     doFirst {
         getClusters().forEach { cluster ->
-            String allTransportSocketURI = cluster.nodes.stream().flatMap { node ->
-                node.getAllTransportPortURI().stream()
-            }.collect(Collectors.joining(","))
-            String allHttpSocketURI = cluster.nodes.stream().flatMap { node ->
-                node.getAllHttpSocketURI().stream()
-            }.collect(Collectors.joining(","))
-
-            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> allHttpSocketURI}"
-            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> allTransportSocketURI}"
+            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> getAllHttpSocketURI(cluster)}"
+            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> getAllTransportSocketURI(cluster)}"
         }
     }
 
@@ -501,9 +503,7 @@ integTest {
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
 
-    systemProperty "https", System.getProperty("https")
-    systemProperty "user", System.getProperty("user")
-    systemProperty "password", System.getProperty("password")
+    systemProperties dynamicLoginConfig
 
     // Set default query size limit
     systemProperty 'defaultQuerySizeLimit', '10000'
@@ -516,7 +516,6 @@ integTest {
         }
         systemProperty 'cluster.debug', getDebug()
     }
-
 
     if (System.getProperty("test.debug") != null) {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006'
@@ -554,6 +553,9 @@ integTest {
 
     // Exclude this IT, because they executed in another task (:integTestWithSecurity)
     exclude 'org/opensearch/sql/security/**'
+
+    // Exclude this IT, because they executed in another task (:integTestWithGeo)
+    exclude 'org/opensearch/sql/geo/**'
 }
 
 
@@ -759,10 +761,7 @@ task integTestRemote(type: RestIntegTestTask) {
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
     systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
-
-    systemProperty "https", System.getProperty("https")
-    systemProperty "user", System.getProperty("user")
-    systemProperty "password", System.getProperty("password")
+    systemProperties dynamicLoginConfig
 
     // Set default query size limit
     systemProperty 'defaultQuerySizeLimit', '10000'
@@ -783,3 +782,9 @@ task integTestRemote(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
     exclude 'org/opensearch/sql/jdbc/**'
 }
+
+
+
+
+
+

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -433,7 +433,7 @@ task integTestWithSecurity(type: RestIntegTestTask) {
     // NOTE: this IT config discovers only junit5 (jupiter) tests.
     // https://github.com/opensearch-project/sql/issues/1974
     filter {
-        includeTestsMatching 'org.opensearch.sql.geo.PplIpEnrichmentIT'
+        includeTestsMatching 'org.opensearch.sql.security.CrossClusterSearchIT'
     }
 }
 

--- a/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
@@ -8,15 +8,30 @@
 package org.opensearch.sql.geo;
 
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_GEOIP;
+import static org.opensearch.sql.util.MatcherUtils.columnName;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 /** IP enrichment PPL request with OpenSearch Geo-sptial plugin */
@@ -24,7 +39,16 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
 
   private static boolean initialized = false;
 
+  private static Map<String, Object> MANIFEST_LOCATION =
+          Map.of(
+                  "endpoint",
+                  "https://raw.githubusercontent.com/opensearch-project/geospatial/main/src/test/resources/ip2geo/server/city/manifest.json");
+
+  private static String DATASOURCE_NAME = "dummycityindex";
+
   private static String PLUGIN_NAME = "opensearch-geospatial";
+
+  private static String GEO_SPATIAL_DATASOURCE_PATH = "/_plugins/geospatial/ip2geo/datasource/";
 
   @SneakyThrows
   @BeforeEach
@@ -33,6 +57,14 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
       setUpIndices();
       initialized = true;
     }
+  }
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.GEOIP);
+    // Create a new dataSource
+    createDatasource(DATASOURCE_NAME, MANIFEST_LOCATION);
+    waitForDatasourceToBeAvailable(DATASOURCE_NAME, Duration.ofSeconds(10));
   }
 
   @Test
@@ -45,5 +77,82 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
     Response response = client().performRequest(request);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     Assert.assertTrue(getResponseBody(response, true).contains(PLUGIN_NAME));
+  }
+
+  @SneakyThrows
+  @Test
+  public void testGeoIpEnrichment() {
+    JSONObject resultGeoIp =
+            executeQuery(
+                    String.format(
+                            "search source=%s | eval enrichmentResult = geoip(\\\"%s\\\",%s)",
+                            TEST_INDEX_GEOIP, "dummycityindex", "ip"));
+
+    verifyColumn(resultGeoIp, columnName("name"), columnName("ip"), columnName("enrichmentResult"));
+    verifyDataRows(
+            resultGeoIp,
+            rows("Test user - USA", "10.1.1.1", Map.of("country", "USA", "city", "Seattle")),
+            rows("Test user - Canada", "127.1.1.1", Map.of("country", "Canada", "city", "Vancouver")));
+  }
+
+  /**
+   * Helper method to send a PUT request to create a dummy dataSource with provided endpoint for
+   * integration test.
+   *
+   * @param name Name of the dataSource
+   * @param properties Request payload in Json format
+   * @return Response for the create dataSource request.
+   * @throws IOException In case of network failure
+   */
+  private Response createDatasource(final String name, Map<String, Object> properties)
+          throws IOException {
+    XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+    for (Map.Entry<String, Object> config : properties.entrySet()) {
+      builder.field(config.getKey(), config.getValue());
+    }
+    builder.endObject();
+    Request request = new Request("PUT", GEO_SPATIAL_DATASOURCE_PATH + name);
+    request.setJsonEntity(builder.toString());
+    return client().performRequest(request);
+  }
+
+  /**
+   * Helper method check the status of dataSource creation within the specific timeframe.
+   *
+   * @param name The name of the dataSource to assert
+   * @param timeout The timeout value in seconds
+   * @throws Exception Exception
+   */
+  private void waitForDatasourceToBeAvailable(final String name, final Duration timeout)
+          throws Exception {
+    Instant start = Instant.now();
+    while (!"AVAILABLE".equals(getDatasourceState(name))) {
+      if (Duration.between(start, Instant.now()).compareTo(timeout) > 0) {
+        throw new RuntimeException(
+                String.format(
+                        Locale.ROOT,
+                        "Datasource state didn't change to %s after %d seconds",
+                        "AVAILABLE",
+                        timeout.toSeconds()));
+      }
+      Thread.sleep(1000);
+    }
+  }
+
+  /**
+   * Helper method to fetch the DataSource creation status via REST client.
+   *
+   * @param name dataSource name
+   * @return Status in String
+   * @throws Exception IO.
+   */
+  private String getDatasourceState(final String name) throws Exception {
+    Request request = new Request("GET", GEO_SPATIAL_DATASOURCE_PATH + name);
+    Response response = client().performRequest(request);
+    var responseInMap =
+            createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()))
+                    .map();
+    var datasources = (List<Map<String, Object>>) responseInMap.get("datasources");
+    return (String) datasources.get(0).get("state");
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.geo;
+
+import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+import java.io.IOException;
+
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
+
+/** IP enrichment PPL request with OpenSearch Geo-sptial plugin */
+public class PplIpEnrichmentIT extends PPLIntegTestCase {
+
+  private static boolean initialized = false;
+
+  private static String PLUGIN_NAME = "opensearch-geospatial";
+
+  @SneakyThrows
+  @BeforeEach
+  public void initialize() {
+    if (!initialized) {
+      setUpIndices();
+      initialized = true;
+    }
+  }
+
+  @Test
+  public void testGeoPluginInstallation() throws IOException {
+
+    Request request = new Request("GET", "/_cat/plugins?v");
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    Assert.assertTrue(getResponseBody(response, true).contains(PLUGIN_NAME));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
@@ -40,9 +40,9 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
   private static boolean initialized = false;
 
   private static Map<String, Object> MANIFEST_LOCATION =
-          Map.of(
-                  "endpoint",
-                  "https://raw.githubusercontent.com/opensearch-project/geospatial/main/src/test/resources/ip2geo/server/city/manifest.json");
+      Map.of(
+          "endpoint",
+          "https://raw.githubusercontent.com/opensearch-project/geospatial/main/src/test/resources/ip2geo/server/city/manifest.json");
 
   private static String DATASOURCE_NAME = "dummycityindex";
 
@@ -83,16 +83,16 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
   @Test
   public void testGeoIpEnrichment() {
     JSONObject resultGeoIp =
-            executeQuery(
-                    String.format(
-                            "search source=%s | eval enrichmentResult = geoip(\\\"%s\\\",%s)",
-                            TEST_INDEX_GEOIP, "dummycityindex", "ip"));
+        executeQuery(
+            String.format(
+                "search source=%s | eval enrichmentResult = geoip(\\\"%s\\\",%s)",
+                TEST_INDEX_GEOIP, "dummycityindex", "ip"));
 
     verifyColumn(resultGeoIp, columnName("name"), columnName("ip"), columnName("enrichmentResult"));
     verifyDataRows(
-            resultGeoIp,
-            rows("Test user - USA", "10.1.1.1", Map.of("country", "USA", "city", "Seattle")),
-            rows("Test user - Canada", "127.1.1.1", Map.of("country", "Canada", "city", "Vancouver")));
+        resultGeoIp,
+        rows("Test user - USA", "10.1.1.1", Map.of("country", "USA", "city", "Seattle")),
+        rows("Test user - Canada", "127.1.1.1", Map.of("country", "Canada", "city", "Vancouver")));
   }
 
   /**
@@ -105,7 +105,7 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
    * @throws IOException In case of network failure
    */
   private Response createDatasource(final String name, Map<String, Object> properties)
-          throws IOException {
+      throws IOException {
     XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
     for (Map.Entry<String, Object> config : properties.entrySet()) {
       builder.field(config.getKey(), config.getValue());
@@ -124,16 +124,16 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
    * @throws Exception Exception
    */
   private void waitForDatasourceToBeAvailable(final String name, final Duration timeout)
-          throws Exception {
+      throws Exception {
     Instant start = Instant.now();
     while (!"AVAILABLE".equals(getDatasourceState(name))) {
       if (Duration.between(start, Instant.now()).compareTo(timeout) > 0) {
         throw new RuntimeException(
-                String.format(
-                        Locale.ROOT,
-                        "Datasource state didn't change to %s after %d seconds",
-                        "AVAILABLE",
-                        timeout.toSeconds()));
+            String.format(
+                Locale.ROOT,
+                "Datasource state didn't change to %s after %d seconds",
+                "AVAILABLE",
+                timeout.toSeconds()));
       }
       Thread.sleep(1000);
     }
@@ -150,8 +150,8 @@ public class PplIpEnrichmentIT extends PPLIntegTestCase {
     Request request = new Request("GET", GEO_SPATIAL_DATASOURCE_PATH + name);
     Response response = client().performRequest(request);
     var responseInMap =
-            createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()))
-                    .map();
+        createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()))
+            .map();
     var datasources = (List<Map<String, Object>>) responseInMap.get("datasources");
     return (String) datasources.get(0).get("state");
   }

--- a/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/geo/PplIpEnrichmentIT.java
@@ -7,6 +7,9 @@
 
 package org.opensearch.sql.geo;
 
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
+
+import java.io.IOException;
 import lombok.SneakyThrows;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,10 +18,6 @@ import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
-
-import java.io.IOException;
-
-import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 
 /** IP enrichment PPL request with OpenSearch Geo-sptial plugin */
 public class PplIpEnrichmentIT extends PPLIntegTestCase {

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -20,6 +20,7 @@ import static org.opensearch.sql.legacy.TestUtils.getDogs2IndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getDogs3IndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getEmployeeNestedTypeIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getGameOfThronesIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getGeoIpIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getGeopointIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getJoinTypeIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getLocationIndexMapping;
@@ -625,6 +626,11 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         "unexpandedObject",
         getUnexpandedObjectIndexMapping(),
         "src/test/resources/unexpanded_objects.json"),
+    GEOIP(
+        TestsConstants.TEST_INDEX_GEOIP,
+        "geoip",
+        getGeoIpIndexMapping(),
+        "src/test/resources/geoip.json"),
     BANK(
         TestsConstants.TEST_INDEX_BANK,
         "account",

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -195,6 +195,11 @@ public class TestUtils {
     return getMappingFile(mappingFile);
   }
 
+  public static String getGeoIpIndexMapping() {
+    String mappingFile = "geoip_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
   public static String getBankWithNullValuesIndexMapping() {
     String mappingFile = "bank_with_null_values_index_mapping.json";
     return getMappingFile(mappingFile);

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -58,6 +58,7 @@ public class TestsConstants {
   public static final String TEST_INDEX_MULTI_NESTED_TYPE = TEST_INDEX + "_multi_nested";
   public static final String TEST_INDEX_NESTED_WITH_NULLS = TEST_INDEX + "_nested_with_nulls";
   public static final String TEST_INDEX_GEOPOINT = TEST_INDEX + "_geopoint";
+  public static final String TEST_INDEX_GEOIP = TEST_INDEX + "_geoip";
   public static final String DATASOURCES = ".ql-datasources";
 
   public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";

--- a/integ-test/src/test/java/org/opensearch/sql/security/CrossClusterSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/security/CrossClusterSearchIT.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.security;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_GEOIP;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
@@ -41,6 +42,7 @@ public class CrossClusterSearchIT extends PPLIntegTestCase {
 
   private static final String TEST_INDEX_BANK_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_BANK;
   private static final String TEST_INDEX_DOG_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
+  private static final String TEST_INDEX_GEOIP_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_GEOIP;
   private static final String TEST_INDEX_DOG_MATCH_ALL_REMOTE =
       MATCH_ALL_REMOTE_CLUSTER + ":" + TEST_INDEX_DOG;
   private static final String TEST_INDEX_ACCOUNT_REMOTE = REMOTE_CLUSTER + ":" + TEST_INDEX_ACCOUNT;

--- a/integ-test/src/test/resources/geoip.json
+++ b/integ-test/src/test/resources/geoip.json
@@ -1,0 +1,4 @@
+{"index":{"_id":"1"}}
+{"name":"Test user - USA","ip":"10.1.1.1"}
+{"index":{"_id":"6"}}
+{"name":"Test user - Canada","ip": "127.1.1.1"}

--- a/integ-test/src/test/resources/indexDefinitions/geoip_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/geoip_index_mapping.json
@@ -1,0 +1,12 @@
+{
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "text"
+      },
+      "ip": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation group: 'org.json', name: 'json', version:'20231013'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
+    implementation group: 'org.opensearch', name:'geospatial-client', version: "${opensearch_build}"
+
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.9.3')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.9.3')

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtector.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtector.java
@@ -10,6 +10,7 @@ import org.opensearch.sql.monitor.ResourceMonitor;
 import org.opensearch.sql.opensearch.planner.physical.ADOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLCommonsOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLOperator;
+import org.opensearch.sql.opensearch.planner.physical.OpenSearchEvalOperator;
 import org.opensearch.sql.planner.physical.AggregationOperator;
 import org.opensearch.sql.planner.physical.CursorCloseOperator;
 import org.opensearch.sql.planner.physical.DedupeOperator;
@@ -96,6 +97,13 @@ public class OpenSearchExecutionProtector extends ExecutionProtector {
 
   @Override
   public PhysicalPlan visitEval(EvalOperator node, Object context) {
+    if (node instanceof OpenSearchEvalOperator evalOperator) {
+      return doProtect(
+          new OpenSearchEvalOperator(
+              visitInput(evalOperator.getInput(), context),
+              evalOperator.getExpressionList(),
+              evalOperator.getNodeClient()));
+    }
     return new EvalOperator(visitInput(node.getInput(), context), node.getExpressionList());
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchEvalOperator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchEvalOperator.java
@@ -1,0 +1,140 @@
+/*
+ *
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.opensearch.planner.physical;
+
+import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
+import static org.opensearch.sql.expression.env.Environment.extendEnv;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.geospatial.action.IpEnrichmentActionClient;
+import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.ip.OpenSearchFunctionExpression;
+import org.opensearch.sql.planner.physical.EvalOperator;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+
+/**
+ * OpenSearch version of eval operator, which contains nodeClient, in order to perform OpenSearch
+ * related operation during the eval process.
+ */
+public class OpenSearchEvalOperator extends EvalOperator {
+
+  @Getter private final NodeClient nodeClient;
+
+  public OpenSearchEvalOperator(
+      PhysicalPlan input,
+      List<Pair<ReferenceExpression, Expression>> expressionList,
+      NodeClient nodeClient) {
+    super(input, expressionList);
+    this.nodeClient = nodeClient;
+  }
+
+  @Override
+  public ExprValue next() {
+    ExprValue inputValue = this.getInput().next();
+    Map<String, ExprValue> evalMap = eval(inputValue.bindingTuples());
+    if (STRUCT == inputValue.type()) {
+      ImmutableMap.Builder<String, ExprValue> resultBuilder = new ImmutableMap.Builder<>();
+      Map<String, ExprValue> tupleValue = ExprValueUtils.getTupleValue(inputValue);
+      for (Map.Entry<String, ExprValue> valueEntry : tupleValue.entrySet()) {
+        if (evalMap.containsKey(valueEntry.getKey())) {
+          resultBuilder.put(valueEntry.getKey(), evalMap.get(valueEntry.getKey()));
+          evalMap.remove(valueEntry.getKey());
+        } else {
+          resultBuilder.put(valueEntry);
+        }
+      }
+      resultBuilder.putAll(evalMap);
+      return ExprTupleValue.fromExprValueMap(resultBuilder.build());
+    } else {
+      return inputValue;
+    }
+  }
+
+  /**
+   * Evaluate the expression in the {@link EvalOperator} with {@link Environment}.
+   *
+   * @param env {@link Environment}
+   * @return The mapping of reference and {@link ExprValue} for each expression.
+   */
+  private Map<String, ExprValue> eval(Environment<Expression, ExprValue> env) {
+    Map<String, ExprValue> evalResultMap = new LinkedHashMap<>();
+    for (Pair<ReferenceExpression, Expression> pair : this.getExpressionList()) {
+      ReferenceExpression var = pair.getKey();
+      Expression valueExpr = pair.getValue();
+      ExprValue value;
+      if (valueExpr instanceof OpenSearchFunctionExpression openSearchFuncExpression) {
+        if ("geoip".equals(openSearchFuncExpression.getFunctionName().getFunctionName())) {
+          // Rewrite to encapsulate the try catch.
+          value = fetchIpEnrichment(openSearchFuncExpression.getArguments(), env);
+        } else {
+          return null;
+        }
+      } else {
+        value = pair.getValue().valueOf(env);
+      }
+      env = extendEnv(env, var, value);
+      evalResultMap.put(var.toString(), value);
+    }
+    return evalResultMap;
+  }
+
+  private ExprValue fetchIpEnrichment(
+      List<Expression> arguments, Environment<Expression, ExprValue> env) {
+    final Set<String> PERMITTED_OPTIONS =
+        Set.of(
+            "country_iso_code",
+            "country_name",
+            "continent_name",
+            "region_iso_code",
+            "region_name",
+            "city_name",
+            "time_zone",
+            "location");
+    IpEnrichmentActionClient ipClient = new IpEnrichmentActionClient(nodeClient);
+    String dataSource = StringUtils.unquoteText(arguments.get(0).toString());
+    String ipAddress = arguments.get(1).valueOf(env).stringValue();
+    final Set<String> options = new HashSet<>();
+    if (arguments.size() > 2) {
+      String option = StringUtils.unquoteText(arguments.get(2).toString());
+      // Convert the option into a set.
+      options.addAll(
+          Arrays.stream(option.split(","))
+              .filter(PERMITTED_OPTIONS::contains)
+              .collect(Collectors.toSet()));
+    }
+    try {
+      Map<String, Object> geoLocationData = ipClient.getGeoLocationData(ipAddress, dataSource);
+      Map<String, ExprValue> enrichmentResult =
+          geoLocationData.entrySet().stream()
+              .filter(entry -> options.isEmpty() || options.contains(entry.getKey()))
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey, v -> new ExprStringValue(v.getValue().toString())));
+      return ExprTupleValue.fromExprValueMap(enrichmentResult);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -21,6 +21,7 @@ import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.planner.physical.ADOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLCommonsOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLOperator;
+import org.opensearch.sql.opensearch.planner.physical.OpenSearchEvalOperator;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.request.system.OpenSearchDescribeIndexRequest;
@@ -28,6 +29,7 @@ import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScan;
 import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScanBuilder;
 import org.opensearch.sql.planner.DefaultImplementor;
 import org.opensearch.sql.planner.logical.LogicalAD;
+import org.opensearch.sql.planner.logical.LogicalEval;
 import org.opensearch.sql.planner.logical.LogicalML;
 import org.opensearch.sql.planner.logical.LogicalMLCommons;
 import org.opensearch.sql.planner.logical.LogicalPlan;
@@ -208,6 +210,12 @@ public class OpenSearchIndex implements Table {
     @Override
     public PhysicalPlan visitML(LogicalML node, OpenSearchIndexScan context) {
       return new MLOperator(visitChild(node, context), node.getArguments(), client.getNodeClient());
+    }
+
+    @Override
+    public PhysicalPlan visitEval(LogicalEval node, OpenSearchIndexScan context) {
+      return new OpenSearchEvalOperator(
+          visitChild(node, context), node.getExpressions(), client.getNodeClient());
     }
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -47,6 +47,7 @@ import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.data.model.ExprBooleanValue;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.NamedExpression;
@@ -58,10 +59,12 @@ import org.opensearch.sql.expression.window.aggregation.AggregateWindowFunction;
 import org.opensearch.sql.expression.window.ranking.RankFunction;
 import org.opensearch.sql.monitor.ResourceMonitor;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.planner.physical.ADOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLCommonsOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLOperator;
+import org.opensearch.sql.opensearch.planner.physical.OpenSearchEvalOperator;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
@@ -337,6 +340,24 @@ class OpenSearchExecutionProtectorTest {
     assertEquals(
         resourceMonitor(trendlineOperator),
         executionProtector.visitTrendline(trendlineOperator, null));
+  }
+
+  @Test
+  void test_visitOpenSearchEval() {
+    NodeClient nodeClient = mock(NodeClient.class);
+    OpenSearchEvalOperator evalOperator =
+        //    ADOperator adOperator =
+        new OpenSearchEvalOperator(
+            values(emptyList()),
+            List.of(
+                ImmutablePair.of(
+                    new ReferenceExpression("ageInAbs", OpenSearchTextType.of()),
+                    DSL.abs(DSL.abs(new ReferenceExpression("age", ExprCoreType.LONG))))),
+            nodeClient);
+
+    assertEquals(
+        executionProtector.doProtect(evalOperator),
+        executionProtector.visitEval(evalOperator, null));
   }
 
   PhysicalPlan resourceMonitor(PhysicalPlan input) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchEvalOperatorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchEvalOperatorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.planner.physical;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.geospatial.action.IpEnrichmentAction;
+import org.opensearch.geospatial.action.IpEnrichmentRequest;
+import org.opensearch.geospatial.action.IpEnrichmentResponse;
+import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.ip.OpenSearchFunctionExpression;
+import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
+import org.opensearch.sql.opensearch.data.value.OpenSearchExprTextValue;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+
+/** To assert the original behaviour of eval operator. */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class OpenSearchEvalOperatorTest {
+
+  @Mock private PhysicalPlan input;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private NodeClient nodeClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private ActionFuture<ActionResponse> actionFuture;
+
+  private final ExprTupleValue DATE_ROW =
+      new ExprTupleValue(
+          new LinkedHashMap<>(
+              Map.of(
+                  "firstname",
+                  new OpenSearchExprTextValue("Amber"),
+                  "age",
+                  new ExprLongValue(32),
+                  "email",
+                  new OpenSearchExprTextValue("amberduke@pyrami.com"),
+                  "ipInStr",
+                  new OpenSearchExprTextValue("192.168.1.1"))));
+
+  /**
+   * The test-case aim to assert OpenSearchEvalOperator behaviour when evaluating generic
+   * expression, which is not OpenSearch Engine specific. (Ex: ABS(age) )
+   */
+  @Test
+  public void testEvalOperatorOnGenericOperations() {
+
+    // The input dataset
+    when(input.next()).thenReturn(DATE_ROW);
+
+    // Expression to be evaluated
+    List<Pair<ReferenceExpression, Expression>> ipAddress =
+        List.of(
+            ImmutablePair.of(
+                new ReferenceExpression("ageInAbs", OpenSearchTextType.of()),
+                DSL.abs(DSL.abs(new ReferenceExpression("age", ExprCoreType.LONG)))));
+
+    OpenSearchEvalOperator evalOperator = new OpenSearchEvalOperator(input, ipAddress, nodeClient);
+
+    // Make sure generic Expression function as expected when wrapped with OpenSearchEvalOperator.
+    assertSame(32, evalOperator.next().keyValue("ageInAbs").integerValue());
+  }
+
+  /**
+   * The test-case aim to assert OpenSearchEvalOperator behaviour when evaluating
+   * geoipFunctionExpression, which is only available when executing on OpeSearch storage engine.
+   * (No option)
+   */
+  @SneakyThrows
+  @Test
+  public void testEvalOperatorOnGeoIpExpression() {
+
+    // The input dataset
+    when(input.next()).thenReturn(DATE_ROW);
+    when(nodeClient.execute(
+            eq(IpEnrichmentAction.INSTANCE),
+            argThat(
+                request ->
+                    request instanceof IpEnrichmentRequest
+                        && "192.168.1.1".equals(((IpEnrichmentRequest) request).getIpString()))))
+        .thenReturn(actionFuture);
+    when(actionFuture.get()).thenReturn(new IpEnrichmentResponse(Map.of("country_name", "Canada")));
+
+    // Expression to be evaluated
+    List<Pair<ReferenceExpression, Expression>> ipAddress =
+        List.of(
+            ImmutablePair.of(
+                new ReferenceExpression("ipEnrichmentResult", OpenSearchTextType.of()),
+                new OpenSearchFunctionExpression(
+                    BuiltinFunctionName.GEOIP.getName(),
+                    List.of(
+                        DSL.literal("my-datasource"),
+                        new ReferenceExpression("ipInStr", OpenSearchTextType.of())),
+                    BOOLEAN)));
+
+    OpenSearchEvalOperator evalOperator = new OpenSearchEvalOperator(input, ipAddress, nodeClient);
+
+    // Make sure generic Expression function as expected when wrapped with OpenSearchEvalOperator.
+    Map<String, ExprValue> ipEnrichmentResult =
+        evalOperator.next().keyValue("ipEnrichmentResult").tupleValue();
+    assertSame("Canada", ipEnrichmentResult.get("country_name").stringValue());
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -87,6 +87,9 @@ ANOMALY_SCORE_THRESHOLD:            'ANOMALY_SCORE_THRESHOLD';
 CASE:                               'CASE';
 IN:                                 'IN';
 
+// Geo IP eval function
+GEOIP:                              'GEOIP';
+
 // LOGICAL KEYWORDS
 NOT:                                'NOT';
 OR:                                 'OR';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -419,6 +419,7 @@ evalFunctionName
    | flowControlFunctionName
    | systemFunctionName
    | positionFunctionName
+   | goeipFunctionName
    ;
 
 functionArgs
@@ -518,6 +519,10 @@ mathematicalFunctionName
    | SQRT
    | TRUNCATE
    | trigonometricFunctionName
+   ;
+
+goeipFunctionName
+   : GEOIP
    ;
 
 trigonometricFunctionName
@@ -863,6 +868,7 @@ keywordsCanBeId
    | mathematicalFunctionName
    | positionFunctionName
    | conditionFunctionName
+   | goeipFunctionName
    // commands
    | SEARCH
    | DESCRIBE


### PR DESCRIPTION
### Description
Introduce a new PPL command expression `geoip`, to perform geo-spatial information lookup with the provided IPv4 || IPv6 addresses, result of the lookup is formatted into a tuple with attribute as key and location detail as value. 

In this particular setting, SQL plugin will act as a thin client, by relaying the IPEnrichment request to OpenSearch Geo-Spatial plugin, WITHIN the same cluster. 
Detail implementation and interface that exposed on Geo-Spatial side can be found:
https://github.com/opensearch-project/geospatial/pull/700

Internally this functionality is achieved by:
 - Adding an no-op `OpenSearchFunctionExpression` marker to identify this is an expression has no default implement on other runtime (Ex: Prometheus)
 - Update `OpenSearchIndex` in order to provide an OpenSearch specific handler for `eval` operator and its expressions, when OS being used as the storage engine. 

During runtime, all eval expressions, will being passed to `OpenSearchIndex.visitEval( )`, then `OpenSearchEvalOperator` class will pick up the call, by evaluating all `eval` expression as it is, and then handle all occasion of `OpenSearchFunctionExpression` separately, by reading the function name and argument, and execute the appropriate business logic. 

Marker class `OpenSearchFunctionExpression` is being used in this case because the actual implementation require runtime OpenSearch client connectivity, however `core` module is mean to be generic, hence this workaround is being deployed, by tagging it as `OpenSearchFunctionExpression` on `core` and only handle it on the `opensearch` Cradle module .


### Related Issues
Resolves: https://github.com/opensearch-project/sql/issues/3037
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
